### PR TITLE
Fix for connection closed while waiting for receipt response

### DIFF
--- a/signer-service/src/api/controllers/moonbeam.controller.js
+++ b/signer-service/src/api/controllers/moonbeam.controller.js
@@ -5,29 +5,9 @@ const { privateKeyToAccount } = require('viem/accounts');
 const { MOONBEAM_EXECUTOR_PRIVATE_KEY, MOONBEAM_RECEIVER_CONTRACT_ADDRESS } = require('../../constants/constants');
 const splitReceiverABI = require('../../../../mooncontracts/splitReceiverABI.json');
 
-const transactionCache = {};
-
 exports.executeXcmController = async (req, res) => {
   const { id, payload } = req.body;
   const moonbeamExecutorAccount = privateKeyToAccount(MOONBEAM_EXECUTOR_PRIVATE_KEY);
-
-  const cacheKey = `${id}_${JSON.stringify(payload)}`;
-
-  if (transactionCache[cacheKey]) {
-    try {
-      let hash = await transactionCache[cacheKey];
-      return res.send({ hash });
-    } catch (error) {
-      return res.status(400).send({ error: 'Invalid transaction' });
-    }
-  }
-
-  let resolveWithHash;
-  let rejectWithError;
-  transactionCache[cacheKey] = new Promise((resolve, reject) => {
-    resolveWithHash = resolve;
-    rejectWithError = reject;
-  });
 
   try {
     const walletClient = createWalletClient({
@@ -47,33 +27,21 @@ exports.executeXcmController = async (req, res) => {
       args: [id, payload],
     });
 
-    let hash;
     try {
       const { maxFeePerGas, maxPriorityFeePerGas } = await publicClient.estimateFeesPerGas();
-
-      hash = await walletClient.sendTransaction({
+      const hash = await walletClient.sendTransaction({
         to: MOONBEAM_RECEIVER_CONTRACT_ADDRESS,
         value: 0n,
         data,
         maxFeePerGas,
         maxPriorityFeePerGas,
       });
-      resolveWithHash(hash);
-    } catch (error) {
-      console.error('Error executing XCM:', error);
-      rejectWithError(error);
-    }
-
-    try {
-      hash = await transactionCache[cacheKey];
       return res.send({ hash });
     } catch (error) {
-      return res.status(400).send({ error: 'Invalid transaction' });
+      console.error('Error executing XCM:', error);
+      res.status(400).send({ error: 'Invalid transaction' });
     }
   } catch (error) {
-    if (rejectWithError) {
-      rejectWithError(error);
-    }
     console.error('Error executing XCM:', error);
     res.status(500).send({ error: 'Internal Server Error' });
   }

--- a/src/components/FeeCollapse/index.tsx
+++ b/src/components/FeeCollapse/index.tsx
@@ -20,7 +20,7 @@ interface CollapseProps {
   exchangeRate?: JSX.Element;
 }
 
-export const FeeCollapse: FC<CollapseProps> = ({ fromAmount, toAmount, toToken, exchangeRate }) => {
+export const FeeCollapse: FC<CollapseProps> = ({ toAmount, toToken, exchangeRate }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { trackEvent } = useEventsContext();
   const toTokenSymbol = toToken.fiat.symbol;

--- a/src/hooks/useMainProcess.ts
+++ b/src/hooks/useMainProcess.ts
@@ -10,13 +10,12 @@ import { fetchTomlValues, sep10, sep24Second } from '../services/anchor';
 import { stringifyBigWithSignificantDecimals } from '../helpers/contracts';
 import { useConfig } from 'wagmi';
 import {
-  FinalOfframpingPhase,
-  OfframpingPhase,
   OfframpingState,
   advanceOfframpingState,
   clearOfframpingState,
   constructInitialState,
   readCurrentState,
+  recoverFromFailure,
 } from '../services/offrampingFlow';
 import { EventStatus, GenericEvent } from '../components/GenericEvent';
 import Big from 'big.js';
@@ -38,7 +37,7 @@ export const useMainProcess = () => {
   // storageService.set(storageKeys.OFFRAMP_STATUS, OperationStatus.Sep6Completed);
 
   const [offrampingStarted, setOfframpingStarted] = useState<boolean>(false);
-  const [offrampingPhase, setOfframpingPhase] = useState<OfframpingPhase | FinalOfframpingPhase | undefined>(undefined);
+  const [offrampingState, setOfframpingState] = useState<OfframpingState | undefined>(undefined);
   const [sep24Url, setSep24Url] = useState<string | undefined>(undefined);
   const [sep24Id, setSep24Id] = useState<string | undefined>(undefined);
 
@@ -51,15 +50,15 @@ export const useMainProcess = () => {
 
   const updateHookStateFromState = useCallback(
     (state: OfframpingState | undefined) => {
-      if (state?.phase === 'success' || state?.phase === 'failure') {
+      if (state?.phase === 'success' || state?.isFailure === true) {
         setSigningPhase(undefined);
       }
-      setOfframpingPhase(state?.phase);
+      setOfframpingState(state);
       setSep24Id(state?.sep24Id);
 
       if (state?.phase === 'success') {
         trackEvent(createTransactionEvent('transaction_success', state));
-      } else if (state?.phase === 'failure') {
+      } else if (state?.isFailure === true) {
         trackEvent(createTransactionEvent('transaction_failure', state));
       }
     },
@@ -79,7 +78,7 @@ export const useMainProcess = () => {
   // Main submit handler. Offramp button.
   const handleOnSubmit = useCallback(
     ({ inputTokenType, outputTokenType, amountInUnits, minAmountOutUnits }: ExecutionInput) => {
-      if (offrampingStarted || offrampingPhase !== undefined) return;
+      if (offrampingStarted || offrampingState !== undefined) return;
 
       (async () => {
         setOfframpingStarted(true);
@@ -133,7 +132,7 @@ export const useMainProcess = () => {
         }
       })();
     },
-    [offrampingPhase, offrampingStarted, trackEvent, updateHookStateFromState],
+    [offrampingState, offrampingStarted, trackEvent, updateHookStateFromState],
   );
 
   const finishOfframping = useCallback(() => {
@@ -145,23 +144,33 @@ export const useMainProcess = () => {
     })();
   }, [updateHookStateFromState, resetUniqueEvents]);
 
+  const continueFailedFlow = useCallback(() => {
+    const nextState = recoverFromFailure(offrampingState);
+    updateHookStateFromState(nextState);
+  }, [updateHookStateFromState, offrampingState]);
+
   useEffect(() => {
     (async () => {
-      const nextState = await advanceOfframpingState({ renderEvent: addEvent, wagmiConfig, setSigningPhase });
-      updateHookStateFromState(nextState);
+      const nextState = await advanceOfframpingState(offrampingState, {
+        renderEvent: addEvent,
+        wagmiConfig,
+        setSigningPhase,
+      });
+
+      if (offrampingState !== nextState) updateHookStateFromState(nextState);
     })();
-  }, [offrampingPhase, updateHookStateFromState, wagmiConfig]);
+  }, [offrampingState, updateHookStateFromState, wagmiConfig]);
 
   const resetSep24Url = () => setSep24Url(undefined);
 
   return {
-    setOfframpingPhase,
     handleOnSubmit,
     sep24Url,
-    offrampingPhase,
+    offrampingState,
     offrampingStarted,
     sep24Id,
     finishOfframping,
+    continueFailedFlow,
     resetSep24Url,
     signingPhase,
   };

--- a/src/pages/failure/index.tsx
+++ b/src/pages/failure/index.tsx
@@ -13,10 +13,11 @@ const Cross = () => (
 
 interface FailurePageProps {
   finishOfframping: () => void;
+  continueFailedFlow: () => void;
   transactionId: string | undefined;
 }
 
-export const FailurePage = ({ finishOfframping, transactionId }: FailurePageProps) => {
+export const FailurePage = ({ finishOfframping, continueFailedFlow, transactionId }: FailurePageProps) => {
   console.log('Failure page');
   const main = (
     <main>
@@ -25,15 +26,20 @@ export const FailurePage = ({ finishOfframping, transactionId }: FailurePageProp
         <h1 className="mt-6 text-2xl font-bold text-center text-red-500">Withdrawal unsuccessful</h1>
         {transactionId && <TransactionInfo transactionId={transactionId} />}
         <p className="mt-6 text-center">
-          Unfortunately, your withdrawal request could not be processed. Please try again.
+          Unfortunately, your withdrawal request could not be processed in time. This could be due to a temporary
+          problem such as bad internet connection.
         </p>
+        <p>Either try to continue or start over.</p>
+        <button className="w-full mt-5 text-white bg-blue-700 btn rounded-xl" onClick={continueFailedFlow}>
+          Continue
+        </button>
+        <button className="w-full mt-5 text-white bg-blue-700 btn rounded-xl" onClick={finishOfframping}>
+          Start over
+        </button>
         <div className="h-0.5 m-auto w-1/5 bg-pink-500 mt-8 mb-5" />
         <p className="text-center text-gray-400">If you continue to experience issues, contact support on:</p>
         <TelegramButton />
         <EmailForm transactionId={transactionId} />
-        <button className="w-full mt-5 text-white bg-blue-700 btn rounded-xl" onClick={finishOfframping}>
-          Try again
-        </button>
       </Box>
     </main>
   );

--- a/src/pages/progress/index.tsx
+++ b/src/pages/progress/index.tsx
@@ -1,6 +1,6 @@
-import { FC, StateUpdater, useEffect } from 'preact/compat';
+import { FC } from 'preact/compat';
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
-import { FinalOfframpingPhase, OfframpingPhase } from '../../services/offrampingFlow';
+import { OfframpingPhase, OfframpingState } from '../../services/offrampingFlow';
 import { Box } from '../../components/Box';
 import { BaseLayout } from '../../layouts';
 
@@ -19,34 +19,13 @@ const OFFRAMPING_PHASE_MESSAGES: Record<OfframpingPhase, string> = {
   stellarCleanup: '12/12: Cleaning up Stellar ephemeral account',
 };
 
-const handleTabClose = (event: Event) => {
-  event.preventDefault();
-};
-
 interface ProgressPageProps {
-  setOfframpingPhase: StateUpdater<OfframpingPhase | FinalOfframpingPhase | undefined>;
-  offrampingPhase: OfframpingPhase | FinalOfframpingPhase | undefined;
+  offrampingState: OfframpingState;
 }
 
-export const ProgressPage: FC<ProgressPageProps> = ({ setOfframpingPhase, offrampingPhase }) => {
-  // After 15 minutes of waiting, we want to redirect user to the failure page.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setOfframpingPhase('failure');
-    }, 15 * 60 * 1000);
-
-    window.addEventListener('beforeunload', handleTabClose);
-
-    return () => {
-      clearTimeout(timer);
-      window.removeEventListener('beforeunload', handleTabClose);
-    };
-  }, [setOfframpingPhase]);
-
+export const ProgressPage: FC<ProgressPageProps> = ({ offrampingState }) => {
   const phaseMessage =
-    offrampingPhase === undefined || offrampingPhase === 'failure' || offrampingPhase === 'success'
-      ? undefined
-      : OFFRAMPING_PHASE_MESSAGES[offrampingPhase];
+    offrampingState.phase === 'success' ? undefined : OFFRAMPING_PHASE_MESSAGES[offrampingState.phase];
 
   const main = (
     <main>

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -53,11 +53,11 @@ export const SwapPage = () => {
   const {
     handleOnSubmit,
     finishOfframping,
+    continueFailedFlow,
     offrampingStarted,
     sep24Url,
     sep24Id,
-    offrampingPhase,
-    setOfframpingPhase,
+    offrampingState,
     resetSep24Url,
     signingPhase,
   } = useMainProcess();
@@ -216,19 +216,25 @@ export const SwapPage = () => {
     />
   );
 
-  if (offrampingPhase === 'success') {
+  if (offrampingState?.phase === 'success') {
     return <SuccessPage finishOfframping={finishOfframping} transactionId={sep24Id} />;
   }
 
-  if (offrampingPhase === 'failure') {
-    return <FailurePage finishOfframping={finishOfframping} transactionId={sep24Id} />;
+  if (offrampingState?.isFailure === true) {
+    return (
+      <FailurePage
+        finishOfframping={finishOfframping}
+        continueFailedFlow={continueFailedFlow}
+        transactionId={sep24Id}
+      />
+    );
   }
 
-  if (offrampingPhase !== undefined || offrampingStarted) {
+  if (offrampingState !== undefined || offrampingStarted) {
     const showMainScreenAnyway =
-      offrampingPhase === undefined || ['prepareTransactions', 'squidRouter'].includes(offrampingPhase);
+      offrampingState === undefined || ['prepareTransactions', 'squidRouter'].includes(offrampingState.phase);
     if (!showMainScreenAnyway) {
-      return <ProgressPage setOfframpingPhase={setOfframpingPhase} offrampingPhase={offrampingPhase} />;
+      return <ProgressPage offrampingState={offrampingState} />;
     }
   }
 
@@ -275,7 +281,7 @@ export const SwapPage = () => {
           <SwapSubmitButton
             text={offrampingStarted ? 'Offramping in Progress' : 'Confirm'}
             disabled={Boolean(getCurrentErrorMessage()) || !inputAmountIsStable}
-            pending={offrampingStarted || offrampingPhase !== undefined}
+            pending={offrampingStarted || offrampingState !== undefined}
           />
         )}
       </form>

--- a/src/services/moonbeam.ts
+++ b/src/services/moonbeam.ts
@@ -31,28 +31,38 @@ export async function executeXCM(state: OfframpingState): Promise<OfframpingStat
   const pendulumEphemeralAccountHex = u8aToHex(decodeAddress(ephemeralKeypair.address));
   const squidRouterPayload = encodePayload(pendulumEphemeralAccountHex);
 
-  const response = await fetch(`${SIGNING_SERVICE_URL}/v1/moonbeam/execute-xcm`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ id: state.squidRouterReceiverId, payload: squidRouterPayload }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Error while executing XCM: ${response.statusText}`);
-  }
-
-  let hash;
-  try {
-    hash = (await response.json()).hash;
-    await waitForTransactionReceipt(moonbeamConfig, hash);
-  } catch (error) {
-    throw new Error(`Error while executing XCM: Could not fetch transaction receipt for hash : ${hash}`);
-  }
-
-  await waitUntilTrue(async () => {
+  const didInputTokenArrivedOnPendulum = async () => {
     const inputBalanceRaw = await getRawInputBalance(state);
     return inputBalanceRaw.gt(Big(0));
-  }, 5000);
+  };
+
+  if (!(await didInputTokenArrivedOnPendulum())) {
+    let { moonbeamXcmTransactionHash } = state;
+
+    if (moonbeamXcmTransactionHash === undefined) {
+      const response = await fetch(`${SIGNING_SERVICE_URL}/v1/moonbeam/execute-xcm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: state.squidRouterReceiverId, payload: squidRouterPayload }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error while executing XCM: ${response.statusText}`);
+      }
+
+      try {
+        moonbeamXcmTransactionHash = (await response.json()).hash;
+        return { ...state, moonbeamXcmTransactionHash };
+      } catch (error) {
+        throw new Error(
+          `Error while executing XCM: Could not fetch transaction receipt for hash : ${moonbeamXcmTransactionHash}`,
+        );
+      }
+    }
+
+    await waitForTransactionReceipt(moonbeamConfig, { hash: moonbeamXcmTransactionHash, chainId: moonbeam.id });
+    await waitUntilTrue(didInputTokenArrivedOnPendulum, 5000);
+  }
 
   return { ...state, phase: 'subsidizePreSwap' };
 }

--- a/src/services/nabla.ts
+++ b/src/services/nabla.ts
@@ -29,6 +29,7 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { decodeSubmittableExtrinsic } from './signedTransactions';
 import { config } from '../config';
 import { KeyringPair } from '@polkadot/keyring/types';
+import { getEphemeralNonce } from './polkadot/ephemeral';
 
 async function createAndSignApproveExtrinsic({
   api,
@@ -60,7 +61,7 @@ async function createAndSignApproveExtrinsic({
 
   const { extrinsic } = execution;
 
-  return extrinsic.signAsync(keypairEphemeral, { nonce });
+  return extrinsic.signAsync(keypairEphemeral, { nonce, era: 0 });
 }
 
 export async function prepareNablaApproveTransaction(
@@ -132,12 +133,22 @@ export async function nablaApprove(
   state: OfframpingState,
   { renderEvent }: ExecutionContext,
 ): Promise<OfframpingState> {
-  const { transactions, inputAmount, inputTokenType } = state;
+  const { transactions, inputAmount, inputTokenType, nablaApproveNonce } = state;
   const inputToken = INPUT_TOKEN_CONFIG[inputTokenType];
 
   if (!transactions) {
     console.error('Missing transactions for nablaApprove');
-    return { ...state, phase: 'failure' };
+    return { ...state, isFailure: true };
+  }
+
+  const successorState = {
+    ...state,
+    phase: 'nablaSwap',
+  } as const;
+
+  const ephemeralAccountNonce = await getEphemeralNonce(state);
+  if (ephemeralAccountNonce !== undefined && ephemeralAccountNonce > nablaApproveNonce) {
+    return successorState;
   }
 
   try {
@@ -170,10 +181,7 @@ export async function nablaApprove(
     return Promise.reject('Could not approve token');
   }
 
-  return {
-    ...state,
-    phase: 'nablaSwap',
-  };
+  return successorState;
 }
 
 interface CreateAndSignSwapExtrinsicOptions {
@@ -221,7 +229,7 @@ export async function createAndSignSwapExtrinsic({
   }
 
   const { extrinsic } = execution;
-  return extrinsic.signAsync(keypairEphemeral, { nonce });
+  return extrinsic.signAsync(keypairEphemeral, { nonce, era: 0 });
 }
 
 export async function prepareNablaSwapTransaction(
@@ -278,7 +286,26 @@ export async function prepareNablaSwapTransaction(
 }
 
 export async function nablaSwap(state: OfframpingState, { renderEvent }: ExecutionContext): Promise<OfframpingState> {
-  const { transactions, inputAmount, inputTokenType, outputAmount, outputTokenType, pendulumEphemeralSeed } = state;
+  const {
+    transactions,
+    inputAmount,
+    inputTokenType,
+    outputAmount,
+    outputTokenType,
+    pendulumEphemeralSeed,
+    nablaSwapNonce,
+  } = state;
+
+  const successorState = {
+    ...state,
+    phase: 'subsidizePostSwap',
+  } as const;
+
+  const ephemeralAccountNonce = await getEphemeralNonce(state);
+  if (ephemeralAccountNonce !== undefined && ephemeralAccountNonce > nablaSwapNonce) {
+    return successorState;
+  }
+
   const inputToken = INPUT_TOKEN_CONFIG[inputTokenType];
   const outputToken = OUTPUT_TOKEN_CONFIG[outputTokenType];
 
@@ -338,10 +365,7 @@ export async function nablaSwap(state: OfframpingState, { renderEvent }: Executi
 
   console.log('Swap successful');
 
-  return {
-    ...state,
-    phase: 'subsidizePostSwap',
-  };
+  return successorState;
 }
 
 const calcDeadline = (min: number) => `${Math.floor(Date.now() / 1000) + min * 60}`;

--- a/src/services/polkadot/ephemeral.tsx
+++ b/src/services/polkadot/ephemeral.tsx
@@ -23,6 +23,22 @@ async function getEphemeralAddress({ pendulumEphemeralSeed }: OfframpingState) {
   return ephemeralKeypair.address;
 }
 
+export async function getEphemeralNonce({ pendulumEphemeralSeed }: OfframpingState): Promise<number | undefined> {
+  const pendulumApiComponents = await getApiManagerInstance();
+  const apiData = pendulumApiComponents.apiData!;
+
+  const keyring = new Keyring({ type: 'sr25519', ss58Format: apiData.ss58Format });
+  const ephemeralKeypair = keyring.addFromUri(pendulumEphemeralSeed);
+
+  try {
+    const accountData = await apiData.api.query.system.account(ephemeralKeypair.address);
+    return accountData.nonce.toNumber();
+  } catch (error) {
+    console.error(`Can't request nonce of ephemeral account ${ephemeralKeypair.address}`);
+    return undefined;
+  }
+}
+
 export async function pendulumFundEphemeral(
   state: OfframpingState,
   { wagmiConfig }: ExecutionContext,

--- a/src/services/polkadot/index.tsx
+++ b/src/services/polkadot/index.tsx
@@ -73,7 +73,7 @@ export async function executeSpacewalkRedeem(
 
   if (!transactions) {
     console.error('Transactions not prepared, cannot execute Spacewalk redeem');
-    return { ...state, phase: 'failure' };
+    return { ...state, isFailure: true };
   }
   let redeemRequestEvent;
 

--- a/src/services/polkadot/spacewalk.tsx
+++ b/src/services/polkadot/spacewalk.tsx
@@ -12,6 +12,7 @@ import { getAddressForFormat } from '../../helpers/addressFormatter';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { SpacewalkPrimitivesCurrencyId } from '@pendulum-chain/types/interfaces';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { SignerOptions } from '@polkadot/api-base/types';
 
 export function extractAssetFromWrapped(wrapped: SpacewalkPrimitivesCurrencyId) {
   if (!wrapped.isStellar) {
@@ -117,7 +118,10 @@ export class VaultService {
 
     // We distinguish between a WalletAccount and a KeyringPair because we need to handle the signer differently
     const addressOrPair = isWalletAccount(accountOrPair) ? accountOrPair.address : accountOrPair;
-    const options = isWalletAccount(accountOrPair) ? { signer: accountOrPair.signer as any, nonce } : { nonce };
+    const options: Partial<SignerOptions> = isWalletAccount(accountOrPair)
+      ? { signer: accountOrPair.signer as any, nonce }
+      : { nonce };
+    options.era = 0;
 
     const stellarPkBytes = Uint8Array.from(stellarPkBytesBuffer);
 


### PR DESCRIPTION
#157 and #160.

Following changes to the flow:
- Endpoint `executeXCM` prioritizes the transaction with more gas.
- Endpoint will also cache the response, such that it is compatible with the frontend possible restart and refetch of the same (id, payload). In that case to avoid saving one more extra state on the UI, the endpoint will just return again the hash. (this doesn't survive a backend restart)
- UI will now `waitForTransactionReceipt` instead. Continue once it is included, or error if it is not.

Recoverable errors retry
- If we do not return specifically a next phase `failure` in our transitions functions (like [here](https://github.com/pendulum-chain/vortex/pull/159/files#diff-a3e0787c73e858fc843b7cdaa0987f3b96c38e7ae536b944c1c9dbd3a92b62f6R287)), then the app will reload the page and restart the current phase again, until 10 minutes from the creation of the off-ramp passed.