### PR TITLE
Add unique identifiers for error messages to enable GTM tracking

### DIFF
--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -49,7 +49,11 @@ export interface ClickSupportEvent {
 
 export interface FormErrorEvent {
   event: 'form_error';
-  error_message: 'insufficient_balance' | 'insufficient_liquidity' | 'less_than_minimum_withdrawal';
+  error_message:
+    | 'insufficient_balance'
+    | 'insufficient_liquidity'
+    | 'less_than_minimum_withdrawal'
+    | 'more_than_maximum_withdrawal';
 }
 
 export type TrackableEvent =
@@ -68,6 +72,7 @@ const useEvents = () => {
 
   const previousAddress = useRef<`0x${string}` | undefined>(undefined);
   const userClickedState = useRef<boolean>(false);
+  const firedFormErrors = useRef<Set<FormErrorEvent['error_message']>>(new Set());
   const { address } = useAccount();
 
   const trackEvent = useCallback(
@@ -81,6 +86,18 @@ const useEvents = () => {
             trackedEventTypes.add(event.event);
           }
         }
+
+        // Check if form error message has already been fired as we only want to fire each error message once
+        if (event.event === 'form_error') {
+          const { error_message } = event;
+          if (firedFormErrors.current.has(error_message)) {
+            return trackedEventTypes;
+          } else {
+            // Add error message to fired form errors
+            firedFormErrors.current.add(error_message);
+          }
+        }
+
         console.log('Push data layer', event);
 
         window.dataLayer.push(event);

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -11,7 +11,7 @@ declare global {
   }
 }
 
-const UNIQUE_EVENT_TYPES = [
+const UNIQUE_EVENT_TYPES: TrackableEvent['event'][] = [
   'amount_type',
   'click_details',
   'click_support',
@@ -47,12 +47,18 @@ export interface ClickSupportEvent {
   transaction_status: 'success' | 'failure';
 }
 
+export interface FormErrorEvent {
+  event: 'form_error';
+  error_message: 'insufficient_balance' | 'insufficient_liquidity' | 'less_than_minimum_withdrawal';
+}
+
 export type TrackableEvent =
   | AmountTypeEvent
   | ClickDetailsEvent
   | WalletConnectEvent
   | TransactionEvent
-  | ClickSupportEvent;
+  | ClickSupportEvent
+  | FormErrorEvent;
 
 type EventType = TrackableEvent['event'];
 

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -40,6 +40,8 @@ export const SwapPage = () => {
 
   const { isDisconnected } = useAccount();
 
+  const { trackEvent } = useEventsContext();
+
   useEffect(() => {
     const initializeApiManager = async () => {
       const manager = await getApiManagerInstance();
@@ -161,8 +163,7 @@ export const SwapPage = () => {
     [form, fromToken, setModalType],
   );
 
-  function useGetCurrentErrorMessage() {
-    const { trackEvent } = useEventsContext();
+  function getCurrentErrorMessage() {
     // Do not show any error if the user is disconnected
     if (isDisconnected) return;
 
@@ -256,7 +257,7 @@ export const SwapPage = () => {
         <LabeledInput label="You withdraw" Input={WithdrawNumericInput} />
         <Arrow />
         <LabeledInput label="You receive" Input={ReceiveNumericInput} />
-        <p className="text-red-600 mb-6">{useGetCurrentErrorMessage()}</p>
+        <p className="text-red-600 mb-6">{getCurrentErrorMessage()}</p>
         <FeeCollapse
           fromAmount={fromAmount?.toString()}
           toAmount={tokenOutData.data?.amountOut.preciseString}
@@ -287,7 +288,7 @@ export const SwapPage = () => {
         ) : (
           <SwapSubmitButton
             text={isInitiating ? 'Confirming' : offrampingStarted ? 'Processing Details' : 'Confirm'}
-            disabled={Boolean(useGetCurrentErrorMessage()) || !inputAmountIsStable}
+            disabled={Boolean(getCurrentErrorMessage()) || !inputAmountIsStable}
             pending={isInitiating || offrampingStarted || offrampingState !== undefined}
           />
         )}


### PR DESCRIPTION
In GTM, I set up a new event 'GA4 Event | form_error' that groups all possible errors caused by the user input in the swap page form. I didn't want to add different events for each error, but instead added an 'error_message' parameter to them. To ensure that each `FormErrorEvent` only fires once, extra logic is added to the `trackEvent` function. 

While #143 does not define returning an error when exceeding the maximum withdrawal amount, I added it anyways because it seems related. 


Closes #143. 