### PR TITLE
simple fix

### DIFF
--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -90,7 +90,9 @@ export const SwapPage = () => {
   });
 
   const inputAmountIsStable =
-    tokenOutData.stableAmountInUnits !== undefined && Big(tokenOutData.stableAmountInUnits).gt(Big(0));
+    tokenOutData.stableAmountInUnits !== undefined &&
+    tokenOutData.stableAmountInUnits != '' &&
+    Big(tokenOutData.stableAmountInUnits).gt(Big(0));
 
   function onSubmit(e: Event) {
     e.preventDefault();


### PR DESCRIPTION
#170 

Upon selection ONLY when the input field was empty, rendering was attempting to create a `Big` of empty string, leading to the error experienced.