### PR TITLE
Revert automatic close of anchor kyc window

### DIFF
--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -19,7 +19,7 @@ const ToastProperties: Record<ToastMessage, ToastSettings> = {
     },
   },
   [ToastMessage.KYC_COMPLETED]: {
-    message: 'Successfully completed KYC. Offramp is being processed.',
+    message: 'Successfully completed required actions on partner website. Offramp is being processed.',
     options: {
       toastId: ToastMessage.KYC_COMPLETED,
       type: 'success',

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -258,8 +258,11 @@ export const SwapPage = () => {
       // See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
       // status: pending_user_transfer_start indicates the anchor is ready to receive funds
       if (event.data.transaction.status === 'pending_user_transfer_start') {
-        console.log('Callback received from external site, anchor flow completed. Closing...');
-        event.source.close();
+        console.log('Callback received from external site, anchor flow completed.');
+
+        // We don't automatically close the window, as this could be confusing for the user.
+        // event.source.close();
+
         showToast(ToastMessage.KYC_COMPLETED);
       }
     };


### PR DESCRIPTION
- [x] Make app not close anchor window on completion
- [x] Changes the text of the toast notification to 'Successfully completed required actions on partner website. Offramp is being processed.',

I decided not to revert the code changes but only adjust it slightly as we might want to get back to this feature again in the future.

Closes #204.