### PR TITLE
Add call to switch chain to submission handler

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -12,6 +12,3 @@ export const TRANSFER_WAITING_TIME_SECONDS = 6000;
 export const SIGNING_SERVICE_URL =
   config.maybeSignerServiceUrl ||
   (config.isProd ? 'https://prototype-signer-service-polygon.pendulumchain.tech' : 'http://localhost:3000');
-
-// The chain id for polygon is 137, see [here](https://wagmi.sh/react/api/chains#available-chains)
-export const POLYGON_CHAIN_ID = 137;

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -12,3 +12,6 @@ export const TRANSFER_WAITING_TIME_SECONDS = 6000;
 export const SIGNING_SERVICE_URL =
   config.maybeSignerServiceUrl ||
   (config.isProd ? 'https://prototype-signer-service-polygon.pendulumchain.tech' : 'http://localhost:3000');
+
+// The chain id for polygon is 137, see [here](https://wagmi.sh/react/api/chains#available-chains)
+export const POLYGON_CHAIN_ID = 137;

--- a/src/hooks/useMainProcess.ts
+++ b/src/hooks/useMainProcess.ts
@@ -7,7 +7,7 @@ import { INPUT_TOKEN_CONFIG, OUTPUT_TOKEN_CONFIG } from '../constants/tokenConfi
 
 import { fetchTomlValues, sep10, sep24Second } from '../services/anchor';
 // Utils
-import { useConfig } from 'wagmi';
+import { useConfig, useSwitchChain } from 'wagmi';
 import {
   OfframpingState,
   advanceOfframpingState,
@@ -22,6 +22,7 @@ import { createTransactionEvent, useEventsContext } from '../contexts/events';
 import { showToast, ToastMessage } from '../helpers/notifications';
 import { stringifyBigWithSignificantDecimals } from '../helpers/contracts';
 import { IAnchorSessionParams, ISep24Intermediate } from '../services/anchor';
+import { POLYGON_CHAIN_ID } from '../constants/constants';
 
 export type SigningPhase = 'started' | 'approved' | 'signed' | 'finished';
 type ExtendedExecutionInput = ExecutionInput & { truncatedAmountToOfframp: string; stellarEphemeralSecret: string };
@@ -51,6 +52,7 @@ export const useMainProcess = () => {
   const [signingPhase, setSigningPhase] = useState<SigningPhase | undefined>(undefined);
 
   const wagmiConfig = useConfig();
+  const { switchChain } = useSwitchChain();
   const { trackEvent, resetUniqueEvents } = useEventsContext();
 
   const [, setEvents] = useState<GenericEvent[]>([]);
@@ -101,6 +103,9 @@ export const useMainProcess = () => {
       }
 
       (async () => {
+        // If we already are on the polygon chain, we don't need to switch and this will be a no-op
+        switchChain({ chainId: POLYGON_CHAIN_ID });
+
         setOfframpingStarted(true);
         trackEvent({
           event: 'transaction_confirmation',

--- a/src/hooks/useMainProcess.ts
+++ b/src/hooks/useMainProcess.ts
@@ -8,6 +8,7 @@ import { INPUT_TOKEN_CONFIG, OUTPUT_TOKEN_CONFIG } from '../constants/tokenConfi
 import { fetchTomlValues, sep10, sep24Second } from '../services/anchor';
 // Utils
 import { useConfig, useSwitchChain } from 'wagmi';
+import { polygon } from 'wagmi/chains';
 import {
   OfframpingState,
   advanceOfframpingState,
@@ -22,7 +23,6 @@ import { createTransactionEvent, useEventsContext } from '../contexts/events';
 import { showToast, ToastMessage } from '../helpers/notifications';
 import { stringifyBigWithSignificantDecimals } from '../helpers/contracts';
 import { IAnchorSessionParams, ISep24Intermediate } from '../services/anchor';
-import { POLYGON_CHAIN_ID } from '../constants/constants';
 
 export type SigningPhase = 'started' | 'approved' | 'signed' | 'finished';
 type ExtendedExecutionInput = ExecutionInput & { truncatedAmountToOfframp: string; stellarEphemeralSecret: string };
@@ -104,7 +104,7 @@ export const useMainProcess = () => {
 
       (async () => {
         // If we already are on the polygon chain, we don't need to switch and this will be a no-op
-        switchChain({ chainId: POLYGON_CHAIN_ID });
+        switchChain({ chainId: polygon.id });
 
         setOfframpingStarted(true);
         trackEvent({


### PR DESCRIPTION
Adds a call to switch to polygon to the submission handler. If the user is already on Polygon, nothing happens and the flow continues as usual. The documentation for `isSwitchchain()` [here](https://wagmi.sh/react/api/hooks/useSwitchChain).

Closes #218.

