### PR TITLE
Cache id to show in success and failure screen

### DIFF
--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -283,7 +283,7 @@ export const SwapPage = () => {
   );
 
   if (offrampingState?.phase === 'success') {
-    return <SuccessPage finishOfframping={finishOfframping} transactionId={firstSep24ResponseState?.id} />;
+    return <SuccessPage finishOfframping={finishOfframping} transactionId={cachedId} />;
   }
 
   if (offrampingState?.failure !== undefined) {
@@ -291,7 +291,7 @@ export const SwapPage = () => {
       <FailurePage
         finishOfframping={finishOfframping}
         continueFailedFlow={continueFailedFlow}
-        transactionId={firstSep24ResponseState?.id}
+        transactionId={cachedId}
         failure={offrampingState.failure}
       />
     );

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -46,6 +46,7 @@ export const SwapPage = () => {
   const { isDisconnected, address } = useAccount();
   const [initializeFailed, setInitializeFailed] = useState(false);
   const [isReady, setIsReady] = useState(false);
+  const [cachedId, setCachedId] = useState<string | undefined>(undefined);
   const { trackEvent } = useEventsContext();
 
   // Hook used for services on initialization and pre-offramp check
@@ -80,6 +81,13 @@ export const SwapPage = () => {
     signingPhase,
     setIsInitiating,
   } = useMainProcess();
+
+  // Store the id as it is cleared after the user opens the anchor window
+  useEffect(() => {
+    if (firstSep24ResponseState?.id != undefined) {
+      setCachedId(firstSep24ResponseState?.id);
+    }
+  }, [firstSep24ResponseState?.id]);
 
   const {
     tokensModal: [modalType, setModalType],


### PR DESCRIPTION
#217 

The issue is that after our latest changes, `firstSep24ResponseState` is cleared quickly. When no `id` is passed, clicking `submit` on the email form does nothing. Also, we can see from failure screenshots that the `id` is not there anymore.