### PR TITLE
Add more information to GTM events

### DIFF
--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -38,13 +38,22 @@ export interface WalletConnectEvent {
   wallet_action: 'connect' | 'disconnect' | 'change';
 }
 
-export interface TransactionEvent {
-  event: 'transaction_confirmation' | 'kyc_started' | 'kyc_completed' | 'transaction_success' | 'transaction_failure';
+interface OfframpingParameters {
   from_asset: string;
   to_asset: string;
   from_amount: string;
   to_amount: string;
 }
+
+export type TransactionEvent = OfframpingParameters & {
+  event: 'transaction_confirmation' | 'kyc_started' | 'kyc_completed' | 'transaction_success' | 'transaction_failure';
+};
+
+export type TransactionFailedEvent = OfframpingParameters & {
+  event: 'transaction_failure';
+  phase_name: string;
+  phase_index: number;
+};
 
 export interface ProgressEvent {
   event: 'progress';
@@ -86,6 +95,7 @@ export type TrackableEvent =
   | ClickDetailsEvent
   | WalletConnectEvent
   | TransactionEvent
+  | TransactionFailedEvent
   | ClickSupportEvent
   | FormErrorEvent
   | EmailSubmissionEvent

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -57,8 +57,8 @@ export type TransactionFailedEvent = OfframpingParameters & {
 
 export interface ProgressEvent {
   event: 'progress';
-  phase: number;
-  name: string;
+  phase_name: string;
+  phase_index: number;
 }
 
 export interface SigningRequestedEvent {

--- a/src/hooks/useMainProcess.ts
+++ b/src/hooks/useMainProcess.ts
@@ -23,6 +23,7 @@ import { createTransactionEvent, useEventsContext } from '../contexts/events';
 import { showToast, ToastMessage } from '../helpers/notifications';
 import { stringifyBigWithSignificantDecimals } from '../helpers/contracts';
 import { IAnchorSessionParams, ISep24Intermediate } from '../services/anchor';
+import { OFFRAMPING_PHASE_SECONDS } from '../pages/progress';
 
 export type SigningPhase = 'started' | 'approved' | 'signed' | 'finished';
 type ExtendedExecutionInput = ExecutionInput & { truncatedAmountToOfframp: string; stellarEphemeralSecret: string };
@@ -67,7 +68,15 @@ export const useMainProcess = () => {
       if (state?.phase === 'success') {
         trackEvent(createTransactionEvent('transaction_success', state));
       } else if (state?.failure !== undefined) {
-        trackEvent(createTransactionEvent('transaction_failure', state));
+        const currentPhase = state?.phase;
+        const currentPhaseIndex = Object.keys(OFFRAMPING_PHASE_SECONDS).indexOf(currentPhase);
+
+        trackEvent({
+          ...createTransactionEvent('transaction_failure', state),
+          event: 'transaction_failure',
+          phase_name: currentPhase,
+          phase_index: currentPhaseIndex,
+        });
       }
     },
     [trackEvent],

--- a/src/pages/progress/index.tsx
+++ b/src/pages/progress/index.tsx
@@ -34,7 +34,7 @@ function createOfframpingPhaseMessage(offrampingState: OfframpingState): string 
   }
 }
 
-const OFFRAMPING_PHASE_SECONDS: Record<OfframpingPhase, number> = {
+export const OFFRAMPING_PHASE_SECONDS: Record<OfframpingPhase, number> = {
   prepareTransactions: 1,
   squidRouter: 1,
   pendulumFundEphemeral: 80,

--- a/src/pages/progress/index.tsx
+++ b/src/pages/progress/index.tsx
@@ -163,7 +163,7 @@ export const ProgressPage: FC<ProgressPageProps> = ({ offrampingState }) => {
   const message = createOfframpingPhaseMessage(offrampingState);
 
   useEffect(() => {
-    trackEvent({ event: 'progress', phase: currentPhaseIndex, name: offrampingState.phase });
+    trackEvent({ event: 'progress', phase_index: currentPhaseIndex, phase_name: offrampingState.phase });
   }, [currentPhaseIndex, trackEvent, offrampingState.phase]);
 
   return (


### PR DESCRIPTION
I modified the GTM setup as follows:
- Rename `GA Event | transaction_failure` to `GA4 Event | transaction_failure`
- Add two new event parameters to `GA4 Event | transaction_failure`: `phase_name` and `phase_index`
- Add two new Variables `DLV | phase_index` and `DLV | phase_name`
- Modified the event parameters of `GA4 Event | progress` to use the new variables as well
- Deleted the variable `DLV | phase` and `DLV | progress name` (the naming was confusing and it's better to streamline with the other two news variables)



Closes #242.