### PR TITLE
140 integrate additional events into google analytics query into the prototype

### DIFF
--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -1,9 +1,10 @@
 import { createContext } from 'preact';
 import { PropsWithChildren, useCallback, useContext, useEffect, useRef } from 'preact/compat';
+import * as Sentry from '@sentry/react';
 import { useAccount } from 'wagmi';
 import { INPUT_TOKEN_CONFIG, OUTPUT_TOKEN_CONFIG } from '../constants/tokenConfig';
 import { OfframpingState } from '../services/offrampingFlow';
-import * as Sentry from '@sentry/react';
+
 declare global {
   interface Window {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,6 +37,7 @@ export interface ClickDetailsEvent {
 export interface WalletConnectEvent {
   event: 'wallet_connect';
   wallet_action: 'connect' | 'disconnect' | 'change';
+  account_address: string;
 }
 
 interface OfframpingParameters {
@@ -81,6 +83,12 @@ export interface ClickSupportEvent {
   transaction_status: 'success' | 'failure';
 }
 
+export interface NetworkChangeEvent {
+  event: 'network_change';
+  from_network: number;
+  to_network: number;
+}
+
 export interface FormErrorEvent {
   event: 'form_error';
   error_message:
@@ -101,14 +109,16 @@ export type TrackableEvent =
   | EmailSubmissionEvent
   | SigningRequestedEvent
   | TransactionSignedEvent
-  | ProgressEvent;
+  | ProgressEvent
+  | NetworkChangeEvent;
 
 type EventType = TrackableEvent['event'];
 
 type UseEventsContext = ReturnType<typeof useEvents>;
 const useEvents = () => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const previousAddress = useRef<`0x${string}` | undefined>(undefined);
+  const previousChainId = useRef<number | undefined>(undefined);
   const userClickedState = useRef<boolean>(false);
 
   const trackedEventTypes = useRef<Set<EventType>>(new Set());
@@ -144,6 +154,24 @@ const useEvents = () => {
   }, []);
 
   useEffect(() => {
+    if (!chainId) return;
+
+    if (previousChainId.current === undefined) {
+      previousChainId.current = chainId;
+      // This means we are in the first render, so we don't want to track the event
+      return;
+    }
+
+    trackEvent({
+      event: 'network_change',
+      from_network: previousChainId.current || chainId,
+      to_network: chainId,
+    });
+
+    previousChainId.current = chainId;
+  }, [chainId, previousChainId]);
+
+  useEffect(() => {
     const wasConnected = previousAddress.current !== undefined;
     const isConnected = address !== undefined;
 
@@ -159,9 +187,17 @@ const useEvents = () => {
     }
 
     if (!isConnected) {
-      trackEvent({ event: 'wallet_connect', wallet_action: 'disconnect' });
+      trackEvent({
+        event: 'wallet_connect',
+        wallet_action: 'disconnect',
+        account_address: previousAddress.current || '',
+      });
     } else {
-      trackEvent({ event: 'wallet_connect', wallet_action: wasConnected ? 'change' : 'connect' });
+      trackEvent({
+        event: 'wallet_connect',
+        wallet_action: wasConnected ? 'change' : 'connect',
+        account_address: address,
+      });
     }
 
     userClickedState.current = false;

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -164,12 +164,12 @@ const useEvents = () => {
 
     trackEvent({
       event: 'network_change',
-      from_network: previousChainId.current || chainId,
+      from_network: previousChainId.current,
       to_network: chainId,
     });
 
     previousChainId.current = chainId;
-  }, [chainId, previousChainId]);
+  }, [chainId, trackEvent]);
 
   useEffect(() => {
     const wasConnected = previousAddress.current !== undefined;

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -175,8 +175,6 @@ const useEvents = () => {
     const wasConnected = previousAddress.current !== undefined;
     const isConnected = address !== undefined;
 
-    previousAddress.current = address;
-
     // set sentry user as wallet address
     if (address) {
       Sentry.setUser({ id: address });
@@ -200,6 +198,7 @@ const useEvents = () => {
       });
     }
 
+    previousAddress.current = address;
     userClickedState.current = false;
     // Important NOT to add userClicked to the dependencies array, otherwise logic will not work.
   }, [address, trackEvent, userClickedState]);


### PR DESCRIPTION
It took me some time to figure out how to be able to properly watch the connected network. I noticed that the [watchChainId](https://wagmi.sh/core/api/actions/watchChainId) and [useChainId](https://wagmi.sh/react/api/hooks/useChainId) both don't fire when switching from or to a non-supported network, ie a network that is not defined in our `wagmiConfig`. Since only `polygon` is defined in our `wagmiConfig`, it never triggered when switching from any network to polygon.

Instead, we are now using the `chainId` contained in the data of the [useAccount](https://wagmi.sh/react/api/hooks/useAccount) hook as it's always updated when the network changes. 

## GA config
### New Variables
- `DLV | from_network` and `DLV | to_network`
- `DLV | account_address`

### New triggers
- `DL Event | network_change`

### Events
- New event `GA4 Event | network_change`
   - Has parameters `from_network` - > `{{DLV | from_network }}` and `to_network` -> `{{DLV | to_network}}` 
   - Has trigger `DL Event | network_change`
- Changed event `GA4 Event | wallet_connect`
   - Has new parameters `account_address` -> `{{DLV | account_address}}`   

Closes #140. 