### PR TITLE
Replace DaisyUI spinner with custom component

### DIFF
--- a/src/components/SigningBox/index.tsx
+++ b/src/components/SigningBox/index.tsx
@@ -3,6 +3,7 @@ import { FC } from 'preact/compat';
 import accountBalanceWalletIcon from '../../assets/account-balance-wallet.svg';
 
 import { SigningPhase } from '../../hooks/useMainProcess';
+import { Spinner } from '../Spinner';
 
 const progressValues: Record<SigningPhase, string> = {
   started: '25',
@@ -52,7 +53,7 @@ export const SigningBox: FC<SigningBoxProps> = ({ step }) => {
           </div>
         </main>
         <footer className="flex items-center justify-center bg-[#5E88D5] text-white rounded-b">
-          <span className="loading loading-spinner loading-sm"></span>
+          <Spinner />
           <p className="ml-2.5 my-2 text-xs">Waiting for signature {getSignatureNumber(step)}/2</p>
         </footer>
       </div>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,3 @@
+export function Spinner() {
+  return <div className="border-white border-t-transparent rounded-full animate-spin border-[2.5px] w-5 h-5" />;
+}

--- a/src/components/buttons/SwapSubmitButton/index.tsx
+++ b/src/components/buttons/SwapSubmitButton/index.tsx
@@ -1,5 +1,6 @@
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { FC } from 'preact/compat';
+import { Spinner } from '../../Spinner';
 
 interface SwapSubmitButtonProps {
   text: string;
@@ -32,7 +33,7 @@ export const SwapSubmitButton: FC<SwapSubmitButtonProps> = ({ text, disabled, pe
 
             return (
               <button className="w-full mt-5 btn-vortex-primary btn" disabled={showInDisabledState}>
-                {pending && <span className="loading loading-spinner loading-sm"></span>}
+                {pending && <Spinner />}
                 {text}
               </button>
             );


### PR DESCRIPTION
Closes #260 

As I wrote on the ticket, this is a well-known bug in daisy-ui spinners: https://github.com/saadeghi/daisyui/issues/2570

I just replaced it with a very simple custom spinner using tailwind animation. I tested it on iOS Safari and it works reliably.