### PR TITLE
Track amount type event 

### DIFF
--- a/src/components/AssetNumericInput/index.tsx
+++ b/src/components/AssetNumericInput/index.tsx
@@ -9,6 +9,7 @@ interface AssetNumericInputProps {
   assetIcon: AssetIconType;
   tokenSymbol: string;
   onClick: () => void;
+  onChange?: (e: KeyboardEvent) => void;
   disabled?: boolean;
   readOnly?: boolean;
   registerInput: UseFormRegisterReturn<keyof SwapFormValues>;

--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -10,6 +10,7 @@ interface NumericInputProps {
   defaultValue?: string;
   autoFocus?: boolean;
   disableStyles?: boolean;
+  onChange?: (e: KeyboardEvent) => void;
 }
 
 export const NumericInput = ({
@@ -20,9 +21,11 @@ export const NumericInput = ({
   defaultValue,
   autoFocus,
   disableStyles = false,
+  onChange,
 }: NumericInputProps) => {
   function handleOnChange(e: KeyboardEvent): void {
     handleOnChangeNumericInput(e, maxDecimals);
+    if (onChange) onChange(e);
     register.onChange(e);
   }
 

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -249,6 +249,10 @@ export const SwapPage = () => {
           tokenSymbol={fromToken.assetSymbol}
           assetIcon={fromToken.polygonAssetIcon}
           onClick={() => setModalType('from')}
+          onChange={(e) => {
+            // User interacted with the input field
+            trackEvent({ event: 'amount_type' });
+          }}
           id="fromAmount"
         />
         <UserBalance token={fromToken} onClick={(amount: string) => form.setValue('fromAmount', amount)} />


### PR DESCRIPTION
As described [here](https://github.com/pendulum-chain/vortex/issues/46#issuecomment-2273198079):

> event amount_type: sent when user edits the "from amount" field for the first time

This PR adds changes so that the event `amount_type` is emitted when the user changes the value of the `fromAmount` field. Since `amount_type` is included in the `UNIQUE_EVENT_TYPES`, the event will only get tracked once, even if `trackEvent()` fires multiple times. 

--- 
Closes #288. 