### PR TITLE
Set to SameSite to None for auth cookie

### DIFF
--- a/signer-service/src/api/controllers/siwe.controller.js
+++ b/signer-service/src/api/controllers/siwe.controller.js
@@ -26,8 +26,8 @@ exports.validateSiweSignature = async (req, res) => {
 
     res.cookie('authToken', token, {
       httpOnly: true,
-      secure: false, // TODO TODO TODO: Change to true in production
-      sameSite: 'Strict',
+      secure: true,
+      sameSite: 'None',
       maxAge: DEFAULT_LOGIN_EXPIRATION_TIME_HOURS * 60 * 60 * 1000,
     });
 


### PR DESCRIPTION
Another unforeseen fix required after #257 

Cookies were set to `SameSite=Strict`, the issue is that our backend and frontend don't share the same home domain, and the cookie cannot be set on the deployment.

Regarding security:
This would open the possibility to CSRF attacks BUT we are also using CORS and limiting requests to the backend only from our deployments, so there should be no risk of that.

