### PR TITLE
Add new events to google analytics

### DIFF
--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -67,7 +67,7 @@ function FeeProviderRow({
       };
       scheduleQuote(provider.name, providerPrice ? providerPrice.toFixed(2, 0) : '-1', parameters);
     }
-  }, [amount, provider.name, scheduleQuote, sourceAssetSymbol, targetAssetSymbol, providerPrice, error, vortexPrice]);
+  }, [amount, provider.name, scheduleQuote, sourceAssetSymbol, targetAssetSymbol, providerPrice, vortexPrice, error]);
 
   return (
     <div className="flex items-center justify-between w-full">

--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import { useMemo } from 'preact/hooks';
-import { useEffect, useRef, useState } from 'preact/compat';
+import { useEffect, useRef } from 'preact/compat';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Skeleton } from '../Skeleton';

--- a/src/components/FeeComparison/quoteProviders.tsx
+++ b/src/components/FeeComparison/quoteProviders.tsx
@@ -1,10 +1,10 @@
-import { getQueryFnForService, QuoteQuery } from '../../services/quotes';
+import { getQueryFnForService, QuoteQuery, QuoteService } from '../../services/quotes';
 import alchemyPayIcon from '../../assets/alchemypay.svg';
 import moonpayIcon from '../../assets/moonpay.svg';
 import transakIcon from '../../assets/transak.svg';
 
 export interface QuoteProvider {
-  name: string;
+  name: QuoteService;
   icon?: JSX.Element;
   query: QuoteQuery;
   href: string;
@@ -12,19 +12,19 @@ export interface QuoteProvider {
 
 export const quoteProviders: QuoteProvider[] = [
   {
-    name: 'AlchemyPay',
+    name: 'alchemypay',
     icon: <img src={alchemyPayIcon} className="w-40 ml-1" alt="AlchemyPay" />,
     query: getQueryFnForService('alchemypay'),
     href: 'https://alchemypay.org',
   },
   {
-    name: 'MoonPay',
+    name: 'moonpay',
     icon: <img src={moonpayIcon} className="w-40 ml-1" alt="Moonpay" />,
     query: getQueryFnForService('moonpay'),
     href: 'https://moonpay.com',
   },
   {
-    name: 'Transak',
+    name: 'transak',
     icon: <img src={transakIcon} className="w-30 h-10" alt="Transak" />,
     query: getQueryFnForService('transak'),
     href: 'https://transak.com',

--- a/src/components/Nabla/useSwapForm.tsx
+++ b/src/components/Nabla/useSwapForm.tsx
@@ -52,8 +52,8 @@ export const useSwapForm = () => {
   const from = useWatch({ control, name: 'from' });
   const to = useWatch({ control, name: 'to' });
 
-  const fromToken = from ? INPUT_TOKEN_CONFIG[from] : undefined;
-  const toToken = to ? OUTPUT_TOKEN_CONFIG[to] : undefined;
+  const fromToken = useMemo(() => (from ? INPUT_TOKEN_CONFIG[from] : undefined), [from]);
+  const toToken = useMemo(() => (to ? OUTPUT_TOKEN_CONFIG[to] : undefined), [to]);
 
   const onFromChange = useCallback(
     (tokenKey: string) => {
@@ -96,12 +96,13 @@ export const useSwapForm = () => {
     defaultValue: '0',
   });
 
-  let fromAmount: Big | undefined;
-  try {
-    fromAmount = new Big(fromAmountString);
-  } catch {
-    // no action required
-  }
+  const fromAmount: Big | undefined = useMemo(() => {
+    try {
+      return new Big(fromAmountString);
+    } catch {
+      return undefined;
+    }
+  }, [fromAmountString]);
 
   return {
     form,

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -57,6 +57,7 @@ export type TransactionFailedEvent = OfframpingParameters & {
   event: 'transaction_failure';
   phase_name: string;
   phase_index: number;
+  error_message: string;
 };
 
 export interface ProgressEvent {

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -1,9 +1,11 @@
 import { createContext } from 'preact';
 import { PropsWithChildren, useCallback, useContext, useEffect, useRef } from 'preact/compat';
+import Big from 'big.js';
 import * as Sentry from '@sentry/react';
 import { useAccount } from 'wagmi';
 import { INPUT_TOKEN_CONFIG, OUTPUT_TOKEN_CONFIG } from '../constants/tokenConfig';
 import { OfframpingState } from '../services/offrampingFlow';
+import { calculateTotalReceive } from '../components/FeeCollapse';
 
 declare global {
   interface Window {
@@ -240,6 +242,6 @@ export function createTransactionEvent(type: TransactionEvent['event'], state: O
     from_asset: INPUT_TOKEN_CONFIG[state.inputTokenType].assetSymbol,
     to_asset: OUTPUT_TOKEN_CONFIG[state.outputTokenType].stellarAsset.code.string,
     from_amount: state.inputAmount.units,
-    to_amount: state.outputAmount.units,
+    to_amount: calculateTotalReceive(Big(state.outputAmount.units), OUTPUT_TOKEN_CONFIG[state.outputTokenType]),
   };
 }

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'preact';
-import { PropsWithChildren, useCallback, useContext, useEffect, useRef, useState } from 'preact/compat';
+import { PropsWithChildren, useCallback, useContext, useEffect, useRef } from 'preact/compat';
 import Big from 'big.js';
 import * as Sentry from '@sentry/react';
 import { useAccount } from 'wagmi';

--- a/src/hooks/useMainProcess.ts
+++ b/src/hooks/useMainProcess.ts
@@ -87,6 +87,7 @@ export const useMainProcess = () => {
           event: 'transaction_failure',
           phase_name: currentPhase,
           phase_index: currentPhaseIndex,
+          error_message: state.failure.message,
         });
       }
     },

--- a/src/hooks/useMainProcess.ts
+++ b/src/hooks/useMainProcess.ts
@@ -23,6 +23,8 @@ import { showToast, ToastMessage } from '../helpers/notifications';
 import { IAnchorSessionParams, ISep24Intermediate } from '../services/anchor';
 import { OFFRAMPING_PHASE_SECONDS } from '../pages/progress';
 import { useSiweContext } from '../contexts/siwe';
+import { calculateTotalReceive } from '../components/FeeCollapse';
+
 export type SigningPhase = 'started' | 'approved' | 'signed' | 'finished';
 
 export interface ExecutionInput {
@@ -132,7 +134,7 @@ export const useMainProcess = () => {
           from_asset: INPUT_TOKEN_CONFIG[inputTokenType].assetSymbol,
           to_asset: OUTPUT_TOKEN_CONFIG[outputTokenType].stellarAsset.code.string,
           from_amount: amountInUnits,
-          to_amount: offrampAmount.toFixed(2, 0),
+          to_amount: calculateTotalReceive(offrampAmount, OUTPUT_TOKEN_CONFIG[outputTokenType]),
         });
 
         try {
@@ -219,7 +221,10 @@ export const useMainProcess = () => {
       from_asset: INPUT_TOKEN_CONFIG[executionInputState.inputTokenType].assetSymbol,
       to_asset: OUTPUT_TOKEN_CONFIG[executionInputState.outputTokenType].stellarAsset.code.string,
       from_amount: executionInputState.amountInUnits,
-      to_amount: executionInputState.offrampAmount.toFixed(2, 0),
+      to_amount: calculateTotalReceive(
+        executionInputState.offrampAmount,
+        OUTPUT_TOKEN_CONFIG[executionInputState.outputTokenType],
+      ),
     });
 
     // stop fetching new sep24 url's and clean session variables from the state to be safe.

--- a/src/pages/failure/index.tsx
+++ b/src/pages/failure/index.tsx
@@ -27,7 +27,7 @@ export const FailurePage = ({ finishOfframping, continueFailedFlow, transactionI
         <Cross />
         <h1 className="mt-6 text-2xl font-bold text-center text-red-500">Oops! Something went wrong</h1>
         {transactionId && <TransactionInfo transactionId={transactionId} />}
-        {failure === 'recoverable' ? (
+        {failure.type === 'recoverable' ? (
           <>
             <p className="mt-6 text-center">
               Unfortunately, your withdrawal request could not be processed in time. This could be due to a temporary
@@ -36,7 +36,7 @@ export const FailurePage = ({ finishOfframping, continueFailedFlow, transactionI
             <p>Either try to continue or start over.</p>
           </>
         ) : undefined}
-        {failure === 'recoverable' && (
+        {failure.type === 'recoverable' && (
           <button className="w-full mt-5 btn-vortex-primary btn rounded-xl" onClick={continueFailedFlow}>
             Continue
           </button>

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -111,7 +111,7 @@ export const SwapPage = () => {
   const fromToken = INPUT_TOKEN_CONFIG[from];
   const toToken = OUTPUT_TOKEN_CONFIG[to];
   const formToAmount = form.watch('toAmount');
-  const vortexPrice = formToAmount ? Big(formToAmount) : Big(0);
+  const vortexPrice = useMemo(() => (formToAmount ? Big(formToAmount) : Big(0)), [formToAmount]);
 
   const userInputTokenBalance = useInputTokenBalance({ fromToken });
 

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -264,7 +264,7 @@ export const SwapPage = () => {
         <UserBalance token={fromToken} onClick={(amount: string) => form.setValue('fromAmount', amount)} />
       </>
     ),
-    [form, fromToken, setModalType],
+    [form, fromToken, setModalType, trackEvent],
   );
 
   function getCurrentErrorMessage() {

--- a/src/services/nabla.ts
+++ b/src/services/nabla.ts
@@ -137,8 +137,9 @@ export async function nablaApprove(
   const inputToken = INPUT_TOKEN_CONFIG[inputTokenType];
 
   if (!transactions) {
-    console.error('Missing transactions for nablaApprove');
-    return { ...state, failure: 'unrecoverable' };
+    const message = 'Missing transactions for nablaApprove';
+    console.error(message);
+    return { ...state, failure: { type: 'unrecoverable', message } };
   }
 
   const successorState = {
@@ -319,8 +320,9 @@ export async function nablaSwap(state: OfframpingState, { renderEvent }: Executi
   const outputToken = OUTPUT_TOKEN_CONFIG[outputTokenType];
 
   if (transactions === undefined) {
-    console.error('Missing transactions for nablaSwap');
-    return { ...state, failure: 'unrecoverable' };
+    const message = 'Missing transactions for nablaSwap';
+    console.error(message);
+    return { ...state, failure: { type: 'unrecoverable', message } };
   }
 
   const { api, ss58Format } = (await getApiManagerInstance()).apiData!;

--- a/src/services/offrampingFlow.ts
+++ b/src/services/offrampingFlow.ts
@@ -30,7 +30,10 @@ import * as Sentry from '@sentry/react';
 
 const minutesInMs = (minutes: number) => minutes * 60 * 1000;
 
-export type FailureType = 'recoverable' | 'unrecoverable';
+export interface FailureType {
+  type: 'recoverable' | 'unrecoverable';
+  message?: string;
+}
 
 export type OfframpingPhase =
   | 'prepareTransactions'
@@ -281,7 +284,7 @@ export async function advanceOfframpingState(
     }
 
     console.error('Error advancing offramping state', error);
-    newState = { ...state, failure: 'recoverable' };
+    newState = { ...state, failure: { type: 'recoverable', message: error?.toString() } };
   }
 
   if (newState !== undefined) {

--- a/src/services/polkadot/index.tsx
+++ b/src/services/polkadot/index.tsx
@@ -124,8 +124,9 @@ export async function executeSpacewalkRedeem(
   }
 
   if (!transactions) {
-    console.error('Transactions not prepared, cannot execute Spacewalk redeem');
-    return { ...state, failure: 'unrecoverable' };
+    const message = 'Transactions not prepared, cannot execute Spacewalk redeem';
+    console.error(message);
+    return { ...state, failure: { type: 'unrecoverable', message } };
   }
   let redeemRequestEvent;
 

--- a/src/services/quotes/index.ts
+++ b/src/services/quotes/index.ts
@@ -4,7 +4,7 @@ import { polygon } from 'wagmi/chains';
 
 const QUOTE_ENDPOINT = `${SIGNING_SERVICE_URL}/v1/quotes`;
 
-type QuoteService = 'moonpay' | 'transak' | 'alchemypay';
+export type QuoteService = 'moonpay' | 'transak' | 'alchemypay';
 
 type SupportedNetworks = typeof polygon.name;
 

--- a/src/services/squidrouter/process.ts
+++ b/src/services/squidrouter/process.ts
@@ -61,7 +61,7 @@ export async function squidRouter(
     });
 
     console.error('Error in squidRouter: ', e);
-    return { ...state, failure: 'unrecoverable' };
+    return { ...state, failure: { type: 'unrecoverable', message: e?.toString() } };
   }
 
   setSigningPhase?.('approved');
@@ -93,7 +93,7 @@ export async function squidRouter(
     });
 
     console.error('Error in squidRouter: ', e);
-    return { ...state, failure: 'unrecoverable' };
+    return { ...state, failure: { type: 'unrecoverable', message: e?.toString() } };
   }
 
   setSigningPhase?.('signed');


### PR DESCRIPTION
## Changes in GA

#### New event
- `GA4 Event | compare_quote`
   - parameters:
      -  `{{ Transaction Event Variables }}`
      - `transak_quote`: `{{DLV | transak_quote}}`
      - `moonpay_quote`: `{{DLV | moonpay_quote}}`
      - `alchemypay_quote`: `{{DLV | alchemypay_quote}}`
   - trigger
      - `DL Event | compare_quote` 

#### Changed event
- `GA4 Event | transaction_failure`
   - changed parameters 
      - `error_message`: `{{DLV | error_message}}` 

## Logic changes
- Changes the emitted value of `to_amount` to the amount after fees
- Adds a new field `message` to `FailureType` so that the error message is available on the failure page (and is available  to emit in the respective event)
- The return values of `useSwapForm` were memoized to prevent infinite rerenders of the new `useEffect` hook in the `FeeProviderRow` component
- A new function `scheduleQuote()` was added to the events context. This function is used to accumulate the received quotes from within the `FeeProviderRow`s and emit the event only once all quotes are ready. As the quotes are only fetched and available in the `FeeProviderRow` components, we would need to lift this state out of these components if we wanted to implement it differently.


Closes #279. 