### PR TITLE
Hotfix: Update the Mykobo home domain

### DIFF
--- a/signer-service/src/constants/tokenConfig.js
+++ b/signer-service/src/constants/tokenConfig.js
@@ -6,7 +6,7 @@ const TOKEN_CONFIG = {
     vaultAccountId: '6bsD97dS8ZyomMmp1DLCnCtx25oABtf19dypQKdZe6FBQXSm',
     minWithdrawalAmount: '10000000000000',
     maximumSubsidyAmountRaw: '1000000000000', // 1 unit
-    homeDomain: 'mykobo.co',
+    homeDomain: 'circle.anchor.mykobo.co',
     clientDomainEnabled: true,
     pendulumCurrencyId: {
       Stellar: {


### PR DESCRIPTION
This is a hotfix to use the new home domain of Mykobo.

See Slack for more info.