### PR TITLE
Scroll to beginning of the comparison table.

### DIFF
--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -184,7 +184,7 @@ export function FeeComparison({
 }: FeeComparisonProps) {
   useEffect(() => {
     if (enabled) {
-      const feeComparissonElement = document.getElementById('feeComparisson');
+      const feeComparisonElement = document.getElementById('feeComparison');
       if (feeComparissonElement) {
         setTimeout(() => {
           window.scrollTo({ top: feeComparissonElement.offsetTop, behavior: 'smooth' });

--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import { useMemo } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 import { useEffect, useRef } from 'preact/compat';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
@@ -10,7 +10,7 @@ import { Skeleton } from '../Skeleton';
 import { QuoteProvider, quoteProviders } from './quoteProviders';
 import { OfframpingParameters, useEventsContext } from '../../contexts/events';
 
-type FeeProviderRowProps = FeeComparisonProps & { provider: QuoteProvider };
+type FeeProviderRowProps = Omit<FeeComparisonProps, 'enabled'> & { provider: QuoteProvider };
 
 function VortexRow({
   targetAssetSymbol,
@@ -112,7 +112,7 @@ function FeeProviderRow({
   );
 }
 
-type FeeComparisonTableProps = FeeComparisonProps;
+type FeeComparisonTableProps = Omit<FeeComparisonProps, 'enabled'>;
 
 function FeeComparisonTable({
   amount,
@@ -171,6 +171,7 @@ interface FeeComparisonProps {
   targetAssetSymbol: string;
   vortexPrice: Big;
   network: Networks;
+  enabled: boolean;
 }
 
 export function FeeComparison({
@@ -179,9 +180,28 @@ export function FeeComparison({
   targetAssetSymbol,
   vortexPrice,
   network,
+  enabled,
 }: FeeComparisonProps) {
+  useEffect(() => {
+    if (enabled) {
+      const feeComparissonElement = document.getElementById('feeComparisson');
+      if (feeComparissonElement) {
+        setTimeout(() => {
+          window.scrollTo({ top: feeComparissonElement.offsetTop, behavior: 'smooth' });
+        }, 300);
+      }
+    }
+  }, [enabled]);
+
+  if (!enabled) {
+    return null;
+  }
+
   return (
-    <div className="flex flex-col items-center max-w-4xl px-4 py-8 rounded-lg md:flex-row gap-x-8 gap-y-8 md:mx-auto md:w-3/4">
+    <div
+      id="feeComparisson"
+      className="flex flex-col items-center max-w-4xl px-4 py-8 rounded-lg md:flex-row gap-x-8 gap-y-8 md:mx-auto md:w-3/4"
+    >
       <div className="w-full gap-6 overflow-auto grow">
         <h1 className="text-2xl font-bold">Save on exchange rate markups</h1>
         <p className="mt-4 text-lg">

--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -185,9 +185,9 @@ export function FeeComparison({
   useEffect(() => {
     if (enabled) {
       const feeComparisonElement = document.getElementById('feeComparison');
-      if (feeComparissonElement) {
+      if (feeComparisonElement) {
         setTimeout(() => {
-          window.scrollTo({ top: feeComparissonElement.offsetTop, behavior: 'smooth' });
+          window.scrollTo({ top: feeComparisonElement.offsetTop, behavior: 'smooth' });
         }, 300);
       }
     }
@@ -199,7 +199,7 @@ export function FeeComparison({
 
   return (
     <div
-      id="feeComparisson"
+      id="feeComparison"
       className="flex flex-col items-center max-w-4xl px-4 py-8 rounded-lg md:flex-row gap-x-8 gap-y-8 md:mx-auto md:w-3/4"
     >
       <div className="w-full gap-6 overflow-auto grow">

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -426,10 +426,6 @@ export const SwapPage = () => {
             onClick={(e) => {
               e.preventDefault();
               setShowCompareFees(!showCompareFees);
-              // Smooth scroll to bottom of page
-              setTimeout(() => {
-                window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
-              }, 300);
             }}
           >
             Compare fees
@@ -466,6 +462,7 @@ export const SwapPage = () => {
           targetAssetSymbol={toToken.fiat.symbol}
           vortexPrice={vortexPrice}
           network={selectedNetwork}
+          enabled={showCompareFees}
         />
       )}
       <TrustedBy />


### PR DESCRIPTION
No issue created.

### 
- Scroll to the beginning of the fee comparison table upon click of the button and using the deep link.

### Changes
- Add an id to the overarching`FeeComparison` div.
- Use a state hook to detect when the `FeeComparison` element is visible, and only then scroll to it. 