### PR TITLE
Add `notranslate` meta tag to prevent browser translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>Vortex</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <meta name="google" content="notranslate" />
 
     <!-- Google Tag Manager -->
     <script>
@@ -35,14 +36,14 @@
 
   <body style="background-color: #fff">
     <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
+    <noscript>
+      <iframe
         src="https://www.googletagmanager.com/ns.html?id=GTM-T8JZSLD8"
         height="0"
         width="0"
         style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
+      ></iframe>
+    </noscript>
     <!-- End Google Tag Manager (noscript) -->
 
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="notranslate" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />


### PR DESCRIPTION
Prevent browser from suggesting translation on Vortex. Solution based on StackOverflow answer [here](https://stackoverflow.com/a/61363117). 

I tested this and with the new configuration, the browser will not even translate it if the user manually opens the translation box. Which I think is good. 
<img width="1705" alt="image" src="https://github.com/user-attachments/assets/0de2868a-0085-41e0-8bf3-59199059d3cb" />


Closes #354.