### PR TITLE
Make deep link for quote comparison not scroll down but only open table

### DIFF
--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -1,5 +1,6 @@
 import Big from 'big.js';
-import { useEffect, useRef, useMemo } from 'preact/hooks';
+import { useEffect, useRef, useMemo, useImperativeHandle } from 'preact/hooks';
+import { forwardRef } from 'preact/compat';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 
@@ -161,24 +162,18 @@ function FeeComparisonTable(props: BaseComparisonProps) {
   );
 }
 
-export function FeeComparison({ enabled, ...props }: FeeComparisonProps) {
+export interface FeeComparisonRef {
+  scrollIntoView: (options?: ScrollIntoViewOptions) => void;
+}
+
+export const FeeComparison = forwardRef<FeeComparisonRef, FeeComparisonProps>(function FeeComparison(props, ref) {
   const feeComparisonRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!enabled) return;
-    if (!feeComparisonRef.current) return;
-
-    const timer = setTimeout(() => {
-      window.scrollTo({
-        top: feeComparisonRef.current!.offsetTop,
-        behavior: 'smooth',
-      });
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [enabled]);
-
-  if (!enabled) return null;
+  useImperativeHandle(ref, () => ({
+    scrollIntoView: (options?: ScrollIntoViewOptions) => {
+      feeComparisonRef.current?.scrollIntoView(options || { block: 'start', behavior: 'smooth' });
+    },
+  }));
 
   return (
     <div
@@ -196,4 +191,4 @@ export function FeeComparison({ enabled, ...props }: FeeComparisonProps) {
       <FeeComparisonTable {...props} />
     </div>
   );
-}
+});

--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -18,10 +18,6 @@ interface BaseComparisonProps {
   network: Networks;
 }
 
-interface FeeComparisonProps extends BaseComparisonProps {
-  enabled: boolean;
-}
-
 type VortexRowProps = Pick<BaseComparisonProps, 'targetAssetSymbol' | 'vortexPrice'>;
 
 function VortexRow({ targetAssetSymbol, vortexPrice }: VortexRowProps) {
@@ -166,7 +162,7 @@ export interface FeeComparisonRef {
   scrollIntoView: (options?: ScrollIntoViewOptions) => void;
 }
 
-export const FeeComparison = forwardRef<FeeComparisonRef, FeeComparisonProps>(function FeeComparison(props, ref) {
+export const FeeComparison = forwardRef<FeeComparisonRef, BaseComparisonProps>(function FeeComparison(props, ref) {
   const feeComparisonRef = useRef<HTMLDivElement>(null);
 
   useImperativeHandle(ref, () => ({

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -467,7 +467,6 @@ export const SwapPage = () => {
           targetAssetSymbol={toToken.fiat.symbol}
           vortexPrice={vortexPrice}
           network={selectedNetwork}
-          enabled={showCompareFees}
           ref={feeComparisonRef}
         />
       )}

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -9,7 +9,7 @@ import { SwapSubmitButton } from '../../components/buttons/SwapSubmitButton';
 import { TermsAndConditions } from '../../components/TermsAndConditions';
 import { AssetNumericInput } from '../../components/AssetNumericInput';
 import { useSwapForm } from '../../components/Nabla/useSwapForm';
-import { FeeComparison } from '../../components/FeeComparison';
+import { FeeComparison, FeeComparisonRef } from '../../components/FeeComparison';
 import { BenefitsList } from '../../components/BenefitsList';
 import { ExchangeRate } from '../../components/ExchangeRate';
 import { LabeledInput } from '../../components/LabeledInput';
@@ -69,6 +69,7 @@ const Arrow = () => (
 
 export const SwapPage = () => {
   const formRef = useRef<HTMLDivElement | null>(null);
+  const feeComparisonRef = useRef<FeeComparisonRef>(null);
   const pendulumNode = usePendulumNode();
   const [api, setApi] = useState<ApiPromise | null>(null);
   const { address } = useVortexAccount();
@@ -424,7 +425,12 @@ export const SwapPage = () => {
             disabled={!inputAmountIsStable}
             onClick={(e) => {
               e.preventDefault();
-              setShowCompareFees(!showCompareFees);
+              // We always show the fees comparison when the user clicks on the button. It will not be hidden again.
+              if (!showCompareFees) setShowCompareFees(true);
+              // Scroll to the comparison fees section (with a small delay to allow the component to render first)
+              setTimeout(() => {
+                feeComparisonRef.current?.scrollIntoView();
+              }, 200);
             }}
           >
             Compare fees
@@ -462,6 +468,7 @@ export const SwapPage = () => {
           vortexPrice={vortexPrice}
           network={selectedNetwork}
           enabled={showCompareFees}
+          ref={feeComparisonRef}
         />
       )}
       <TrustedBy />


### PR DESCRIPTION
- Only scroll to the quote table when user clicks on 'Compare fees' button.
- Change the behavior of the 'Compare fees' button to always show the table and never hide it again. This means that the quote table will only be hidden when the user opens the page without `showCompareFees=true` (or with `showCompareFees=false`) and before clicking the 'Compare fees' button. 

Closes #361 and closes #372. 