### PR TITLE
Revert "Add `notranslate` meta tag to prevent browser translation"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="notranslate" translate="no">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
@@ -7,7 +7,6 @@
     <title>Vortex</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <meta name="google" content="notranslate" />
 
     <!-- Google Tag Manager -->
     <script>
@@ -36,14 +35,14 @@
 
   <body style="background-color: #fff">
     <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe
+    <noscript
+      ><iframe
         src="https://www.googletagmanager.com/ns.html?id=GTM-T8JZSLD8"
         height="0"
         width="0"
         style="display: none; visibility: hidden"
-      ></iframe>
-    </noscript>
+      ></iframe
+    ></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
     <div id="app"></div>


### PR DESCRIPTION
Reverts pendulum-chain/vortex#359.

We saw that removing the option to translate the page makes users drop.