### PR TITLE
Increase max withdrawal amount to 10000 EUR

### DIFF
--- a/src/constants/tokenConfig.ts
+++ b/src/constants/tokenConfig.ts
@@ -277,7 +277,7 @@ export const OUTPUT_TOKEN_CONFIG: Record<OutputTokenType, OutputTokenDetails> = 
     vaultAccountId: '6dgJM1ijyHFEfzUokJ1AHq3z3R3Z8ouc8B5SL9YjMRUaLsjh',
     erc20WrapperAddress: '6eNUvRWCKE3kejoyrJTXiSM7NxtWi37eRXTnKhGKPsJevAj5',
     minWithdrawalAmountRaw: '10000000000000',
-    maxWithdrawalAmountRaw: '5000000000000000',
+    maxWithdrawalAmountRaw: '10000000000000000',
     offrampFeesBasisPoints: 25,
     usesMemo: false,
     supportsClientDomain: true,


### PR DESCRIPTION
Mykobo raised their max withdrawal amount to 30k EUR. We set it to 10k EUR. 