### PR TITLE
Track quote only after user interaction

### DIFF
--- a/src/components/FeeComparison/index.tsx
+++ b/src/components/FeeComparison/index.tsx
@@ -16,6 +16,7 @@ interface BaseComparisonProps {
   targetAssetSymbol: string;
   vortexPrice: Big;
   network: Networks;
+  trackQuote: boolean;
 }
 
 type VortexRowProps = Pick<BaseComparisonProps, 'targetAssetSymbol' | 'vortexPrice'>;
@@ -46,6 +47,7 @@ function FeeProviderRow({
   targetAssetSymbol,
   vortexPrice,
   network,
+  trackQuote,
 }: FeeProviderRowProps) {
   const { scheduleQuote } = useEventsContext();
   // The vortex price is sometimes lagging behind the amount (as it first has to be calculated asynchronously)
@@ -79,7 +81,7 @@ function FeeProviderRow({
 
     if (prevVortexPrice.current?.eq(vortexPrice)) return;
 
-    scheduleQuote(provider.name, providerPrice ? providerPrice.toFixed(2, 0) : '-1', parameters);
+    scheduleQuote(provider.name, providerPrice ? providerPrice.toFixed(2, 0) : '-1', parameters, trackQuote);
     prevVortexPrice.current = vortexPrice;
   }, [
     amount,

--- a/src/contexts/events.tsx
+++ b/src/contexts/events.tsx
@@ -205,7 +205,9 @@ const useEvents = () => {
   /// This function is used to schedule a quote returned by a quote service. Once all quotes are ready, it emits a compare_quote event.
   /// Calling this function with a quote of '-1' will make the function emit the quote as undefined.
   const scheduleQuote = useCallback(
-    (service: QuoteService, quote: string, parameters: OfframpingParameters) => {
+    (service: QuoteService, quote: string, parameters: OfframpingParameters, enableEventTracking: boolean) => {
+      if (!enableEventTracking) return;
+
       const prev = scheduledQuotes.current;
 
       // Do a deep comparison of the parameters to check if they are the same.

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -70,6 +70,7 @@ export const SwapPage = () => {
   const formRef = useRef<HTMLDivElement | null>(null);
   const feeComparisonRef = useRef<FeeComparisonRef>(null);
   const pendulumNode = usePendulumNode();
+  const trackQuote = useRef(false);
   const [api, setApi] = useState<ApiPromise | null>(null);
   const { isDisconnected, address } = useVortexAccount();
   const [initializeFailedMessage, setInitializeFailedMessage] = useState<string | null>(null);
@@ -277,6 +278,8 @@ export const SwapPage = () => {
           onChange={() => {
             // User interacted with the input field
             trackEvent({ event: 'amount_type' });
+            // This also enables the quote tracking events
+            trackQuote.current = true;
           }}
           id="fromAmount"
         />
@@ -480,11 +483,15 @@ export const SwapPage = () => {
             onClick={(e) => {
               e.preventDefault();
               // We always show the fees comparison when the user clicks on the button. It will not be hidden again.
-              if (!showCompareFees) setShowCompareFees(true);
+              if (!showCompareFees) {
+                setShowCompareFees(true);
+              }
               // Scroll to the comparison fees section (with a small delay to allow the component to render first)
               setTimeout(() => {
                 feeComparisonRef.current?.scrollIntoView();
               }, 200);
+              // We track the user interaction with the button, for tracking the quote requested.
+              trackQuote.current = true;
             }}
           >
             Compare fees
@@ -526,6 +533,7 @@ export const SwapPage = () => {
           vortexPrice={vortexPrice}
           network={selectedNetwork}
           ref={feeComparisonRef}
+          trackQuote={trackQuote.current}
         />
       )}
       <TrustedBy />


### PR DESCRIPTION
Issue #411

We disable tracking of the quote event, until either the input field changes, or the user clicks on the `Compare Fees` button, even if this one is already expanded. 