### PR TITLE
 Use default input amount to display fee section always.

### DIFF
--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -36,8 +36,8 @@ export const NumericInput = ({
     handleOnPasteNumericInput(e, maxDecimals);
     register.onChange(e);
   }
-  console.log(defaultValue, 'defaultValue');
-  const removeText = disabled ? ' text-white' : '';
+  const removeText = disabled ? ' opacity-0' : '';
+
   return (
     <div className={disableStyles ? 'relative flex-grow' : 'relative flex-grow text-black font-outfit'}>
       <Input

--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -11,6 +11,7 @@ interface NumericInputProps {
   defaultValue?: string;
   autoFocus?: boolean;
   disableStyles?: boolean;
+  disabled?: boolean;
   onChange?: (e: ChangeEvent) => void;
 }
 
@@ -22,6 +23,7 @@ export const NumericInput = ({
   defaultValue,
   autoFocus,
   disableStyles = false,
+  disabled,
   onChange,
 }: NumericInputProps) => {
   function handleOnChange(e: ChangeEvent): void {
@@ -34,9 +36,10 @@ export const NumericInput = ({
     handleOnPasteNumericInput(e, maxDecimals);
     register.onChange(e);
   }
-
+  console.log(defaultValue, 'defaultValue');
+  const removeText = disabled ? ' text-white' : '';
   return (
-    <div className={disableStyles ? 'flex-grow' : 'flex-grow text-black font-outfit'}>
+    <div className={disableStyles ? 'relative flex-grow' : 'relative flex-grow text-black font-outfit'}>
       <Input
         {...register}
         autoComplete="off"
@@ -44,8 +47,8 @@ export const NumericInput = ({
         autoCapitalize="none"
         className={
           disableStyles
-            ? 'border-0 bg-transparent focus:outline-none px-4 ' + additionalStyle
-            : 'input-ghost w-full text-lg pl-2 focus:outline-none text-accent-content ' + additionalStyle
+            ? 'border-0 bg-transparent focus:outline-none px-4 text-opacity-100 ' + additionalStyle + removeText
+            : 'input-ghost w-full text-lg pl-2 focus:outline-none text-accent-content text-opacity-100' + removeText
         }
         minLength={1}
         onChange={handleOnChange}
@@ -60,6 +63,9 @@ export const NumericInput = ({
         value={defaultValue}
         autoFocus={autoFocus}
       />
+      {disabled && (
+        <span className="absolute top-1/2 right-3 -translate-y-1/2 loading loading-bars loading-sm text-primary"></span>
+      )}
     </div>
   );
 };

--- a/src/hooks/nabla/useTokenAmountOut.ts
+++ b/src/hooks/nabla/useTokenAmountOut.ts
@@ -13,7 +13,7 @@ import { NABLA_ROUTER } from '../../constants/constants';
 import { useContractRead } from './useContractRead';
 import { useDebouncedValue } from '../useDebouncedValue';
 import { ApiPromise } from '@polkadot/api';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   getInputTokenDetailsOrDefault,
   InputTokenType,
@@ -62,6 +62,8 @@ export function useTokenOutAmount({
 }: UseTokenOutAmountProps) {
   const { setError, clearErrors } = form;
   const { trackEvent } = useEventsContext();
+  const [pending, setPending] = useState(true);
+  const [initializing, setInitializing] = useState(true);
 
   const debouncedFromAmountString = useDebouncedValue(fromAmountString, 800);
   let debouncedAmountBigDecimal: Big | undefined;
@@ -144,15 +146,21 @@ export function useTokenOutAmount({
     },
   );
 
-  const pending = (isLoading && fetchStatus !== 'idle') || debouncedFromAmountString !== fromAmountString;
   useEffect(() => {
+    const pending =
+      (isLoading && fetchStatus !== 'idle') || debouncedFromAmountString !== fromAmountString || initializing;
+    if (fetchStatus === 'fetching' && initializing) {
+      setInitializing(false);
+    }
+    setPending(pending);
+
     if (pending) return;
     if (error === null) {
       clearErrors('root');
     } else {
       setError('root', { type: 'custom', message: error });
     }
-  }, [error, pending, clearErrors, setError]);
+  }, [error, isLoading, fetchStatus, initializing, debouncedAmountBigDecimal, fromAmountString, clearErrors, setError]);
 
   const isInputStable = debouncedFromAmountString === fromAmountString;
   const stableAmountInUnits = isInputStable ? debouncedFromAmountString : undefined;

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -210,7 +210,7 @@ export const SwapPage = () => {
       // Calculate the final amount after the offramp fees
       const totalReceive = calculateTotalReceive(toAmount, toToken);
       form.setValue('toAmount', totalReceive);
-    } else if (!tokenOutAmount.isLoading || tokenOutAmount.error) {
+    } else if (tokenOutAmount.error) {
       form.setValue('toAmount', '0');
     } else {
       // Do nothing

--- a/src/pages/swap/useSwapUrlParams.ts
+++ b/src/pages/swap/useSwapUrlParams.ts
@@ -16,26 +16,19 @@ export const useSwapUrlParams = ({ form, setShowCompareFees }: UseSwapUrlParamsP
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const fromAmountParam = params.get('fromAmount');
-    const toToken = params.get('to');
     const toTokenForm = form.getValues('to');
-
-    // const newurl = window.location.protocol + "//" + window.location.host;
-    // window.history.pushState({path:newurl},'',newurl);
 
     if (fromAmountParam) {
       const parsedAmount = Number(fromAmountParam);
       if (!isNaN(parsedAmount) && parsedAmount >= 0) {
         form.setValue('fromAmount', parsedAmount.toFixed(2));
       }
-    } //less invasive -> else if (defaultAmounts[toToken as OutputTokenType] && !address) {
-    else if (toTokenForm) {
+      setShowCompareFees(true);
+      // toToken should always exist due to hardcoded default values. Defensive.
+    } else if (toTokenForm) {
       const defaultAmount = defaultAmounts[toTokenForm];
       form.setValue('fromAmount', defaultAmount.toFixed(2));
+      setShowCompareFees(true);
     }
-    setShowCompareFees(true);
-    // const showCompareFeesParam = params.get('showCompareFees');
-    // if (showCompareFeesParam === 'true') {
-    //   setShowCompareFees(true);
-    // }
   }, [form, setShowCompareFees]);
 };

--- a/src/pages/swap/useSwapUrlParams.ts
+++ b/src/pages/swap/useSwapUrlParams.ts
@@ -9,7 +9,7 @@ interface UseSwapUrlParamsProps {
   form: UseFormReturn<SwapFormValues, any, undefined>;
   setShowCompareFees: Dispatch<SetStateAction<boolean>>;
 }
-const defaultAmounts: Record<OutputTokenType, number> = { eurc: 1000, ars: 200 };
+const defaultFromAmounts: Record<OutputTokenType, number> = { eurc: 1000, ars: 200 };
 
 export const useSwapUrlParams = ({ form, setShowCompareFees }: UseSwapUrlParamsProps) => {
   useEffect(() => {
@@ -25,7 +25,7 @@ export const useSwapUrlParams = ({ form, setShowCompareFees }: UseSwapUrlParamsP
       setShowCompareFees(true);
       // toToken should always exist due to hardcoded default values. Defensive.
     } else if (toTokenForm) {
-      const defaultAmount = defaultAmounts[toTokenForm];
+      const defaultAmount = defaultFromAmounts[toTokenForm];
       form.setValue('fromAmount', defaultAmount.toFixed(2));
       setShowCompareFees(true);
     }

--- a/src/pages/swap/useSwapUrlParams.ts
+++ b/src/pages/swap/useSwapUrlParams.ts
@@ -12,7 +12,6 @@ interface UseSwapUrlParamsProps {
 const defaultAmounts: Record<OutputTokenType, number> = { eurc: 1000, ars: 200 };
 
 export const useSwapUrlParams = ({ form, setShowCompareFees }: UseSwapUrlParamsProps) => {
-  const { address } = useVortexAccount();
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const fromAmountParam = params.get('fromAmount');

--- a/src/pages/swap/useSwapUrlParams.ts
+++ b/src/pages/swap/useSwapUrlParams.ts
@@ -1,27 +1,41 @@
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { SwapFormValues } from '../../components/Nabla/schema';
+import { OutputTokenType } from '../../constants/tokenConfig';
+import { useVortexAccount } from '../../hooks/useVortexAccount';
 
 interface UseSwapUrlParamsProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   form: UseFormReturn<SwapFormValues, any, undefined>;
   setShowCompareFees: Dispatch<SetStateAction<boolean>>;
 }
+const defaultAmounts: Record<OutputTokenType, number> = { eurc: 1000, ars: 200 };
 
 export const useSwapUrlParams = ({ form, setShowCompareFees }: UseSwapUrlParamsProps) => {
+  const { address } = useVortexAccount();
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const fromAmountParam = params.get('fromAmount');
+    const toToken = params.get('to');
+    const toTokenForm = form.getValues('to');
+
+    // const newurl = window.location.protocol + "//" + window.location.host;
+    // window.history.pushState({path:newurl},'',newurl);
+
     if (fromAmountParam) {
       const parsedAmount = Number(fromAmountParam);
       if (!isNaN(parsedAmount) && parsedAmount >= 0) {
         form.setValue('fromAmount', parsedAmount.toFixed(2));
       }
+    } //less invasive -> else if (defaultAmounts[toToken as OutputTokenType] && !address) {
+    else if (toTokenForm) {
+      const defaultAmount = defaultAmounts[toTokenForm];
+      form.setValue('fromAmount', defaultAmount.toFixed(2));
     }
-
-    const showCompareFeesParam = params.get('showCompareFees');
-    if (showCompareFeesParam === 'true') {
-      setShowCompareFees(true);
-    }
+    setShowCompareFees(true);
+    // const showCompareFeesParam = params.get('showCompareFees');
+    // if (showCompareFeesParam === 'true') {
+    //   setShowCompareFees(true);
+    // }
   }, [form, setShowCompareFees]);
 };


### PR DESCRIPTION
Issue: #421 

### Changes
- Uses hard coded default values depending on the output amount, to have always a non-zero amount and show the compare fee section permanently.
- This also adds a new state to `useTokenAmountOut` hook, such that it returns loading when starting the app. Previously, this value was initially set to `false` which lead to "flickering" of the final quote.