### PR TITLE
Readd `rateLimitNumberOfProxies` parameter

### DIFF
--- a/signer-service/src/config/express.js
+++ b/signer-service/src/config/express.js
@@ -29,7 +29,7 @@ app.use(
 
 // enable rate limiting
 // Set number of expected proxies
-app.set('trust proxy', true);
+app.set('trust proxy', rateLimitNumberOfProxies);
 
 app.use((req, res, next) => {
   console.log({


### PR DESCRIPTION
Since https://github.com/pendulum-chain/tasks/issues/447 is done, we can re-add the `rateLimitNumberOfProxies` parameter and check for the correct number for the parameter. 