### PR TITLE
Change styling of reset and restart button

### DIFF
--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -35,7 +35,7 @@ export const TextInput = ({
   <div className="flex-grow text-black font-outfit">
     <input
       className={
-        'h-[3rem] input input-ghost w-full text-lg font-outfit pl-2 focus:outline-none focus:text-accent-content text-accent-content disabled:text-gray-200 ' +
+        'input input-lg w-full font-outfit py-2 pl-2 focus:outline-none focus:text-accent-content text-accent-content disabled:text-gray-200 ' +
         additionalStyle
       }
       type={type || 'text'}

--- a/src/pages/failure/index.tsx
+++ b/src/pages/failure/index.tsx
@@ -56,10 +56,16 @@ export const FailurePage = ({ finishOfframping, continueFailedFlow, transactionI
           . We’re here to help!
         </p>
         <p className="mb-5 text-center text-gray-400">
-          Contacted support and ready to start fresh with a new transaction? <br /> Tap
-          <button className="btn btn-sm rounded-xl inline-flex ml-1 text-gray-400" onClick={finishOfframping}>
-            Reset and Restart
-          </button>
+          Contacted support and ready to start fresh with a new transaction?
+          <p className="mt-1">
+            Tap
+            <button
+              className="btn h-8! btn-xs btn-dash rounded-xl inline-flex ml-1 text-gray-400"
+              onClick={finishOfframping}
+            >
+              Reset and Restart
+            </button>
+          </p>
         </p>
         <EmailForm transactionId={transactionId} transactionSuccess={false} />
       </Box>


### PR DESCRIPTION
Change the 'Reset and Restart' button to have a dashed border and change the styling of the email input field so that it's apparent to be an input field again. 


Before
<img width="715" alt="image" src="https://github.com/user-attachments/assets/f5b2130e-a6a6-42a1-9579-3cfa8078a06b" />


After

<img width="714" alt="image" src="https://github.com/user-attachments/assets/abf68849-ed19-45f3-b640-695cd4649352" />
