### PR TITLE
Fetch events from BRLA API instead of webhooks cache.

### DIFF
--- a/signer-service/src/api/controllers/brla.controller.ts
+++ b/signer-service/src/api/controllers/brla.controller.ts
@@ -76,7 +76,7 @@ export const getOfframpStatus = async (req: Request<{}, {}, {}, { taxId: string 
       return;
     }
 
-    const lastEventCached = eventPoller.getLatestEventForUser(subaccount.id);
+    const lastEventCached = await eventPoller.getLatestEventForUser(subaccount.id);
 
     if (!lastEventCached) {
       res.status(404).json({ error: `No status events found for ${taxId}` });
@@ -140,7 +140,7 @@ export const fetchSubaccountKycStatus = async (
       return;
     }
 
-    const lastEventCached = eventPoller.getLatestEventForUser(subaccount.id);
+    const lastEventCached = await eventPoller.getLatestEventForUser(subaccount.id);
 
     if (!lastEventCached) {
       res.status(404).json({ error: `No status events found for ${taxId}` });

--- a/signer-service/src/api/controllers/brla.controller.ts
+++ b/signer-service/src/api/controllers/brla.controller.ts
@@ -83,6 +83,15 @@ export const getOfframpStatus = async (req: Request<{}, {}, {}, { taxId: string 
       return;
     }
 
+    if (
+      lastEventCached.subscription !== 'MONEY-TRANSFER' &&
+      lastEventCached.subscription !== 'BURN' &&
+      lastEventCached.subscription !== 'BALANCE-UPDATE'
+    ) {
+      res.status(404).json({ error: `No offramp status event found for ${taxId}` });
+      return;
+    }
+
     res.status(200).json({ type: lastEventCached.subscription, status: lastEventCached.data.status });
   } catch (error) {
     console.error('Error while requesting offramp status: ', error);
@@ -144,6 +153,11 @@ export const fetchSubaccountKycStatus = async (
 
     if (!lastEventCached) {
       res.status(404).json({ error: `No status events found for ${taxId}` });
+      return;
+    }
+
+    if (lastEventCached.subscription !== 'KYC') {
+      res.status(404).json({ error: `No KYC status event found for ${taxId}` });
       return;
     }
 

--- a/signer-service/src/api/services/brla/brlaApiService.ts
+++ b/signer-service/src/api/services/brla/brlaApiService.ts
@@ -132,8 +132,11 @@ export class BrlaApiService {
     if (!response.ok) {
       throw new Error(`Request failed with status ${response.status}, ${await response.text()}`);
     }
-
-    return response.json();
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
   }
 
   public async getSubaccount(taxId: string): Promise<SubaccountData | undefined> {
@@ -162,7 +165,6 @@ export class BrlaApiService {
 
   public async acknowledgeEvents(ids: string[]): Promise<void> {
     const endpoint = `/webhooks/events`;
-    console.log('Calling acknowledgeEvents with ids: ', ids);
     return await this.sendRequest(endpoint, 'PATCH', undefined, { ids });
   }
 }

--- a/signer-service/src/api/services/brla/brlaApiService.ts
+++ b/signer-service/src/api/services/brla/brlaApiService.ts
@@ -1,5 +1,6 @@
 import { BRLA_LOGIN_PASSWORD, BRLA_LOGIN_USERNAME, BRLA_BASE_URL } from '../../../constants/constants';
 import { SubaccountData, RegisterSubaccountPayload, OfframpPayload } from './types';
+import { Event } from './webhooks';
 
 interface EndpointMapping {
   '/subaccounts': {
@@ -37,7 +38,7 @@ interface EndpointMapping {
     };
     GET: {
       body: undefined;
-      response: undefined;
+      response: { events: Event[] };
     };
     PATCH: {
       body: { ids: string[] };
@@ -150,6 +151,13 @@ export class BrlaApiService {
   public async createSubaccount(registerSubaccountPayload: RegisterSubaccountPayload): Promise<{ id: string }> {
     const endpoint = `/subaccounts`;
     return await this.sendRequest(endpoint, 'POST', undefined, registerSubaccountPayload);
+  }
+
+  public async getAllEventsByUser(userId: string): Promise<Event[] | undefined> {
+    const endpoint = `/webhooks/events`;
+    const query = `subaccountId=${encodeURIComponent(userId)}`;
+    const response = await this.sendRequest(endpoint, 'GET', query);
+    return response.events;
   }
 
   public async acknowledgeEvents(ids: string[]): Promise<void> {

--- a/signer-service/src/api/services/brla/webhooks.ts
+++ b/signer-service/src/api/services/brla/webhooks.ts
@@ -135,4 +135,13 @@ export class EventPoller {
     events.sort((a, b) => a.createdAt - b.createdAt);
     return events[events.length - 1];
   }
+
+  public async getSubscriptionEventsForUser(userId: string, subscription: SubscriptionType): Promise<Event[] | null> {
+    const events = await this.brlaApiService.getAllEventsByUser(userId);
+
+    if (!events || events.length === 0) {
+      return null;
+    }
+    return events.filter((event) => event.subscription === subscription);
+  }
 }

--- a/signer-service/src/api/services/brla/webhooks.ts
+++ b/signer-service/src/api/services/brla/webhooks.ts
@@ -126,29 +126,13 @@ export class EventPoller {
     }
   }
 
-  private async forceSyncEvents(userId: string) {
-    // Fetch all events for user from BRLA, get cache.
-    const fetchedUserEvents = await this.brlaApiService.getAllEventsByUser(userId);
-    const userEvents = this.cache.get(userId) || [];
-
-    if (!fetchedUserEvents) {
-      return;
-    }
-
-    if (userEvents.length > 0) {
-      this.appendEventsToCache(userId, userEvents, fetchedUserEvents);
-    } else {
-      this.createNewEventCache(userId, userEvents, fetchedUserEvents);
-    }
-  }
-
   public async getLatestEventForUser(userId: string): Promise<Event | null> {
-    await this.forceSyncEvents(userId);
-    const events = this.cache.get(userId);
+    const events = await this.brlaApiService.getAllEventsByUser(userId);
 
     if (!events || events.length === 0) {
       return null;
     }
+    events.sort((a, b) => a.createdAt - b.createdAt);
     return events[events.length - 1];
   }
 }

--- a/signer-service/src/api/services/brla/webhooks.ts
+++ b/signer-service/src/api/services/brla/webhooks.ts
@@ -80,7 +80,6 @@ export class EventPoller {
     const eventsNotRegistered = fetchedUserEvents.filter(
       (event) => new Date(event.createdAt) > new Date(lastTimestamp),
     );
-    console.log('Poll: Appending events to cache: ', eventsNotRegistered);
     userEvents.push(...eventsNotRegistered);
     this.cache.set(userId, userEvents);
     this.acknowledgeEvents(eventsNotRegistered);
@@ -89,7 +88,6 @@ export class EventPoller {
   private createNewEventCache(userId: string, userEvents: Event[], fetchedUserEvents: Event[]) {
     // Order by createdAt, increasing
     fetchedUserEvents.sort((a, b) => a.createdAt - b.createdAt);
-    console.log('Poll: Creating new cache for user: ', fetchedUserEvents);
     userEvents.push(...fetchedUserEvents);
     this.cache.set(userId, userEvents);
     this.acknowledgeEvents(fetchedUserEvents);

--- a/signer-service/src/index.ts
+++ b/signer-service/src/index.ts
@@ -37,8 +37,6 @@ const validateRequiredEnvVars = () => {
 validateRequiredEnvVars();
 
 export const eventPoller = new EventPoller(DEFAULT_POLLING_INTERVAL);
-// TODO deprecated
-//eventPoller.start();
 
 // listen to requests
 app.listen(port, () => logger.info(`server started on port ${port} (${env})`));

--- a/signer-service/src/index.ts
+++ b/signer-service/src/index.ts
@@ -37,7 +37,8 @@ const validateRequiredEnvVars = () => {
 validateRequiredEnvVars();
 
 export const eventPoller = new EventPoller(DEFAULT_POLLING_INTERVAL);
-eventPoller.start();
+// TODO deprecated
+//eventPoller.start();
 
 // listen to requests
 app.listen(port, () => logger.info(`server started on port ${port} (${env})`));

--- a/src/components/Nabla/useSwapForm.tsx
+++ b/src/components/Nabla/useSwapForm.tsx
@@ -115,7 +115,6 @@ export const useSwapForm = () => {
         to: tokenKey,
         from: prev?.from,
       };
-
       setStorageForSwapSettings(updated);
       setValue('to', tokenKey as OutputTokenType);
       setIsTokenSelectModalVisible(false);

--- a/src/constants/tokenConfig.ts
+++ b/src/constants/tokenConfig.ts
@@ -313,6 +313,14 @@ export enum OutputTokenType {
   ARS = 'ars',
   BRL = 'brl',
 }
+
+export function getEnumKeyByStringValue<T extends { [key: string]: string }>(
+  enumObj: T,
+  value: string,
+): T[keyof T] | undefined {
+  const key = Object.keys(enumObj).find((k) => enumObj[k as keyof T] === value) as keyof T | undefined;
+  return key ? enumObj[key] : undefined;
+}
 export const OUTPUT_TOKEN_CONFIG: Record<OutputTokenType, OutputTokenDetailsSpacewalk | OutputTokenDetailsMoonbeam> = {
   eurc: {
     type: 'spacewalk',

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -22,6 +22,7 @@ import { TrustedBy } from '../../sections/TrustedBy';
 import { WhyVortex } from '../../sections/WhyVortex';
 
 import {
+  getEnumKeyByStringValue,
   getInputTokenDetailsOrDefault,
   getOutputTokenDetails,
   INPUT_TOKEN_CONFIG,
@@ -385,12 +386,15 @@ export const SwapPage = () => {
           assetSymbol: value.assetSymbol,
           assetIcon: value.networkAssetIcon,
         }))
-      : Object.entries(OUTPUT_TOKEN_CONFIG).map(([key, value]) => ({
-          type: OutputTokenType[key as keyof typeof OutputTokenType],
-          assetSymbol: value.fiat.symbol,
-          assetIcon: value.fiat.assetIcon,
-          name: value.fiat.name,
-        }));
+      : Object.entries(OUTPUT_TOKEN_CONFIG).map(([key, value]) => {
+          const tokenType = getEnumKeyByStringValue(OutputTokenType, key);
+          return {
+            type: tokenType!,
+            assetSymbol: value.fiat.symbol,
+            assetIcon: value.fiat.assetIcon,
+            name: value.fiat.name,
+          };
+        });
 
   const modals = (
     <>


### PR DESCRIPTION
### Context
Replace polling of webhooks from the cache service, and fetch directly the events from BRLA API. 

Now, each time a user tries to fetch a status, we first query the last events from BRLA and return the last one, if relevant to the user's query.

### Additional changes
Small fix for bug that prevents output token selection. 