### PR TITLE
Support Safe Wallet

### DIFF
--- a/src/contexts/network.tsx
+++ b/src/contexts/network.tsx
@@ -76,7 +76,7 @@ export const NetworkProvider = ({ children }: NetworkProviderProps) => {
   }, [setSelectedNetwork]);
 
   return (
-    <NetworkContext.Provider
+    <NetworkContext
       value={{
         walletConnectPolkadotSelectedNetworkId: WALLETCONNECT_ASSETHUB_ID,
         selectedNetwork,
@@ -86,7 +86,7 @@ export const NetworkProvider = ({ children }: NetworkProviderProps) => {
       }}
     >
       {children}
-    </NetworkContext.Provider>
+    </NetworkContext>
   );
 };
 

--- a/src/helpers/safe-wallet/isTransactionSafeWallet.test.ts
+++ b/src/helpers/safe-wallet/isTransactionSafeWallet.test.ts
@@ -1,0 +1,23 @@
+import { Hash } from 'viem';
+import { isTransactionHashSafeWallet } from './isTransactionSafeWallet';
+
+const safeWalletHash = '0xB12C0147eA9e2699D36d6666A5dce3f6be4e46e5' as Hash;
+const polygonHash = '0x29ee0aab2b60bd28d81c28d4c1d9e22434f6f8a89ecce52025076a6e78e17b6c' as Hash;
+const polygonChainId = 137;
+
+describe('isTransactionHashSafeWallet (querying safe wallet api and polygon chain)', () => {
+  it.skip('should identify regular Polygon transaction', async () => {
+    const result = await isTransactionHashSafeWallet(polygonHash, polygonChainId);
+    expect(result).toBe(false);
+  });
+
+  it.skip('should identify Safe wallet transaction', async () => {
+    const result = await isTransactionHashSafeWallet(safeWalletHash, polygonChainId);
+    expect(result).toBe(true);
+  });
+
+  it.skip('should handle invalid transaction hash', async () => {
+    const invalidHash = '0x1234' as Hash;
+    await expect(isTransactionHashSafeWallet(invalidHash, polygonChainId)).rejects.toBeTruthy();
+  });
+});

--- a/src/helpers/safe-wallet/isTransactionSafeWallet.ts
+++ b/src/helpers/safe-wallet/isTransactionSafeWallet.ts
@@ -1,7 +1,10 @@
+import SafeApiKit from '@safe-global/api-kit';
 import { getTransaction } from '@wagmi/core';
 import { Hash } from 'viem';
 
 import { wagmiConfig } from '../../wagmiConfig';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Determines if a transaction hash belongs to a Safe Wallet transaction or a regular Ethereum transaction.
@@ -10,26 +13,43 @@ import { wagmiConfig } from '../../wagmiConfig';
  * When querying the blockchain for a Safe transaction hash, it will return null since that hash only exists
  * in Safe's system until the transaction is executed.
  *
- * [!] When SAFE Wallet account has only 1 signer required it works as regular EOA and returns regular Ethereum transaction.
+ * The function first attempts to find the transaction on the blockchain. If found, it's considered a regular
+ * Ethereum transaction. If not found, it checks the Safe API to determine if it's a Safe Wallet transaction.
  *
- * @param hash - The transaction hash to check. Can be either:
- *              - A regular Ethereum transaction hash
- *              - A Safe transaction hash (safeTxHash) from Safe Wallet
+ * Note: When a Safe Wallet has only 1 signer required, it behaves like a regular EOA (Externally Owned Account)
+ * and will produce regular Ethereum transactions.
+ *
+ * @param hash - The transaction hash to check
+ * @param chainId - The chain ID of the network to check
  * @returns true if this is a Safe Wallet transaction, false if it's a regular Ethereum transaction
  */
-
-export async function isTransactionHashSafeWallet(hash: Hash) {
+export async function isTransactionHashSafeWallet(hash: Hash, chainId: number) {
   try {
     // Try to find the transaction on the blockchain
     // If found, it's a regular Ethereum transaction
-    // If not found or throws error, it must be a Safe Wallet transaction that hasn't been executed yet
-    const tx = await getTransaction(wagmiConfig, { hash });
+    // If not found it throws an error, it might be a Safe Wallet transaction that hasn't been executed yet
+    await getTransaction(wagmiConfig, { hash });
 
-    // Return true for Safe Wallet transactions (not found on chain)
-    // Return false for regular Ethereum transactions (found on chain)
-    return !tx;
+    // Transaction found on chain, so it's a regular Ethereum transaction
+    // Note: If a transaction isn't found, it could be a Safe transaction or just not indexed by the node yet
+    return false;
   } catch (error) {
-    // If getTransaction throws an error, assume it's a Safe transaction
-    return true;
+    // Transaction not found on chain, check if it's a Safe Wallet transaction
+    const safeApiKit = new SafeApiKit({
+      chainId: BigInt(chainId),
+    });
+
+    const safeWalletTx = await safeApiKit.getSafeInfo(hash);
+
+    // If we found information in the Safe API, it's a Safe Wallet transaction
+    if (safeWalletTx) {
+      return true;
+    }
+
+    // Wait for 1 second before retrying to help the node index the transaction
+    await delay(1000);
+
+    // Retry, maybe the node we're querying now has the transaction indexed
+    return isTransactionHashSafeWallet(hash, chainId);
   }
 }

--- a/src/helpers/safe-wallet/waitForTransactionConfirmation.ts
+++ b/src/helpers/safe-wallet/waitForTransactionConfirmation.ts
@@ -14,8 +14,8 @@ import { useSafeWalletSignatureStore } from '../../stores/safeWalletSignaturesSt
  * @param hash - The transaction hash to monitor
  * @returns A promise that resolves to the final transaction hash
  */
-export async function waitForTransactionConfirmation(hash: Hash): Promise<Hash> {
-  const isSafeWalletTransaction = await isTransactionHashSafeWallet(hash);
+export async function waitForTransactionConfirmation(hash: Hash, chainId: number): Promise<Hash> {
+  const isSafeWalletTransaction = await isTransactionHashSafeWallet(hash, chainId);
 
   if (isSafeWalletTransaction) {
     // Wait for all required signatures via Safe API

--- a/src/hooks/offramp/useSEP24/useAnchorWindowHandler.ts
+++ b/src/hooks/offramp/useSEP24/useAnchorWindowHandler.ts
@@ -13,6 +13,7 @@ import { usePendulumNode } from '../../../contexts/polkadotNode';
 import { useOfframpActions, useOfframpExecutionInput } from '../../../stores/offrampStore';
 import { useSep24Actions, useSep24InitialResponse, useSep24AnchorSessionParams } from '../../../stores/sep24Store';
 import { useVortexAccount } from '../../useVortexAccount';
+import { useChainId } from 'wagmi';
 
 const handleAmountMismatch = (setOfframpingStarted: (started: boolean) => void): void => {
   setOfframpingStarted(false);
@@ -30,6 +31,7 @@ export const useAnchorWindowHandler = () => {
   const { apiComponents: pendulumNode } = usePendulumNode();
   const { setOfframpStarted, updateOfframpHookStateFromState } = useOfframpActions();
   const { address } = useVortexAccount();
+  const selectedNetworkId = useChainId();
 
   const firstSep24Response = useSep24InitialResponse();
   const anchorSessionParams = useSep24AnchorSessionParams();
@@ -62,6 +64,10 @@ export const useAnchorWindowHandler = () => {
         throw new Error('Missing stellarEphemeralSecret on executionInput');
       }
 
+      if (!address) {
+        throw new Error('Missing address');
+      }
+
       const initialState = await constructInitialState({
         sep24Id: firstSep24Response.id,
         stellarEphemeralSecret: executionInput.stellarEphemeralSecret,
@@ -71,8 +77,9 @@ export const useAnchorWindowHandler = () => {
         amountOut: Big(executionInput.outputAmountUnits.beforeFees),
         sepResult: secondSep24Response,
         network: selectedNetwork,
+        networkId: selectedNetworkId,
         pendulumNode,
-        offramperAddress: address!,
+        offramperAddress: address,
       });
 
       trackKYCCompleted(initialState, selectedNetwork);
@@ -88,6 +95,7 @@ export const useAnchorWindowHandler = () => {
     trackKYCStarted,
     selectedNetwork,
     cleanupSep24State,
+    selectedNetworkId,
     address,
     trackKYCCompleted,
     updateOfframpHookStateFromState,

--- a/src/services/offrampingFlow.ts
+++ b/src/services/offrampingFlow.ts
@@ -86,6 +86,7 @@ export interface InitiateStateArguments {
   amountOut: Big;
   sepResult: SepResult;
   network: Networks;
+  networkId: number;
   pendulumNode: ApiComponents;
   offramperAddress: string;
 }
@@ -96,6 +97,7 @@ export interface BrlaInitiateStateArguments {
   amountIn: string;
   amountOut: Big;
   network: Networks;
+  networkId: number;
   pendulumNode: ApiComponents;
   offramperAddress: string;
   brlaEvmAddress: string;
@@ -125,6 +127,7 @@ export interface BaseOfframpingState {
   createdAt: number;
   failureTimeoutAt: number;
   network: Networks;
+  networkId: number;
   offramperAddress: string;
 }
 
@@ -233,6 +236,7 @@ async function constructBaseInitialState({
   amountIn,
   amountOut,
   network,
+  networkId,
   pendulumNode,
   offramperAddress,
 }: {
@@ -241,6 +245,7 @@ async function constructBaseInitialState({
   amountIn: string;
   amountOut: Big;
   network: Networks;
+  networkId: number;
   pendulumNode: ApiComponents;
   offramperAddress: string;
 }): Promise<BaseOfframpingState> {
@@ -289,6 +294,7 @@ async function constructBaseInitialState({
     createdAt: now,
     failureTimeoutAt: now + minutesInMs(10),
     network,
+    networkId,
     pendulumEphemeralAddress,
     offramperAddress,
   };
@@ -303,6 +309,7 @@ export async function constructInitialState({
   amountOut,
   sepResult,
   network,
+  networkId,
   pendulumNode,
   offramperAddress,
 }: InitiateStateArguments) {
@@ -312,6 +319,7 @@ export async function constructInitialState({
     amountIn,
     amountOut,
     network,
+    networkId,
     pendulumNode,
     offramperAddress,
   });
@@ -334,6 +342,7 @@ export async function constructBrlaInitialState({
   amountIn,
   amountOut,
   network,
+  networkId,
   offramperAddress,
   brlaEvmAddress,
   pixDestination,
@@ -346,6 +355,7 @@ export async function constructBrlaInitialState({
     amountIn,
     amountOut,
     network,
+    networkId,
     offramperAddress,
     pendulumNode,
   });

--- a/src/services/phases/squidrouter/process.ts
+++ b/src/services/phases/squidrouter/process.ts
@@ -122,13 +122,13 @@ export async function squidRouter(
 
     const approvalHash = await handleTokenApproval(inputToken, transactionRequest, state, wagmiConfig, trackEvent);
 
-    const confirmedApprovalHash = await waitForTransactionConfirmation(approvalHash);
+    const confirmedApprovalHash = await waitForTransactionConfirmation(approvalHash, state.networkId);
 
     setOfframpSigningPhase?.('approved');
 
     const swapHash = await handleSwapTransaction(transactionRequest, wagmiConfig, trackEvent);
 
-    const confirmedSwapHash = await waitForTransactionConfirmation(swapHash);
+    const confirmedSwapHash = await waitForTransactionConfirmation(swapHash, state.networkId);
 
     setOfframpSigningPhase?.('signed');
 


### PR DESCRIPTION
PR is READY 🟢
---
Refactored `isTransactionSafeWallet`
Previously false negatives were produced when we queried the blockchain node and the node hadn't managed to index the transaction hash yet and threw an error indicating it was a safe wallet transaction but it was a blockchain transaction.

Now the `isTransactionSafeWallet`
1. Checks if the transaction is indexed in the blockchain
2.a if is found in the blockchain -> returns `false`
2.b if is not found in the blockchain
3. Query the Safe Wallet API in order to find Safe Wallet transaction
4. If a safe wallet transaction is found -> returns `true`
5. If safe wallet transaction is not found -> delay 1 second and recursively call the `isTransactionSafeWallet` function