### PR TITLE
Rename text usages of tax ID to CPF

### DIFF
--- a/src/components/BrlaComponents/BrlaSwapFields/index.tsx
+++ b/src/components/BrlaComponents/BrlaSwapFields/index.tsx
@@ -43,7 +43,7 @@ export const BrlaSwapFields: FC<BrlaSwapFieldsProps> = ({ toToken }) => (
           />
         ))}
         <div className="mt-2">
-          CPF and Pix key need to belong to the <b>same person</b>.
+          CPF and PIX key need to belong to the <b>same person</b>.
         </div>
       </motion.div>
     )}

--- a/src/components/BrlaComponents/BrlaSwapFields/index.tsx
+++ b/src/components/BrlaComponents/BrlaSwapFields/index.tsx
@@ -16,8 +16,8 @@ const containerAnimation: MotionProps = {
 };
 
 const STANDARD_FIELDS = [
-  { id: StandardBrlaFieldOptions.TAX_ID, label: 'Tax ID', index: 0 },
-  { id: StandardBrlaFieldOptions.PIX_ID, label: 'Pix Key', index: 1 },
+  { id: StandardBrlaFieldOptions.TAX_ID, label: 'CPF', index: 0 },
+  { id: StandardBrlaFieldOptions.PIX_ID, label: 'PIX key', index: 1 },
 ];
 
 /**
@@ -43,7 +43,7 @@ export const BrlaSwapFields: FC<BrlaSwapFieldsProps> = ({ toToken }) => (
           />
         ))}
         <div className="mt-2">
-          Tax ID and Pix key need to belong to the <b>same person</b>.
+          CPF and Pix key need to belong to the <b>same person</b>.
         </div>
       </motion.div>
     )}

--- a/src/components/Nabla/schema.tsx
+++ b/src/components/Nabla/schema.tsx
@@ -39,15 +39,15 @@ const schema = Yup.object<SwapFormValues>().shape({
   deadline: Yup.number().nullable().transform(transformNumber),
   taxId: Yup.string().when('to', {
     is: 'brl',
-    then: (schema) => schema.matches(cpfRegex, 'Invalid Tax ID').required('Tax ID is required when transferring BRL'),
+    then: (schema) => schema.matches(cpfRegex, 'Invalid CPF').required('CPF is required when transferring BRL'),
     otherwise: (schema) => schema.optional(),
   }),
   pixId: Yup.string().when('to', {
     is: 'brl',
     then: (schema) =>
       schema
-        .required('Pix key is required when transferring BRL')
-        .test('matches-one', 'Pix key does not match any of the valid formats', (value) => {
+        .required('PIX key is required when transferring BRL')
+        .test('matches-one', 'PIX key does not match any of the valid formats', (value) => {
           if (!value) return false;
           return pixKeyRegex.some((regex) => regex.test(value));
         }),

--- a/src/hooks/brla/useBRLAKYCProcess/index.tsx
+++ b/src/hooks/brla/useBRLAKYCProcess/index.tsx
@@ -82,7 +82,7 @@ export function useKYCProcess() {
   const handleFormSubmit = useCallback(
     async (formData: KYCFormData) => {
       if (!taxId) {
-        throw new Error('useKYCProcess: Tax ID must be defined at this point');
+        throw new Error('useKYCProcess: CPF must be defined at this point');
       }
       resetToDefault();
       setIsSubmitted(true);


### PR DESCRIPTION
Rename mentions of tax ID to CPF to make it clearer for Brazilian citizens. Also capitalize Pix to PIX. 