### PR TITLE
Send custom error logs to sentry

### DIFF
--- a/src/hooks/useVortexAccount.ts
+++ b/src/hooks/useVortexAccount.ts
@@ -1,9 +1,9 @@
-import { useNetwork } from '../contexts/network';
-import { useMemo, useCallback } from 'react';
-import { usePolkadotWalletState } from '../contexts/polkadotWallet';
-import { useAccount } from 'wagmi';
+import { useAccount, useSignMessage } from 'wagmi';
+import { useMemo, useCallback, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 import { Signer } from '@polkadot/types/types';
-import { useSignMessage } from 'wagmi';
+import { useNetwork } from '../contexts/network';
+import { usePolkadotWalletState } from '../contexts/polkadotWallet';
 import { isNetworkEVM, ASSETHUB_CHAIN_ID } from '../helpers/networks';
 
 // A helper hook to provide an abstraction over the account used.
@@ -22,6 +22,17 @@ export const useVortexAccount = () => {
       return evmAccountAddress;
     }
   }, [evmAccountAddress, polkadotWalletAccount, selectedNetwork]);
+
+  useEffect(() => {
+    const user = Sentry.getCurrentScope().getUser();
+    // Set the wallet address in Sentry user context
+    if (address) {
+      Sentry.setUser({
+        ...user,
+        wallet: address,
+      });
+    }
+  }, [address]);
 
   const isDisconnected = useMemo(() => {
     if (isNetworkEVM(selectedNetwork)) {

--- a/src/pages/failure/index.tsx
+++ b/src/pages/failure/index.tsx
@@ -1,3 +1,6 @@
+import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { TransactionInfo } from '../../components/TransactionInfo';
 import { Box } from '../../components/Box';
@@ -5,7 +8,7 @@ import { BaseLayout } from '../../layouts';
 import { EmailForm } from '../../components/EmailForm';
 import { FailureType } from '../../services/offrampingFlow';
 import { config } from '../../config';
-import { useTranslation } from 'react-i18next';
+import { useVortexAccount } from '../../hooks/useVortexAccount';
 
 const Cross = () => (
   <div className="flex items-center justify-center w-20 h-20 border-2 border-red-500 rounded-full">
@@ -22,6 +25,19 @@ interface FailurePageProps {
 
 export const FailurePage = ({ finishOfframping, continueFailedFlow, transactionId, failure }: FailurePageProps) => {
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (failure.type === 'recoverable') {
+      Sentry.captureMessage(`Entered failure page with recoverable error: ${failure.message}`, {
+        level: 'warning',
+      });
+    } else {
+      Sentry.captureMessage(`Entered failure page with unrecoverable error: ${failure.message}`, {
+        level: 'error',
+      });
+    }
+  }, []);
+
   const main = (
     <main>
       <Box className="flex flex-col items-center justify-center mx-auto mt-12">

--- a/src/pages/failure/index.tsx
+++ b/src/pages/failure/index.tsx
@@ -8,7 +8,6 @@ import { BaseLayout } from '../../layouts';
 import { EmailForm } from '../../components/EmailForm';
 import { FailureType } from '../../services/offrampingFlow';
 import { config } from '../../config';
-import { useVortexAccount } from '../../hooks/useVortexAccount';
 
 const Cross = () => (
   <div className="flex items-center justify-center w-20 h-20 border-2 border-red-500 rounded-full">

--- a/src/pages/swap/index.tsx
+++ b/src/pages/swap/index.tsx
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+import * as Sentry from '@sentry/react';
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { ApiPromise } from '@polkadot/api';
 import { useTranslation } from 'react-i18next';
@@ -119,6 +120,7 @@ export const SwapPage = () => {
   const setInitializeFailed = useCallback(
     (message?: string | null) => {
       setInitializeFailedMessage(message ?? t('pages.swap.error.initializeFailed.default'));
+      Sentry.captureMessage(`App initialization failed: ${message}`);
     },
     [t],
   );


### PR DESCRIPTION
- [x] Add the user's wallet address to the Sentry's `user` if available
- [x] Log the failure reason when entering the failure page. I decided to add this as part of a `useEffect` to the failure page component instead of adding it somewhere into the flow because IMO it's easy to read this way and easy to catch both failure reasons only once. 

Closes #515. 