### PR TITLE
Fix two wrong i18n keys

### DIFF
--- a/src/components/PolkadotWalletSelectorDialog/PolkadotWalletSelectorDialogLoading/index.tsx
+++ b/src/components/PolkadotWalletSelectorDialog/PolkadotWalletSelectorDialogLoading/index.tsx
@@ -10,9 +10,9 @@ export const PolkadotWalletSelectorDialogLoading = ({ selectedWallet }: Polkadot
   return (
     <article className="flex flex-col items-center justify-center">
       <span className="loading loading-dots loading-lg"></span>
-      <h1 className="text-2xl">{t('components.polkadotWalletSelectorDialogLoading.title')}</h1>
+      <h1 className="text-2xl">{t('components.dialogs.polkadotWalletSelectorDialogLoading.title')}</h1>
       <p className="mt-2.5 w-52 text-center text-sm">
-        {t('components.polkadotWalletSelectorDialogLoading.description', { selectedWallet })}
+        {t('components.dialogs.polkadotWalletSelectorDialogLoading.description', { selectedWallet })}
       </p>
     </article>
   );


### PR DESCRIPTION
Fixes wrong references to i18n strings for the polkadot wallet selector.