### PR TITLE
Show substrate account with ss58 format and show destination in onramp summary

### DIFF
--- a/frontend/src/components/AccountCard/index.tsx
+++ b/frontend/src/components/AccountCard/index.tsx
@@ -1,6 +1,8 @@
 import { WalletAccount } from '@talismn/connect-wallets';
 import { trimAddress } from '../../helpers/addressFormatter';
 import { usePolkadotWalletState } from '../../contexts/polkadotWallet';
+import { useAssetHubNode } from '../../contexts/polkadotNode';
+import { getAddressForFormat } from 'shared';
 
 interface AccountProps {
   account: WalletAccount;
@@ -8,16 +10,20 @@ interface AccountProps {
 
 export const AccountCard = ({ account }: AccountProps) => {
   const { setWalletAccount } = usePolkadotWalletState();
+  const { apiComponents } = useAssetHubNode();
+
+  const ss58Format = apiComponents ? apiComponents.ss58Format : 42;
+  const addressForNetwork = getAddressForFormat(account.address, ss58Format);
 
   return (
     <li className="w-full">
       <button
-        aria-label={`Select ${account.address}`}
+        aria-label={`Select ${addressForNetwork}`}
         className="flex w-full cursor-pointer items-center rounded border-l-2 border-transparent p-1.5 hover:border-primary hover:bg-base-100"
         onClick={() => setWalletAccount(account)}
       >
         <p className="ml-2.5">
-          {account.name} | {trimAddress(account.address)}
+          {account.name} | {trimAddress(addressForNetwork)}
         </p>
       </button>
     </li>

--- a/frontend/src/components/RampSummaryDialog/FeeDetails.tsx
+++ b/frontend/src/components/RampSummaryDialog/FeeDetails.tsx
@@ -15,6 +15,7 @@ interface FeeDetailsProps {
   toToken: OnChainTokenDetails | FiatTokenDetails;
   partnerUrl: string;
   direction: RampDirection;
+  destinationAddress?: string;
 }
 
 export const FeeDetails: FC<FeeDetailsProps> = ({
@@ -26,6 +27,7 @@ export const FeeDetails: FC<FeeDetailsProps> = ({
   exchangeRate,
   partnerUrl,
   direction,
+  destinationAddress,
 }) => {
   const { t } = useTranslation();
 
@@ -63,6 +65,12 @@ export const FeeDetails: FC<FeeDetailsProps> = ({
           />
         </p>
       </div>
+      {destinationAddress && (
+        <div className="flex justify-between mb-2">
+          <p>{t('components.dialogs.RampSummaryDialog.destination')}</p>
+          {destinationAddress}
+        </div>
+      )}
       <div className="flex justify-between">
         <p>{t('components.dialogs.RampSummaryDialog.partner')}</p>
         <a href={partnerUrl} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">

--- a/frontend/src/components/RampSummaryDialog/TransactionTokensDisplay.tsx
+++ b/frontend/src/components/RampSummaryDialog/TransactionTokensDisplay.tsx
@@ -1,15 +1,16 @@
-import { FC, useState, useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Big from 'big.js';
 import { ArrowDownIcon } from '@heroicons/react/20/solid';
 import {
-  getOnChainTokenDetailsOrDefault,
-  getAnyFiatTokenDetails,
-  OnChainTokenDetails,
   BaseFiatTokenDetails,
-  isStellarOutputTokenDetails,
   FiatTokenDetails,
+  getAddressForFormat,
+  getAnyFiatTokenDetails,
+  getOnChainTokenDetailsOrDefault,
+  isStellarOutputTokenDetails,
   Networks,
+  OnChainTokenDetails,
 } from 'shared';
 import { useGetAssetIcon } from '../../hooks/useGetAssetIcon';
 import { useRampState } from '../../stores/rampStore';
@@ -19,6 +20,9 @@ import { useRampSummaryActions } from '../../stores/rampSummary';
 import { AssetDisplay } from './AssetDisplay';
 import { FeeDetails } from './FeeDetails';
 import { BRLOnrampDetails } from './BRLOnrampDetails';
+import { useAssetHubNode } from '../../contexts/polkadotNode';
+import { trimAddress } from '../../helpers/addressFormatter';
+import { useVortexAccount } from '../../hooks/useVortexAccount';
 
 // Define onramp expiry time in minutes. This is not arbitrary, but based on the assumptions imposed by the backend.
 const ONRAMP_EXPIRY_MINUTES = 5;
@@ -38,6 +42,9 @@ export const TransactionTokensDisplay: FC<TransactionTokensDisplayProps> = ({
 }) => {
   const { t } = useTranslation();
   const rampState = useRampState();
+  const { apiComponents } = useAssetHubNode();
+  const { address, chainId } = useVortexAccount();
+
   const [timeLeft, setTimeLeft] = useState({ minutes: ONRAMP_EXPIRY_MINUTES, seconds: 0 });
   const [targetTimestamp, setTargetTimestamp] = useState<number | null>(null);
   const { setIsQuoteExpired } = useRampSummaryActions();
@@ -113,6 +120,12 @@ export const TransactionTokensDisplay: FC<TransactionTokensDisplayProps> = ({
     ? (fromToken as BaseFiatTokenDetails).fiat.symbol
     : (toToken as BaseFiatTokenDetails).fiat.symbol;
 
+  const destinationAddress = isOnramp
+    ? chainId && chainId > 0
+      ? trimAddress(address || '')
+      : trimAddress(getAddressForFormat(address || '', apiComponents ? apiComponents.ss58Format : 42))
+    : undefined;
+
   return (
     <div className="flex flex-col justify-center">
       <AssetDisplay
@@ -143,6 +156,7 @@ export const TransactionTokensDisplay: FC<TransactionTokensDisplayProps> = ({
         network={selectedNetwork}
         feesCost={executionInput.quote.fee}
         direction={rampDirection}
+        destinationAddress={destinationAddress}
       />
       <BRLOnrampDetails />
       {targetTimestamp !== null && (

--- a/frontend/src/components/buttons/PolkadotWalletButton/PolkadotDisconnectWallet/index.tsx
+++ b/frontend/src/components/buttons/PolkadotWalletButton/PolkadotDisconnectWallet/index.tsx
@@ -7,18 +7,18 @@ import accountBalanceWalletIconPink from '../../../../assets/account-balance-wal
 import { trimAddress } from '../../../../helpers/addressFormatter';
 import { CopyablePublicKey } from '../../../PublicKey/CopyablePublicKey';
 import { usePolkadotWalletState } from '../../../../contexts/polkadotWallet';
+import { useAssetHubNode } from '../../../../contexts/polkadotNode';
+import { getAddressForFormat } from 'shared';
+
 interface WalletButtonProps {
-  wallet?: Wallet;
-  balance?: string;
-  tokenSymbol?: string;
-  walletAccount?: WalletAccount;
+  address: string;
 }
 
-const WalletButton = ({ walletAccount }: WalletButtonProps) => (
+const WalletButton = ({ address }: WalletButtonProps) => (
   <button type="button" className="btn-vortex-secondary btn rounded-3xl group">
     <img src={accountBalanceWalletIcon} className="block group-hover:hidden" alt="wallet account button" />
     <img src={accountBalanceWalletIconPink} className="hidden group-hover:block" alt="wallet account button hovered" />
-    <p className="hidden font-thin md:block ">{walletAccount ? trimAddress(walletAccount.address) : ''}</p>
+    <p className="hidden font-thin md:block ">{trimAddress(address)}</p>
   </button>
 );
 
@@ -51,16 +51,20 @@ const WalletDropdownMenu = ({ walletAccount, address, removeWalletAccount }: Wal
 
 export const DisconnectModal = () => {
   const { walletAccount, removeWalletAccount } = usePolkadotWalletState();
-  const { wallet, address } = walletAccount || {};
+  const { apiComponents } = useAssetHubNode();
+  const { address } = walletAccount || {};
 
   if (!address) return <></>;
+
+  const ss58Format = apiComponents ? apiComponents.ss58Format : 42;
+  const addressForNetwork = getAddressForFormat(address, ss58Format);
 
   return (
     <div className="dropdown dropdown-bottom" role="listbox">
       <label tabIndex={0}>
-        <WalletButton wallet={wallet} balance={'0'} tokenSymbol={'$'} walletAccount={walletAccount} />
+        <WalletButton address={addressForNetwork} />
       </label>
-      <WalletDropdownMenu walletAccount={walletAccount} address={address} removeWalletAccount={removeWalletAccount} />
+      <WalletDropdownMenu walletAccount={walletAccount} address={addressForNetwork} removeWalletAccount={removeWalletAccount} />
     </div>
   );
 };

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -215,6 +215,7 @@
         "continue": "Continue",
         "quote": "Quote",
         "partner": "Partner",
+        "destination": "Destination Account",
         "confirm": "Confirm"
       },
       "selectionModal": {

--- a/frontend/src/translations/pt.json
+++ b/frontend/src/translations/pt.json
@@ -215,6 +215,7 @@
         "continue": "Continuar",
         "quote": "Cotação",
         "partner": "Parceiro",
+        "destination": "Conta de destino",
         "confirm": "Confirmar"
       },
       "selectionModal": {


### PR DESCRIPTION
Adds changes to show the substrate account always in the format of the network. Since we only support Assethub at the moment, we are always using the ss58 format of Assethub.

Also adds the destination address to the onramp summary dialog.