### PR TITLE
Add condition to cleanup previous lock

### DIFF
--- a/frontend/src/hooks/offramp/useRampService/useRegisterRamp.ts
+++ b/frontend/src/hooks/offramp/useRampService/useRegisterRamp.ts
@@ -112,6 +112,13 @@ export const useRegisterRamp = () => {
     // Check if we can proceed with the registration process
     const lockResult = checkLock();
     if (!lockResult.canProceed) {
+      // Alternatively release locks if process was cancelled
+      // This will NOT clean the localStorage right after the process is cancelled
+      // but rather on the first checkLock() call after confirmation.
+      if (!rampStarted){
+        releaseSigningLock();
+        releaseLock();
+      }
       return;
     }
 


### PR DESCRIPTION
Fixes bug that prevented signature prompt after a previous cancelled ramp.

The cause is a persistent `rampStartKey` that stays even when the user has closed the ramp modal and cancelled the process.