### PR TITLE
Phase handlers improvements

### DIFF
--- a/api/src/api/services/moonbeam/balance.ts
+++ b/api/src/api/services/moonbeam/balance.ts
@@ -10,19 +10,20 @@ import { createMoonbeamClientsAndConfig } from './createServices';
 import logger from '../../../config/logger';
 import { Networks } from 'shared';
 
-export function checkMoonbeamBalancePeriodically(
+export function checkEvmBalancePeriodically(
   tokenAddress: string,
   brlaEvmAddress: string,
   amountDesiredRaw: string,
   intervalMs: number,
   timeoutMs: number,
+  chain: any
 ) {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
     const intervalId = setInterval(async () => {
       try {
         const publicClient = createPublicClient({
-          chain: moonbeam,
+          chain,
           transport: http(),
         });
 

--- a/api/src/api/services/pendulum/apiManager.ts
+++ b/api/src/api/services/pendulum/apiManager.ts
@@ -190,15 +190,19 @@ export class ApiManager {
       return new Promise((resolve, reject) => {
         call.signAndSend(senderKeypair, { nonce }, (submissionResult: ISubmittableResult) => {
           const { status, events, dispatchError } = submissionResult;
-          if (status.isFinalized) {
+
+          if (dispatchError) {
+            reject(new Error(`Transaction failed: ${dispatchError}`));
+          }
+
+          if (submissionResult.isError){
+            reject(new Error(`Transaction was not included: ${submissionResult.dispatchError}`));
+          }
+
+          if (submissionResult.isFinalized){
             const hash = status.asFinalized.toString();
-            
-            if (dispatchError) {
-              reject(new Error(`Transaction failed: ${dispatchError}`));
-            } else {
-              resolve({hash});
-            }
-          } 
+            resolve({hash})
+          }
         });
       });
     } catch (initialError: any) {
@@ -214,15 +218,19 @@ export class ApiManager {
           return new Promise((resolve, reject) => {
             call.signAndSend(senderKeypair, { nonce }, (submissionResult: ISubmittableResult) => {
               const { status, events, dispatchError } = submissionResult;
-              if (status.isFinalized) {
-                const hash = status.asFinalized.toString();
 
-                if (dispatchError) {
-                  reject(new Error(`Transaction failed: ${dispatchError}`));
-                } else {
-                  resolve({hash});
-                }
-              } 
+              if (dispatchError) {
+                reject(new Error(`Transaction failed: ${dispatchError}`));
+              }
+
+              if (submissionResult.isError){
+                reject(new Error(`Transaction was not included: ${submissionResult.dispatchError}`));
+              }
+
+              if (submissionResult.isFinalized){
+                const hash = status.asFinalized.toString();
+                resolve({hash})
+              }
             });
           });
         } catch (retryError) {

--- a/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
+++ b/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
@@ -5,8 +5,9 @@ import RampState from '../../../../models/rampState.model';
 import { StateMetadata } from '../meta-state-types';
 import { BasePhaseHandler } from '../base-phase-handler';
 import { BrlaApiService } from '../../brla/brlaApiService';
-import { checkMoonbeamBalancePeriodically } from '../../moonbeam/balance';
+import { checkEvmBalancePeriodically } from '../../moonbeam/balance';
 import logger from '../../../../config/logger';
+import { polygon } from 'viem/chains';
 
 export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
   public getPhaseName(): RampPhase {
@@ -38,12 +39,13 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
     const maxWaitingTimeMs = 5 * 60 * 1000; // 5 minutes
 
     try {
-      await checkMoonbeamBalancePeriodically(
+      await checkEvmBalancePeriodically(
         tokenDetails.polygonErc20Address,
         brlaEvmAddress,
         outputAmountBeforeFees.raw,
         pollingTimeMs,
         maxWaitingTimeMs,
+        polygon
       );
     } catch (balanceCheckError) {
       if (balanceCheckError instanceof Error) {

--- a/api/src/api/services/phases/handlers/brla-teleport-handler.ts
+++ b/api/src/api/services/phases/handlers/brla-teleport-handler.ts
@@ -5,9 +5,10 @@ import RampState from '../../../../models/rampState.model';
 import { StateMetadata } from '../meta-state-types';
 import { BasePhaseHandler } from '../base-phase-handler';
 import { BrlaApiService } from '../../brla/brlaApiService';
-import { checkMoonbeamBalancePeriodically } from '../../moonbeam/balance';
+import { checkEvmBalancePeriodically } from '../../moonbeam/balance';
 import { BrlaTeleportService } from '../../brla/brlaTeleportService';
 import logger from '../../../../config/logger';
+import { moonbeam } from 'viem/chains';
 
 export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
   public getPhaseName(): RampPhase {
@@ -51,12 +52,13 @@ export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
 
       const tokenDetails = getAnyFiatTokenDetailsMoonbeam(FiatToken.BRL);
 
-      await checkMoonbeamBalancePeriodically(
+      await checkEvmBalancePeriodically(
         tokenDetails.moonbeamErc20Address,
         moonbeamEphemeralAddress,
         inputAmountBeforeSwapRaw, // TODO verify this is okay, regarding decimals.
         pollingTimeMs,
         maxWaitingTimeMs,
+        moonbeam
       );
     } catch (balanceCheckError) {
       if (balanceCheckError instanceof Error) {


### PR DESCRIPTION


### Changes
- Adds a callback to the `executeApiCall` of `ApiManager` such that it does not resolves unless the transaction has been including into the block. 
- Waits for BRLA tokens to arrive on the polygon network instead of moonbeam, for the phase `BrlaPayoutOnMoonbeamPhase`.