### PR TITLE
Change landing to show buy and to usdt by default

### DIFF
--- a/frontend/src/hooks/ramp/useRampValidation.ts
+++ b/frontend/src/hooks/ramp/useRampValidation.ts
@@ -34,20 +34,7 @@ function validateOnramp(
     trackEvent: (event: TrackableEvent) => void;
   },
 ): string | null {
-  const maxAmountUnits = multiplyByPowerOfTen(Big(fromToken.maxWithdrawalAmountRaw), -fromToken.decimals);
   const minAmountUnits = multiplyByPowerOfTen(Big(fromToken.minWithdrawalAmountRaw), -fromToken.decimals);
-
-  if (inputAmount && maxAmountUnits.lt(inputAmount)) {
-    trackEvent({
-      event: 'form_error',
-      error_message: 'more_than_maximum_withdrawal',
-      input_amount: inputAmount ? inputAmount.toString() : '0',
-    });
-    return t('pages.swap.error.moreThanMaximumWithdrawal.buy', {
-      maxAmountUnits: stringifyBigWithSignificantDecimals(maxAmountUnits, 2),
-      assetSymbol: fromToken.fiat.symbol,
-    });
-  }
 
   if (inputAmount && !inputAmount.eq(0) && minAmountUnits.gt(inputAmount)) {
     trackEvent({

--- a/frontend/src/hooks/useRampUrlParams.ts
+++ b/frontend/src/hooks/useRampUrlParams.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { RampDirection } from '../components/RampToggle';
 import { AssetHubToken, EvmToken, FiatToken, Networks, OnChainToken } from 'shared';
-import { useRampDirectionToggle } from '../stores/rampDirectionStore';
+import { useRampDirection, useRampDirectionToggle } from '../stores/rampDirectionStore';
 import { useRampFormStoreActions } from '../stores/ramp/useRampFormStore';
 import { useNetwork } from '../contexts/network';
 
@@ -73,6 +73,7 @@ function getNetworkFromParam(param?: string): Networks | undefined {
 export const useRampUrlParams = (): RampUrlParams => {
   const params = useMemo(() => new URLSearchParams(window.location.search), []);
   const { selectedNetwork } = useNetwork();
+  const rampDirection = useRampDirection();
 
   const urlParams = useMemo(() => {
     const rampParam = params.get('ramp')?.toLowerCase();
@@ -81,7 +82,8 @@ export const useRampUrlParams = (): RampUrlParams => {
     const fromTokenParam = params.get('from')?.toLowerCase();
     const inputAmountParam = params.get('fromAmount');
 
-    const ramp = rampParam === 'buy' ? RampDirection.ONRAMP : RampDirection.OFFRAMP;
+    const ramp =
+      rampParam === undefined ? rampDirection : rampParam === 'buy' ? RampDirection.ONRAMP : RampDirection.OFFRAMP;
 
     const from =
       ramp === RampDirection.OFFRAMP
@@ -104,7 +106,7 @@ export const useRampUrlParams = (): RampUrlParams => {
       to,
       fromAmount: inputAmountParam || fromAmount || undefined,
     };
-  }, [params, selectedNetwork]);
+  }, [params, rampDirection, selectedNetwork]);
 
   return urlParams;
 };

--- a/frontend/src/stores/ramp/useRampFormStore.ts
+++ b/frontend/src/stores/ramp/useRampFormStore.ts
@@ -22,7 +22,7 @@ interface RampFormActions {
 
 export const DEFAULT_RAMP_FORM_STORE_VALUES: RampFormState = {
   inputAmount: '20',
-  onChainToken: EvmToken.USDC,
+  onChainToken: EvmToken.USDT,
   fiatToken: FiatToken.EURC,
   taxId: undefined,
   pixId: undefined,

--- a/frontend/src/stores/rampDirectionStore.ts
+++ b/frontend/src/stores/rampDirectionStore.ts
@@ -7,7 +7,7 @@ export interface RampDirectionStore {
 }
 
 export const useRampDirectionStore = create<RampDirectionStore>((set) => ({
-  activeDirection: RampDirection.OFFRAMP,
+  activeDirection: RampDirection.ONRAMP,
   onToggle: (direction: RampDirection) => set({ activeDirection: direction }),
 }));
 


### PR DESCRIPTION
- [x] Show 'buy' by default
- [x] Show USDT by default
- [x] Remove max amount check for onramps in form validation. BRLA doesn't have a fixed max amount. This is determined by the KYC level, so the simple check is not accurate anyway. I will follow up on this by bringing https://github.com/pendulum-chain/vortex/pull/533 up to speed. 