### PR TITLE
Add check for BRL ramping amount

### DIFF
--- a/api/src/api/routes/v1/brla.route.ts
+++ b/api/src/api/routes/v1/brla.route.ts
@@ -11,6 +11,8 @@ const router: Router = Router({ mergeParams: true });
 
 router.route('/getUser').get(brlaController.getBrlaUser);
 
+router.route('/getUserRemainingLimit').get(brlaController.getBrlaUserRemainingLimit);
+
 router.route('/getOfframpStatus').get(brlaController.getOfframpStatus);
 
 router.route('/getKycStatus').get(brlaController.fetchSubaccountKycStatus);

--- a/api/src/api/services/brla/brlaApiService.ts
+++ b/api/src/api/services/brla/brlaApiService.ts
@@ -9,7 +9,7 @@ import {
   FastQuoteQueryParams,
   FastQuoteResponse,
   SwapPayload,
-  OnchainLog,
+  OnchainLog, UsedLimitData,
 } from './types';
 import { Endpoint, EndpointMapping, Endpoints, Methods } from './mappings';
 import { Event } from './webhooks';
@@ -119,6 +119,11 @@ export class BrlaApiService {
     const query = `taxId=${encodeURIComponent(taxId)}`;
     const response = await this.sendRequest(Endpoint.Subaccounts, 'GET', query);
     return response.subaccounts[0];
+  }
+
+  public async getSubaccountUsedLimit(subaccountId: string): Promise<UsedLimitData | undefined> {
+    const query = `subaccountId=${encodeURIComponent(subaccountId)}`;
+    return await this.sendRequest('/used-limit', 'GET', query);
   }
 
   public async triggerOfframp(subaccountId: string, offrampParams: OfframpPayload): Promise<{ id: string }> {

--- a/api/src/api/services/brla/mappings.ts
+++ b/api/src/api/services/brla/mappings.ts
@@ -6,7 +6,7 @@ import {
   DepositLog,
   FastQuoteResponse,
   OnchainLog,
-  SwapPayload,
+  SwapPayload, UsedLimitData,
 } from './types';
 import { Event } from './webhooks';
 
@@ -14,6 +14,7 @@ export enum Endpoint {
   Subaccounts = '/subaccounts',
   PayOut = '/pay-out',
   BrCode = '/pay-in/br-code',
+  UsedLimit = '/used-limit',
   WebhookEvents = '/webhooks/events',
   PixInfo = '/pay-out/pix-info',
   PixHistory = '/pay-in/pix/history',
@@ -45,6 +46,20 @@ export interface EndpointMapping {
     GET: {
       body: undefined;
       response: undefined;
+    };
+    PATCH: {
+      body: undefined;
+      response: undefined;
+    };
+  };
+  [Endpoint.UsedLimit]: {
+    POST: {
+      body: undefined;
+      response: undefined;
+    };
+    GET: {
+      body: undefined;
+      response: UsedLimitData;
     };
     PATCH: {
       body: undefined;

--- a/api/src/api/services/brla/types.ts
+++ b/api/src/api/services/brla/types.ts
@@ -54,6 +54,15 @@ export interface RegisterSubaccountPayload {
   cnpj?: string;
 }
 
+export interface UsedLimitData {
+  limitMint: number;
+  limitBurn: number;
+  limitSwapBuy: number;
+  limitSwapSell: number;
+  limitBRLAOutOwnAccount: number;
+  limitBRLAOutThirdParty: number;
+}
+
 export interface OfframpPayload {
   pixKey: string;
   amount: number;
@@ -71,6 +80,7 @@ export interface PixKeyData {
   taxId: string;
   bankName: string;
 }
+
 // Interface response from /pay-in/pix/history
 export interface DepositLog {
   chain: string;

--- a/api/src/api/services/phases/handlers/brla-teleport-handler.ts
+++ b/api/src/api/services/phases/handlers/brla-teleport-handler.ts
@@ -60,6 +60,10 @@ export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
         maxWaitingTimeMs,
         moonbeam
       );
+
+      // Add delay to ensure the transaction is settled
+      await new Promise((resolve) => setTimeout(resolve, 12000)); // 12 seconds, 2 moonbeam blocks.
+      
     } catch (balanceCheckError) {
       if (balanceCheckError instanceof Error) {
         if (balanceCheckError.message === 'Balance did not meet the limit within the specified time') {

--- a/api/src/api/services/transactions/stellar/offrampTransaction.ts
+++ b/api/src/api/services/transactions/stellar/offrampTransaction.ts
@@ -34,7 +34,7 @@ export async function buildPaymentAndMergeTx({
 }> {
   const baseFee = STELLAR_BASE_FEE;
   const maxTime = Date.now() + 1000 * 60 * 10;
-  const NUMBER_OF_PRESIGNED_TXS = 3;
+  const NUMBER_OF_PRESIGNED_TXS = 5;
 
   if (!FUNDING_SECRET) {
     logger.error('Stellar funding secret not defined');

--- a/frontend/src/helpers/notifications.ts
+++ b/frontend/src/helpers/notifications.ts
@@ -3,6 +3,7 @@ import { ToastOptions, toast } from 'react-toastify';
 
 export enum ToastMessage {
   AMOUNT_MISMATCH = 'AMOUNT_MISMATCH',
+  RAMP_LIMIT_EXCEEDED = 'RAMP_LIMIT_EXCEEDED',
   KYC_COMPLETED = 'KYC_COMPLETED',
   KYC_VERIFICATION_FAILED = 'KYC_VERIFICATION_FAILED',
   SIGNING_FAILED = 'SIGNING_FAILED',
@@ -53,6 +54,13 @@ const toastConfig: Record<ToastMessage, { options: ToastOptions; translationKey:
       type: 'error',
     },
     translationKey: 'toasts.nodeConnectionError',
+  },
+  [ToastMessage.RAMP_LIMIT_EXCEEDED]: {
+    options: {
+      toastId: ToastMessage.RAMP_LIMIT_EXCEEDED,
+      type: 'error',
+    },
+    translationKey: 'toasts.rampLimitExceeded',
   },
   [ToastMessage.ERROR]: {
     options: {

--- a/frontend/src/hooks/ramp/useRampSubmission.ts
+++ b/frontend/src/hooks/ramp/useRampSubmission.ts
@@ -15,6 +15,7 @@ import { useRegisterRamp } from '../offramp/useRampService/useRegisterRamp';
 import { useRampDirection } from '../../stores/rampDirectionStore';
 import { RampDirection } from '../../components/RampToggle';
 import { useStartRamp } from '../offramp/useRampService/useStartRamp';
+import { usePreRampCheck } from '../../services/initialChecks';
 
 interface SubmissionError extends Error {
   code?: string;
@@ -37,6 +38,7 @@ export const useRampSubmission = () => {
   const rampDirection = useRampDirection();
   const { setRampExecutionInput, setRampInitiating, resetRampState } = useRampActions();
   const { registerRamp } = useRegisterRamp();
+  const preRampCheck = usePreRampCheck();
   useStartRamp(); // This will automatically start the ramp process when the conditions are met
 
   // @TODO: implement Error boundary
@@ -115,8 +117,10 @@ export const useRampSubmission = () => {
   const onRampConfirm = useCallback(async () => {
     if (executionPreparing) return;
     setExecutionPreparing(true);
+
     try {
       const executionInput = prepareExecutionInput();
+      await preRampCheck(executionInput);
       setRampExecutionInput(executionInput);
 
       await registerRamp(executionInput);
@@ -129,9 +133,10 @@ export const useRampSubmission = () => {
   }, [
     executionPreparing,
     prepareExecutionInput,
+    preRampCheck,
     setRampExecutionInput,
-    trackTransaction,
     registerRamp,
+    trackTransaction,
     handleSubmissionError,
   ]);
 

--- a/frontend/src/services/api/brla.service.ts
+++ b/frontend/src/services/api/brla.service.ts
@@ -69,6 +69,22 @@ export class BrlaService {
   }
 
   /**
+   * Get the remaining limit for a user
+   * @param taxId The user's tax ID
+   * @returns The remaining limit for onramp and offramp
+   */
+  static async getUserRemainingLimit(taxId: string): Promise<BrlaEndpoints.GetUserRemainingLimitResponse> {
+    return apiRequest<BrlaEndpoints.GetUserRemainingLimitResponse>(
+      'get',
+      `${this.BASE_PATH}/getUserRemainingLimit`,
+      undefined,
+      {
+        params: { taxId },
+      },
+    );
+  }
+
+  /**
    * Trigger an offramp operation
    * @param request The offramp request
    * @returns The offramp ID

--- a/frontend/src/services/initialChecks.ts
+++ b/frontend/src/services/initialChecks.ts
@@ -1,12 +1,68 @@
-import { fetchSigningServiceAccountId } from './signingService';
+import { RampExecutionInput } from '../types/phases';
+import { BrlaService } from './api';
+import { RampDirection } from '../components/RampToggle';
+import { useToastMessage } from '../helpers/notifications';
+import { useRampDirection } from '../stores/rampDirectionStore';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 
-export const initialChecks = async () => {
-  // test signing service
-  try {
-    // this function returns only if all services are active and funded
-    await fetchSigningServiceAccountId();
-  } catch (error) {
-    console.error('Initial check error: ', error);
-    throw new Error('Cannot start offramp process safely');
-  }
-};
+function useRampAmountWithinAllowedLimits() {
+  const { t } = useTranslation();
+  const { showToast, ToastMessage } = useToastMessage();
+
+  const rampDirection = useRampDirection();
+
+  return useCallback(
+    async (amountUnits: string, taxId: string): Promise<boolean> => {
+      try {
+        const remainingLimitResponse = await BrlaService.getUserRemainingLimit(taxId);
+
+        const remainingLimitInUnits =
+          rampDirection === RampDirection.OFFRAMP
+            ? remainingLimitResponse.remainingLimitOfframp
+            : remainingLimitResponse.remainingLimitOnramp;
+
+        const amountNum = Number(amountUnits);
+        const remainingLimitNum = Number(remainingLimitInUnits);
+
+        if (amountNum <= remainingLimitNum) {
+          return true;
+        } else {
+          showToast(
+            ToastMessage.RAMP_LIMIT_EXCEEDED,
+            t('toasts.rampLimitExceeded', { remaining: remainingLimitInUnits }),
+          );
+          return false;
+        }
+      } catch (error) {
+        console.error('Error fetching remaining limit:', error);
+        return false;
+      }
+    },
+    [rampDirection, showToast, t, ToastMessage.RAMP_LIMIT_EXCEEDED],
+  );
+}
+
+export function usePreRampCheck() {
+  const rampWithinLimits = useRampAmountWithinAllowedLimits();
+
+  return useCallback(
+    async (executionInput: RampExecutionInput) => {
+      // For BRL ramps, check if the user is within the limits
+      if (executionInput.fiatToken === 'brl') {
+        if (!executionInput.taxId) {
+          throw new Error('Tax ID is required for BRL transactions.');
+        }
+
+        const isWithinLimits = await rampWithinLimits(
+          executionInput.quote.rampType === 'on' ? executionInput.quote.inputAmount : executionInput.quote.outputAmount,
+          executionInput.taxId,
+        );
+        if (!isWithinLimits) {
+          throw new Error('Ramp amount exceeds the allowed limits.');
+        }
+      }
+    },
+    [rampWithinLimits],
+  );
+}

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -407,6 +407,7 @@
     "signingFailed": "Signing failed. Please try again.",
     "walletAlreadyOpen": "Wallet already open pending connection. Please try again.",
     "nodeConnectionError": "Error while connecting to the node. Refresh the page to re-connect.",
-    "genericError": "An error occurred. Please try again."
+    "genericError": "An error occurred. Please try again.",
+    "rampLimitExceeded": "This amount exceeds the remaining limit of {{remaining}} BRL for your account."
   }
 }

--- a/frontend/src/translations/pt.json
+++ b/frontend/src/translations/pt.json
@@ -406,6 +406,7 @@
     "signingFailed": "Falha na assinatura. Por favor, tente novamente.",
     "walletAlreadyOpen": "Carteira já aberta aguardando conexão. Por favor, tente novamente.",
     "nodeConnectionError": "Erro ao conectar ao nó. Atualize a página para reconectar.",
-    "genericError": "Ocorreu um erro. Por favor, tente novamente."
+    "genericError": "Ocorreu um erro. Por favor, tente novamente.",
+    "rampLimitExceeded": "Este valor excede o limite restante de {{remaining}} BRL para sua conta."
   }
 }

--- a/shared/src/endpoints/brla.endpoints.ts
+++ b/shared/src/endpoints/brla.endpoints.ts
@@ -51,6 +51,15 @@ export namespace BrlaEndpoints {
     [key: string]: any; // Additional fields from BRLA API
   }
 
+  export interface GetUserRemainingLimitRequest {
+    taxId: string;
+  }
+
+  export interface GetUserRemainingLimitResponse {
+    remainingLimitOnramp: number;
+    remainingLimitOfframp: number;
+  }
+
   // POST /brla/triggerOfframp
   export interface TriggerOfframpRequest {
     taxId: string;

--- a/shared/src/helpers/signUnsigned.ts
+++ b/shared/src/helpers/signUnsigned.ts
@@ -10,7 +10,7 @@ import { hdEthereum, mnemonicToLegacySeed } from '@polkadot/util-crypto';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 // Number of transactions to pre-sign for each transaction
-const NUMBER_OF_PRESIGNED_TXS = 3;
+const NUMBER_OF_PRESIGNED_TXS = 5;
 
 export function addAdditionalTransactionsToMeta(primaryTx: PresignedTx, multiSignedTxs: PresignedTx[]): PresignedTx {
   if (multiSignedTxs.length <= 1) {


### PR DESCRIPTION
- [x] Adds an endpoint to check the remaining limit of a BRLA subaccount. The endpoint already subtracts the used limit from the total to calculate the remaining.
- [x] Add a 'preRampCheck' that currently only checks if the amount that the user wants to ramp is within the allowed limits. For simplicity, the check is only executed once the user clicks on the confirm. It's not triggered when the user updates the value in the form. I decided to go this way as we will very soon change the logic to simply change the behaviour of the submit button if the user exceeds the remaining limit instead of showing an error. Thus, going for a better UX at the moment would be wasted effort. 

Supersedes #533 and closes #518.