### PR TITLE
Adjust cleanup worker and nonces.

### DIFF
--- a/api/src/api/services/transactions/onrampTransactions.ts
+++ b/api/src/api/services/transactions/onrampTransactions.ts
@@ -117,13 +117,14 @@ export async function prepareOnrampTransactions(
         signer: account.address,
       });
 
-      // TODO why do we need several? First transfer_all either has no effect or does not transfer... all.
       const moonbeamCleanupTransaction = await prepareMoonbeamCleanupTransaction();
+      // For assethub, we skip the 2 squidrouter transactions, so nonce is 2 lower.
+      const moonbeamCleanupStartingNonce = toNetworkId === getNetworkId(Networks.AssetHub) ? moonbeamEphemeralStartingNonce + 2 : moonbeamEphemeralStartingNonce + 4;
       unsignedTxs.push({
         txData: encodeSubmittableExtrinsic(moonbeamCleanupTransaction),
         phase: 'moonbeamCleanup',
         network: account.network,
-        nonce: 4,
+        nonce: moonbeamCleanupStartingNonce,
         signer: account.address,
       });
 


### PR DESCRIPTION
### Changes

- Adjust the nonce value such that the correct one is used for Assethub type onramps.
- Delays moonbeam cleanup 15 minutes after complete to ensure squidrouter has time to refund. 