### PR TITLE
fix multiple progress page animation intervals causing % above 100

### DIFF
--- a/frontend/src/pages/progress/index.tsx
+++ b/frontend/src/pages/progress/index.tsx
@@ -33,12 +33,12 @@ export const ONRAMPING_PHASE_SECONDS: Record<RampPhase, number> = {
   failed: 0,
 
   // The following are unused phases in the onramping process but are included for completeness.
-  moonbeamToPendulum: 40,
-  assethubToPendulum: 24,
-  spacewalkRedeem: 130,
-  stellarPayment: 6,
-  brlaPayoutOnMoonbeam: 120,
-  stellarCreateAccount: 10,
+  moonbeamToPendulum: 0,
+  assethubToPendulum: 0,
+  spacewalkRedeem: 0,
+  stellarPayment: 0,
+  brlaPayoutOnMoonbeam: 0,
+  stellarCreateAccount: 0,
 };
 
 // The order of the phases is important for the progress bar.
@@ -61,12 +61,12 @@ export const OFFRAMPING_PHASE_SECONDS: Record<RampPhase, number> = {
   failed: 0,
 
   // The following are unused phases in the offramping process but are included for completeness.
-  brlaTeleport: 30,
-  moonbeamToPendulumXcm: 30,
+  brlaTeleport: 0,
+  moonbeamToPendulumXcm: 0,
   pendulumToAssethub: 0,
-  pendulumToMoonbeam: 40,
-  brlaPayoutOnMoonbeam: 120,
-  stellarCreateAccount: 10,
+  pendulumToMoonbeam: 0,
+  brlaPayoutOnMoonbeam: 0,
+  stellarCreateAccount: 0,
 };
 
 // This constant is used to denote how many of the phases are relevant for the progress bar.
@@ -81,28 +81,34 @@ const useProgressUpdate = (
   setDisplayedPercentage: (value: (prev: number) => number) => void,
   setShowCheckmark: (value: boolean) => void,
 ) => {
-  const phaseStartTime = useRef(Date.now());
-  const phaseStartPercentage = useRef(displayedPercentage);
   const numberOfPhases = RELEVANT_PHASES_COUNT;
+  const intervalRef = useRef<NodeJS.Timeout>(null);
 
   useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
     const targetPercentage = Math.round((100 / numberOfPhases) * (currentPhaseIndex + 1));
     const duration = rampPhaseRecords[currentPhase] * 1000;
+    const startTime = Date.now();
+    const startPercentage = displayedPercentage;
 
-    phaseStartTime.current = Date.now();
-    phaseStartPercentage.current = displayedPercentage;
-
-    const progressUpdateInterval = setInterval(() => {
-      const elapsedTime = Date.now() - phaseStartTime.current;
+    const calculateProgress = () => {
+      const elapsedTime = Date.now() - startTime;
       const timeRatio = Math.min(1, elapsedTime / duration);
 
-      const newPercentage = Math.round(
-        phaseStartPercentage.current + (targetPercentage - phaseStartPercentage.current) * timeRatio,
-      );
+      return Math.min(100, Math.round(startPercentage + (targetPercentage - startPercentage) * timeRatio));
+    };
+
+    intervalRef.current = setInterval(() => {
+      const newPercentage = calculateProgress();
 
       setDisplayedPercentage(() => {
-        if (timeRatio === 1) {
-          clearInterval(progressUpdateInterval);
+        if (newPercentage >= targetPercentage) {
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+          }
           if (currentPhaseIndex === numberOfPhases - 1) {
             setShowCheckmark(true);
           }
@@ -111,7 +117,11 @@ const useProgressUpdate = (
       });
     }, 100);
 
-    return () => clearInterval(progressUpdateInterval);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
   }, [
     currentPhase,
     currentPhaseIndex,

--- a/frontend/src/pages/progress/phaseMessages.ts
+++ b/frontend/src/pages/progress/phaseMessages.ts
@@ -12,21 +12,23 @@ import { TFunction } from 'i18next';
 export function getMessageForPhase(ramp: RampState | undefined, t: TFunction<'translation', undefined>): string {
   if (!ramp || !ramp.ramp) return t('pages.progress.initial');
 
-  const currentState = ramp.ramp!;
+  const currentState = ramp.ramp;
   const quote = ramp.quote;
   const currentPhase = currentState.currentPhase;
 
   const fromNetwork = getNetworkFromDestination(quote.from);
   const toNetwork = getNetworkFromDestination(quote.to);
 
+  if (!fromNetwork || !toNetwork) return t('pages.progress.initial');
+
   const inputAssetSymbol =
     currentState.type === 'off'
-      ? getOnChainTokenDetailsOrDefault(fromNetwork!, quote.inputCurrency as OnChainToken).assetSymbol
+      ? getOnChainTokenDetailsOrDefault(fromNetwork, quote.inputCurrency as OnChainToken).assetSymbol
       : getAnyFiatTokenDetails(quote.inputCurrency as FiatToken).assetSymbol;
   const outputAssetSymbol =
     currentState.type === 'off'
       ? getAnyFiatTokenDetails(quote.outputCurrency as FiatToken).assetSymbol
-      : getOnChainTokenDetailsOrDefault(toNetwork!, quote.outputCurrency as OnChainToken).assetSymbol;
+      : getOnChainTokenDetailsOrDefault(toNetwork, quote.outputCurrency as OnChainToken).assetSymbol;
 
   if (currentPhase === 'complete') return t('pages.progress.success');
 


### PR DESCRIPTION
In order to avoid issues with percentage shown in the Progress page animation:
- [x] Ensuring that only one interval is active
- [x] Remove use of ref for following current percentage to avoid rendering errors