### PR TITLE
Fix remaining limit check to allow valid amounts

### DIFF
--- a/frontend/src/services/initialChecks.ts
+++ b/frontend/src/services/initialChecks.ts
@@ -17,7 +17,6 @@ function useRampAmountWithinAllowedLimits() {
       try {
         const subaccount = await BrlaService.getUser(taxId);
         const remainingLimitResponse = await BrlaService.getUserRemainingLimit(taxId);
-        console.log('level:', subaccount.kycLevel);
         if (subaccount.kycLevel < 2) {
           return true;
         }
@@ -29,8 +28,8 @@ function useRampAmountWithinAllowedLimits() {
 
         const amountNum = Number(amountUnits);
         const remainingLimitNum = Number(remainingLimitInUnits);
-        console.log('remainingLimitNum', remainingLimitNum);
-        if (amountNum > remainingLimitNum) {
+
+        if (amountNum <= remainingLimitNum) {
           return true;
         } else {
           showToast(


### PR DESCRIPTION
This pull request includes cleanup and a logic correction in the `useRampAmountWithinAllowedLimits` function within `frontend/src/services/initialChecks.ts`. The changes improve code clarity and fix a conditional check.

Code cleanup:

* Removed unnecessary `console.log` statements that logged the `kycLevel` and `remainingLimitNum` values, reducing noise in the code. [[1]](diffhunk://#diff-815cf676864f7a643071acda6bddc6919ae8ab494676f0299bac2dadd84edad8L20) [[2]](diffhunk://#diff-815cf676864f7a643071acda6bddc6919ae8ab494676f0299bac2dadd84edad8L32-R32)

Logic correction:

* Updated the conditional check to correctly compare `amountNum` and `remainingLimitNum`, ensuring the function returns `true` when `amountNum` is less than or equal to `remainingLimitNum` instead of greater.