### PR TITLE
Change banner to extend campaign to 27 May

### DIFF
--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -180,7 +180,7 @@
   },
   "components": {
     "airdropBanner": {
-      "title": "Special offer until 20 May",
+      "title": "Special offer until 27 May",
       "description": "Buy or sell USDT/C from just R$5 - get 20 USDT for FREE",
       "button": "More info",
       "list": {

--- a/frontend/src/translations/pt.json
+++ b/frontend/src/translations/pt.json
@@ -180,7 +180,7 @@
   },
   "components": {
     "airdropBanner": {
-      "title": "Oferta especial até 20 Maio",
+      "title": "Oferta especial até 27 Maio",
       "description": "Compre ou venda USDT/C por apenas R$5 - receba 20 USDT de graça!",
       "button": "Mais informações",
       "list": {


### PR DESCRIPTION
This pull request updates the promotional banner text in the English and Portuguese translation files to reflect a new end date for the special offer.

* Updated the `airdropBanner.title` in `frontend/src/translations/en.json` to change the offer end date from "20 May" to "27 May".
* Updated the `airdropBanner.title` in `frontend/src/translations/pt.json` to change the offer end date from "20 Maio" to "27 Maio".