### PR TITLE
Add unhandled payment alert worker

### DIFF
--- a/api/src/api/controllers/brla.controller.ts
+++ b/api/src/api/controllers/brla.controller.ts
@@ -4,7 +4,6 @@ import { BrlaEndpoints } from 'shared/src/endpoints/brla.endpoints';
 import httpStatus from 'http-status';
 import { BrlaApiService } from '../services/brla/brlaApiService';
 import { eventPoller } from '../..';
-import { generateReferenceLabel } from '../services/brla/helpers';
 import { RegisterSubaccountPayload } from '../services/brla/types';
 import kycService from '../services/kyc/kyc.service';
 import { PayInCodeQuery } from '../middlewares/validators';

--- a/api/src/api/services/brla/helpers.ts
+++ b/api/src/api/services/brla/helpers.ts
@@ -6,6 +6,11 @@ export function verifyReferenceLabel(referenceLabel: string, memo: string): bool
   return referenceLabel === memo;
 }
 
+export function isValidReferenceLabel(label?: string): boolean {
+  if (!label) return false;
+  return label.length === 8;
+}
+
 type QuoteId = string;
 
 export function generateReferenceLabel(quote: QuoteTicket | QuoteId): string {

--- a/api/src/api/workers/unhandled-payment.worker.ts
+++ b/api/src/api/workers/unhandled-payment.worker.ts
@@ -1,0 +1,236 @@
+import { CronJob } from 'cron';
+import logger from '../../config/logger';
+import RampState from '../../models/rampState.model';
+import { BrlaApiService } from '../services/brla/brlaApiService';
+import { Op } from 'sequelize';
+import { generateReferenceLabel } from '../services/brla/helpers';
+import { SlackNotifier } from '../services/slack.service';
+import { DepositLog } from '../services/brla/types';
+
+const DEFAULT_CRON_TIME = '*/15 * * * *';
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000; 
+
+
+class UnhandledPaymentWorker {
+  private job: CronJob;
+  private readonly brlaApiService: BrlaApiService;
+  private readonly slackNotifier: SlackNotifier;
+  private alertsThisCycle: string[]; 
+  // Store processed states in memory to save compute and db calls.
+  // This worker assumes that checkUnhandledPayments is idempotent on the same state.
+  // Should the state be unhandled, it shall not be alerted again.
+  private processedStateIds: Set<string> = new Set();
+
+  constructor(cronTime = DEFAULT_CRON_TIME) {
+    this.brlaApiService = BrlaApiService.getInstance();
+    this.slackNotifier = new SlackNotifier();
+    this.alertsThisCycle = []; 
+
+    this.job = new CronJob(
+      cronTime,
+      this.checkUnhandledPayments.bind(this),
+      null,
+      false,
+      undefined,
+      null,
+      true,
+    );
+  }
+
+  public start(): void {
+    logger.info('Starting unhandled payment worker');
+    this.job.start();
+  }
+
+  public stop(): void {
+    logger.info('Stopping unhandled payment worker');
+    this.job.stop();
+  }
+
+  private async checkUnhandledPayments(): Promise<void> {
+    logger.info('Running unhandled payment worker cycle');
+    try {
+      const staleInitialStates = await this.fetchStaleInitialStates();
+      const failedStates = await this.fetchFailedStates();
+
+      const statesToCheck = [...staleInitialStates, ...failedStates];
+
+      if (statesToCheck.length === 0) {
+        logger.info('No stale or failed states found for payment check');
+        return;
+      }
+
+      logger.info(`Found ${statesToCheck.length} states to check for unhandled payments`);
+
+      await this.processStatesForUnhandledPayments(statesToCheck);
+
+      logger.info('Unhandled payment worker cycle completed');
+    } catch (error) {
+      logger.error('Error during unhandled payment worker cycle:', error);
+    }
+  }
+
+  /**
+   * Fetch initial ramp states that are stale (created > 10 minutes ago but < 3 days)
+   */
+  private async fetchStaleInitialStates(): Promise<RampState[]> {
+    const tenMinutesAgo = new Date(Date.now() - TEN_MINUTES_MS);
+    const threeDaysAgo = new Date(Date.now() - THREE_DAYS_MS);
+
+    try {
+      const states = await RampState.findAll({
+        where: {
+          currentPhase: 'initial',
+          createdAt: {
+            [Op.lt]: tenMinutesAgo,
+            [Op.gt]: threeDaysAgo,
+          },
+          id: {
+            [Op.notIn]: Array.from(this.processedStateIds),
+          },
+        },
+      });
+
+      return states;
+    } catch (error) {
+      logger.error('Error fetching stale initial states:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Fetch failed ramp states (< 3 days old)
+   */
+  private async fetchFailedStates(): Promise<RampState[]> {
+    const threeDaysAgo = new Date(Date.now() - THREE_DAYS_MS);
+
+    try {
+      const states = await RampState.findAll({
+        where: {
+          currentPhase: 'failed',
+          createdAt: {
+            [Op.gt]: threeDaysAgo,
+          },
+          id: {
+            [Op.notIn]: Array.from(this.processedStateIds),
+          },
+        },
+      });
+
+      return states;
+    } catch (error) {
+      logger.error('Error fetching failed states:', error);
+      return [];
+    }
+  }
+
+  private findFirstDuplicateReferenceInfo(payments: DepositLog[]): { label: string; ids: string[] } | undefined {
+    const referenceDetails = new Map<string, string[]>(); 
+    for (const payment of payments) {
+      if (!payment.referenceLabel || !payment.id) { 
+        continue;
+      }
+
+      const existingIds = referenceDetails.get(payment.referenceLabel);
+      if (existingIds) {
+        existingIds.push(payment.id);
+        return { label: payment.referenceLabel, ids: existingIds };
+      } else {
+        referenceDetails.set(payment.referenceLabel, [payment.id]);
+      }
+    }
+    return undefined;
+  }
+
+  private async processStatesForUnhandledPayments(states: RampState[]): Promise<void> {
+    for (const state of states) {
+      try {
+        // If already alerted in a previous cycle (DB flag is set), skip generating new alerts.
+        // The processedStateIds set primarily prevents re-fetching and re-processing,
+        // this is a secondary check if a state somehow gets re-processed.
+        if (state.state.unhandledPaymentAlertSent) {
+          this.processedStateIds.add(state.id); 
+          continue;
+        }
+
+        const subaccountId = state.state.taxId;
+        if (!subaccountId) {
+          logger.warn(`No subaccount ID (taxId) found for state ${state.id}. Skipping payment checks for this state.`);
+          this.processedStateIds.add(state.id); 
+          continue;
+        }
+
+        this.processedStateIds.add(state.id);
+
+        const referenceLabel = generateReferenceLabel(state.quoteId);
+        const paymentHistory = await this.brlaApiService.getPayInHistory(subaccountId);
+
+        // Check 1: Unexpected payment found for the state's specific referenceLabel
+        const matchingPayments = paymentHistory.filter(payment =>
+          payment.referenceLabel === referenceLabel && payment.id
+        );
+
+        if (matchingPayments.length > 0) {
+          const firstMatchingPayment = matchingPayments[0]; 
+          logger.error(`ALERT: Found ${matchingPayments.length} unhandled payment(s) for state ${state.id} with reference label ${referenceLabel}. First Payment ID: ${firstMatchingPayment.id}`);
+          const reason = 'Payment found for an initial or failed state where none was expected.';
+          const slackMessage = `Unhandled payment for State ID: ${state.id}, Payment ID(s): ${matchingPayments.map(p => p.id).join(', ')}, Label: ${referenceLabel}, Reason: ${reason}`;
+
+          this.updateAlertedState(state, slackMessage);
+        }
+
+        // Check 2: General duplicate reference labels in the payment history for the subaccount
+        const duplicateInfo = this.findFirstDuplicateReferenceInfo(paymentHistory);
+        if (duplicateInfo) {
+          logger.error(`ALERT: Found duplicate reference label ('${duplicateInfo.label}') in payment history for subaccount of state ${state.id}. Associated Payment IDs: ${duplicateInfo.ids.join(', ')}`);
+          const reason = `Duplicate reference label '${duplicateInfo.label}' detected in subaccount ${subaccountId}.`;
+          const slackMessage = `Duplicate payment reference issue associated with State ID: ${state.id}. Duplicated Label: '${duplicateInfo.label}', Involved Payment IDs: ${duplicateInfo.ids.join(', ')}. Reason: ${reason}`;
+          this.updateAlertedState(state, slackMessage);
+        }
+
+      } catch (error) {
+        logger.error(`Error processing state ${state.id} for unhandled payments:`, error);
+      }
+    }
+
+    if (this.alertsThisCycle.length > 0) {
+      await this.notifySlack();
+    }
+    logger.info(`Attempted to process ${states.length} states for unhandled payments this cycle.`);
+  }
+
+  private async updateAlertedState(state: RampState, message: string): Promise<void> {
+
+    if (!state.state.unhandledPaymentAlertSent) {
+      try {
+        const newState = { ...state.state, unhandledPaymentAlertSent: true };
+        await state.update({ state: newState }); 
+        logger.info(`State ${state.id} successfully updated to mark unhandledPaymentAlertSent.`);
+      } catch (error) {
+        logger.error(`Error updating state ${state.id} to mark alert as sent:`, error);
+      }
+    }
+    this.alertsThisCycle.push(message);
+  }
+
+  private async notifySlack(): Promise<void> {
+    if (this.alertsThisCycle.length === 0) {
+      logger.info('No alerts to send to Slack in this cycle.');
+      return;
+    }
+
+    const alertText = this.alertsThisCycle.join('\n');
+    try {
+      logger.info(`Attempting to send ${this.alertsThisCycle.length} alert(s) to Slack.`);
+      await this.slackNotifier.sendMessage({ text: alertText });
+      logger.info('Slack notification sent successfully.');
+      this.alertsThisCycle = []; 
+    } catch (error) {
+      logger.error('Error sending Slack notification:', error);
+      // alertsThisCycle is not cleared, so messages will be included in the next attempt.
+    }
+  }
+}
+
+export default UnhandledPaymentWorker;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -61,6 +61,7 @@ const initializeApp = async () => {
     // Start background workers
     new CleanupWorker().start();
     new RampRecoveryWorker().start();
+    new RampRecoveryWorker().start();
 
     // Register phase handlers
     registerPhaseHandlers();

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -23,6 +23,7 @@ import CleanupWorker from './api/workers/cleanup.worker';
 import RampRecoveryWorker from './api/workers/ramp-recovery.worker';
 import registerPhaseHandlers from './api/services/phases/register-handlers';
 import { EventPoller } from './api/services/brla/webhooks';
+import UnhandledPaymentWorker from './api/workers/unhandled-payment.worker';
 
 const { port, env } = config;
 
@@ -61,7 +62,7 @@ const initializeApp = async () => {
     // Start background workers
     new CleanupWorker().start();
     new RampRecoveryWorker().start();
-    new RampRecoveryWorker().start();
+    new UnhandledPaymentWorker().start();
 
     // Register phase handlers
     registerPhaseHandlers();


### PR DESCRIPTION
### About
Adds a worker that fetches ramp entries with status `failed` and `initial`, using a predefined time window. 

For each ramp, the worker checks:
- If there was a payment with a reference label corresponding to the entry. This should not be the case and should be alerted.
- Checks if there is a duplicate reference label on the list of payments from the BRLA account corresponding to the entry. Rationale is that this may be the cause of a `failed` or `invalid` state.
- If there is a payment with an invalid label (no label, wrong length, etc).

The worker will not alert more than once per day for each`subaccountId`. If from a particular ramp state we detect multiple inconsistencies, then all will be triggered. 