### PR TITLE
[READY] /supported-payment-methods & /supported-cryptocurrencies

### DIFF
--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   rules: {
+    'import/prefer-default-export': 'off',
     'class-methods-use-this': 'off',
     'no-console': 0,
     'no-underscore-dangle': 0,

--- a/api/src/api/controllers/cryptocurrencies.controller.ts
+++ b/api/src/api/controllers/cryptocurrencies.controller.ts
@@ -6,6 +6,7 @@ import {
   SupportedCryptocurrencyDetails,
 } from 'shared/src/endpoints/supported-cryptocurrencies.endpoints';
 import { getSupportedCryptocurrencies } from '../../config/cryptocurrencies.config';
+import { APIError } from '../errors/api-error';
 
 /**
  * Get supported cryptocurrencies with detailed information based on network
@@ -15,7 +16,7 @@ import { getSupportedCryptocurrencies } from '../../config/cryptocurrencies.conf
  */
 export const getSupportedCryptocurrenciesHandler = async (
   req: Request<unknown, unknown, unknown, GetSupportedCryptocurrenciesRequest>,
-  res: Response<GetSupportedCryptocurrenciesResponse>,
+  res: Response<GetSupportedCryptocurrenciesResponse | { error: string }>,
   next: NextFunction,
 ): Promise<void> => {
   try {
@@ -27,6 +28,13 @@ export const getSupportedCryptocurrenciesHandler = async (
       cryptocurrencies,
     });
   } catch (error) {
+    if (error instanceof APIError) {
+      res.status(httpStatus.BAD_REQUEST).json({
+        error: error.message,
+      });
+      return;
+    }
+
     next(error);
   }
 };

--- a/api/src/api/controllers/cryptocurrencies.controller.ts
+++ b/api/src/api/controllers/cryptocurrencies.controller.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction } from 'express';
+import httpStatus from 'http-status';
+import {
+  GetSupportedCryptocurrenciesRequest,
+  GetSupportedCryptocurrenciesResponse,
+  SupportedCryptocurrencyDetails,
+} from 'shared/src/endpoints/supported-cryptocurrencies.endpoints';
+import { getSupportedCryptocurrencies } from '../../config/cryptocurrencies.config';
+
+/**
+ * Get supported cryptocurrencies with detailed information based on network
+ * @param req - Express request object
+ * @param res - Express response object
+ * @param next - Express next function
+ */
+export const getSupportedCryptocurrenciesHandler = async (
+  req: Request<unknown, unknown, unknown, GetSupportedCryptocurrenciesRequest>,
+  res: Response<GetSupportedCryptocurrenciesResponse>,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { network } = req.query;
+
+    const cryptocurrencies: SupportedCryptocurrencyDetails[] = getSupportedCryptocurrencies(network);
+
+    res.status(httpStatus.OK).json({
+      cryptocurrencies,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/api/src/api/controllers/payment-methods.controller.ts
+++ b/api/src/api/controllers/payment-methods.controller.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction } from 'express';
+import httpStatus from 'http-status';
+import {
+  FiatToken,
+  GetSupportedPaymentMethodsRequest,
+  GetSupportedPaymentMethodsResponse,
+  PaymentMethodConfig,
+  PaymentMethodType,
+  PaymentMethodTypes,
+} from 'shared';
+import { PAYMENT_METHODS_CONFIG } from '../../config/payment-methods.config';
+
+/**
+ * Gets payment methods based on type (buy/sell)
+ * @param type - Payment method type "sell" (default) or "buy"
+ * @returns Payment methods for the specified type
+ */
+function getPaymentMethodsByType(type: PaymentMethodType): PaymentMethodConfig[] {
+  return type === PaymentMethodTypes.BUY ? PAYMENT_METHODS_CONFIG.buy : PAYMENT_METHODS_CONFIG.sell;
+}
+
+/**
+ * Filters payment methods by supported fiat currency
+ * @param paymentMethods - Array of payment methods to filter
+ * @param fiat - Fiat currency to filter by
+ * @returns Filtered payment methods that support the specified fiat
+ */
+function getPaymentMethodsByFiat(paymentMethods: PaymentMethodConfig[], fiat: FiatToken): PaymentMethodConfig[] {
+  return paymentMethods.filter((method) => method.supportedFiats.includes(fiat));
+}
+
+export const getSupportedPaymentMethods = async (
+  req: Request<unknown, unknown, unknown, GetSupportedPaymentMethodsRequest>,
+  res: Response<GetSupportedPaymentMethodsResponse>,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { type, fiat } = req.query;
+    const paymentMethodsByType = getPaymentMethodsByType(type);
+    const paymentMethodsByFiat = getPaymentMethodsByFiat(paymentMethodsByType, fiat);
+
+    res.status(httpStatus.OK).json({
+      paymentMethods: paymentMethodsByFiat,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/api/src/api/controllers/payment-methods.controller.ts
+++ b/api/src/api/controllers/payment-methods.controller.ts
@@ -40,7 +40,7 @@ export const getSupportedPaymentMethods = async (
     const paymentMethodsByFiat = getPaymentMethodsByFiat(paymentMethodsByType, fiat);
 
     res.status(httpStatus.OK).json({
-      paymentMethods: paymentMethodsByFiat,
+      paymentMethods: fiat ? paymentMethodsByFiat : paymentMethodsByType,
     });
   } catch (error) {
     next(error);

--- a/api/src/api/middlewares/validators.ts
+++ b/api/src/api/middlewares/validators.ts
@@ -1,8 +1,7 @@
 import { RequestHandler } from 'express';
 import { ParsedQs } from 'qs';
 import httpStatus from 'http-status';
-import { PriceEndpoints } from 'shared/src/endpoints/price.endpoints';
-import { BrlaEndpoints, TokenConfig } from 'shared';
+import { BrlaEndpoints, TokenConfig, PriceEndpoints } from 'shared';
 import { EMAIL_SHEET_HEADER_VALUES } from '../controllers/email.controller';
 import { RATING_SHEET_HEADER_VALUES } from '../controllers/rating.controller';
 import { FLOW_HEADERS } from '../controllers/storage.controller';

--- a/api/src/api/routes/v1/cryptocurrencies.route.ts
+++ b/api/src/api/routes/v1/cryptocurrencies.route.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getSupportedCryptocurrenciesHandler } from '../../controllers/cryptocurrencies.controller';
+
+const router: Router = Router({ mergeParams: true });
+
+router.route('/').get(getSupportedCryptocurrenciesHandler);
+
+export default router;

--- a/api/src/api/routes/v1/index.ts
+++ b/api/src/api/routes/v1/index.ts
@@ -13,6 +13,7 @@ import quoteRoutes from './quote.route';
 import brlaRoutes from './brla.route';
 import rampRoutes from './ramp.route';
 import paymentMethodsRoutes from './payment-methods.route';
+import cryptocurrenciesRoutes from './cryptocurrencies.route';
 
 import { sendStatusWithPk as sendStellarStatusWithPk } from '../../controllers/stellar.controller';
 import { sendStatusWithPk as sendPendulumStatusWithPk } from '../../controllers/pendulum.controller';
@@ -112,6 +113,11 @@ router.use('/ramp', rampRoutes);
  * GET v1/supported-payment-methods
  */
 router.use('/supported-payment-methods', paymentMethodsRoutes);
+
+/**
+ * GET v1/supported-cryptocurrencies
+ */
+router.use('/supported-cryptocurrencies', cryptocurrenciesRoutes);
 
 router.get('/ip', (request: Request, response: Response) => {
   response.send(request.ip);

--- a/api/src/api/routes/v1/index.ts
+++ b/api/src/api/routes/v1/index.ts
@@ -12,6 +12,7 @@ import priceRoutes from './price.route';
 import quoteRoutes from './quote.route';
 import brlaRoutes from './brla.route';
 import rampRoutes from './ramp.route';
+import paymentMethodsRoutes from './payment-methods.route';
 
 import { sendStatusWithPk as sendStellarStatusWithPk } from '../../controllers/stellar.controller';
 import { sendStatusWithPk as sendPendulumStatusWithPk } from '../../controllers/pendulum.controller';
@@ -106,6 +107,11 @@ router.use('/brla', brlaRoutes);
  * GET/POST v1/ramp
  */
 router.use('/ramp', rampRoutes);
+
+/**
+ * GET v1/supported-payment-methods
+ */
+router.use('/supported-payment-methods', paymentMethodsRoutes);
 
 router.get('/ip', (request: Request, response: Response) => {
   response.send(request.ip);

--- a/api/src/api/routes/v1/payment-methods.route.ts
+++ b/api/src/api/routes/v1/payment-methods.route.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getSupportedPaymentMethods } from '../../controllers/payment-methods.controller';
+
+const router: Router = Router({ mergeParams: true });
+
+router.route('/').get(getSupportedPaymentMethods);
+
+export default router;

--- a/api/src/api/services/transactions/squidrouter/offramp.ts
+++ b/api/src/api/services/transactions/squidrouter/offramp.ts
@@ -62,7 +62,7 @@ export async function createOfframpSquidrouterTransactions(
     args: [transactionRequest?.target, params.rawAmount],
   });
 
-  const { maxFeePerGas, maxPriorityFeePerGas } = await publicClient.estimateFeesPerGas();
+  const { maxFeePerGas } = await publicClient.estimateFeesPerGas();
 
   return {
     approveData: {

--- a/api/src/config/cryptocurrencies.config.ts
+++ b/api/src/config/cryptocurrencies.config.ts
@@ -1,0 +1,43 @@
+import { EvmToken, AssetHubToken, Networks, isNetworkEVM, isNetworkAssetHub } from 'shared';
+import {
+  SupportedCryptocurrencyDetails,
+} from 'shared/src/endpoints/supported-cryptocurrencies.endpoints';
+import { evmTokenConfig } from 'shared/src/tokens/evm/config';
+import { assetHubTokenConfig } from 'shared/src/tokens/assethub/config';
+
+/**
+ * Function to get supported cryptocurrencies with details based on network
+ * @param network Optional network filter (default is Polygon)
+ * @returns Array of enhanced token details
+ */
+export function getSupportedCryptocurrencies(network: Networks | undefined = Networks.Polygon): SupportedCryptocurrencyDetails[] {
+  if (network && isNetworkEVM(network)) {
+    const tokens = Object.values(EvmToken);
+
+    return tokens.map(token => {
+      const details = evmTokenConfig[network][token];
+      return {
+        assetSymbol: details.assetSymbol,
+        assetContractAddress: details.erc20AddressSourceChain,
+        assetNetwork: details.network,
+        assetDecimals: details.decimals,
+      };
+    });
+  }
+
+  if (network && isNetworkAssetHub(network)) {
+    const tokens = Object.values(AssetHubToken);
+
+    return tokens.map(token => {
+      const details = assetHubTokenConfig[token];
+      return {
+        assetSymbol: details.assetSymbol,
+        assetForeignAssetId: details.foreignAssetId,
+        assetNetwork: details.network,
+        assetDecimals: details.decimals,
+      };
+    });
+  }
+
+  return [];
+}

--- a/api/src/config/payment-methods.config.ts
+++ b/api/src/config/payment-methods.config.ts
@@ -1,0 +1,36 @@
+import { FiatToken, PaymentMethodConfig, PaymentMethodName, PaymentMethodType } from 'shared';
+
+const SEPA_PAYMENT_METHOD: PaymentMethodConfig = {
+  id: 'sepa',
+  name: PaymentMethodName.SEPA,
+  supportedFiats: [FiatToken.EURC],
+  limits: {
+    min: 10,
+    max: 50000,
+  },
+};
+
+const PIX_PAYMENT_METHOD: PaymentMethodConfig = {
+  id: 'pix',
+  name: PaymentMethodName.PIX,
+  supportedFiats: [FiatToken.BRL],
+  limits: {
+    min: 1,
+    max: 500000,
+  },
+};
+
+const CBU_PAYMENT_METHOD: PaymentMethodConfig = {
+  id: 'cbu',
+  name: PaymentMethodName.CBU,
+  supportedFiats: [FiatToken.ARS],
+  limits: {
+    min: 1,
+    max: 500000,
+  },
+};
+
+export const PAYMENT_METHODS_CONFIG: Record<PaymentMethodType, PaymentMethodConfig[]> = {
+  buy: [PIX_PAYMENT_METHOD],
+  sell: [SEPA_PAYMENT_METHOD, PIX_PAYMENT_METHOD, CBU_PAYMENT_METHOD],
+};

--- a/frontend/src/contexts/events.tsx
+++ b/frontend/src/contexts/events.tsx
@@ -286,21 +286,23 @@ const useEvents = () => {
     const wasChanged = previous !== address;
     const isConnected = address !== undefined;
 
-    if (!isConnected && wasConnected) {
+    const networkId = getNetworkId(selectedNetwork);
+
+    if (!isConnected && wasConnected && networkId) {
       trackEvent({
         event: 'wallet_connect',
         wallet_action: 'disconnect',
         account_address: previous,
         input_amount: inputAmount ? inputAmount.toString() : '0',
-        network_selected: getNetworkId(selectedNetwork).toString(),
+        network_selected: networkId.toString(),
       });
-    } else if (wasChanged) {
+    } else if (wasChanged && networkId) {
       trackEvent({
         event: 'wallet_connect',
         wallet_action: wasConnected ? 'change' : 'connect',
         account_address: address,
         input_amount: inputAmount ? inputAmount.toString() : '0',
-        network_selected: getNetworkId(selectedNetwork).toString(),
+        network_selected: networkId.toString(),
       });
     }
 

--- a/frontend/src/contexts/events.tsx
+++ b/frontend/src/contexts/events.tsx
@@ -288,7 +288,7 @@ const useEvents = () => {
 
     const networkId = getNetworkId(selectedNetwork);
 
-    if (!isConnected && wasConnected && networkId) {
+    if (!isConnected && wasConnected) {
       trackEvent({
         event: 'wallet_connect',
         wallet_action: 'disconnect',

--- a/shared/src/endpoints/index.ts
+++ b/shared/src/endpoints/index.ts
@@ -11,3 +11,4 @@ export * from './siwe.endpoints';
 export * from './stellar.endpoints';
 export * from './storage.endpoints';
 export * from './subsidize.endpoints';
+export * from './payment-methods.endpoints';

--- a/shared/src/endpoints/index.ts
+++ b/shared/src/endpoints/index.ts
@@ -12,3 +12,4 @@ export * from './stellar.endpoints';
 export * from './storage.endpoints';
 export * from './subsidize.endpoints';
 export * from './payment-methods.endpoints';
+export * from './supported-cryptocurrencies.endpoints';

--- a/shared/src/endpoints/payment-methods.endpoints.ts
+++ b/shared/src/endpoints/payment-methods.endpoints.ts
@@ -1,0 +1,37 @@
+import { FiatToken } from 'src/tokens';
+
+export type PaymentMethodType = 'buy' | 'sell';
+
+export enum PaymentMethodTypes {
+  BUY = 'buy',
+  SELL = 'sell',
+}
+
+export enum PaymentMethodName {
+  SEPA = 'SEPA',
+  PIX = 'PIX',
+  CBU = 'CBU',
+}
+
+export type PaymentMethod = 'pix' | 'sepa' | 'cbu';
+
+export interface PaymentMethodLimits {
+  min: number;
+  max: number;
+}
+
+export interface PaymentMethodConfig {
+  id: PaymentMethod;
+  name: PaymentMethodName;
+  supportedFiats: FiatToken[];
+  limits: PaymentMethodLimits;
+}
+
+export interface GetSupportedPaymentMethodsRequest {
+  type: PaymentMethodType;
+  fiat: FiatToken;
+}
+
+export interface GetSupportedPaymentMethodsResponse {
+  paymentMethods: PaymentMethodConfig[];
+}

--- a/shared/src/endpoints/payment-methods.endpoints.ts
+++ b/shared/src/endpoints/payment-methods.endpoints.ts
@@ -1,4 +1,4 @@
-import { FiatToken } from 'src/tokens';
+import { FiatToken } from '../tokens';
 
 export type PaymentMethodType = 'buy' | 'sell';
 

--- a/shared/src/endpoints/supported-cryptocurrencies.endpoints.ts
+++ b/shared/src/endpoints/supported-cryptocurrencies.endpoints.ts
@@ -1,0 +1,29 @@
+import { Networks } from '../helpers';
+import { OnChainToken } from '../tokens/types/base';
+import { OnChainTokenDetails } from '../tokens';
+
+export type SupportedCryptocurrency = OnChainToken;
+
+export type SupportedCryptocurrencyDetails = SupportedEVMCryptocurrencyDetails | SupportedAssetHubCryptocurrencyDetails;
+
+export interface SupportedEVMCryptocurrencyDetails extends SupportedCryptocurrencyDetailsBase {
+  assetContractAddress: string;
+}
+
+export interface SupportedAssetHubCryptocurrencyDetails extends SupportedCryptocurrencyDetailsBase {
+  assetForeignAssetId: number;
+}
+
+export interface SupportedCryptocurrencyDetailsBase {
+  assetSymbol: string;
+  assetNetwork: Networks;
+  assetDecimals: number;
+}
+
+export interface GetSupportedCryptocurrenciesRequest {
+  network?: Networks;
+}
+
+export interface GetSupportedCryptocurrenciesResponse {
+  cryptocurrencies: SupportedCryptocurrencyDetails[];
+}

--- a/shared/src/helpers/networks.ts
+++ b/shared/src/helpers/networks.ts
@@ -1,7 +1,7 @@
+import { PaymentMethod } from 'src/endpoints/payment-methods.endpoints';
 import { polygon, bsc, arbitrum, base, avalanche, moonbeam, mainnet as ethereum } from 'viem/chains';
 
-export type PaymentMethod = 'pix' | 'sepa' | 'cbu';
-export type DestinationType = `${Networks}` | PaymentMethod;
+export type DestinationType = Networks | PaymentMethod;
 
 export enum Networks {
   AssetHub = 'assethub',

--- a/shared/src/helpers/networks.ts
+++ b/shared/src/helpers/networks.ts
@@ -34,8 +34,6 @@ export const ASSETHUB_CHAIN_ID = -1;
 export const PENDULUM_CHAIN_ID = -2;
 export const STELLAR_CHAIN_ID = -99;
 
-const DEFAULT_NETWORK = Networks.AssetHub;
-
 type EVMNetworks = Exclude<Networks, Networks.AssetHub>;
 
 interface NetworkMetadata {
@@ -97,19 +95,31 @@ const NETWORK_METADATA: Record<Networks, NetworkMetadata> = {
   },
 };
 
-export function isNetworkEVM(network: Networks): network is EVMNetworks {
-  return NETWORK_METADATA[network].isEVM;
-}
-
-export function getNetworkId(network: Networks): number {
-  return NETWORK_METADATA[network].id;
-}
-
-export function getNetworkDisplayName(network: Networks): string {
-  return NETWORK_METADATA[network].displayName;
-}
-
-export function getCaseSensitiveNetwork(network: string): Networks {
+export function getCaseSensitiveNetwork(network: string): Networks | undefined {
   const normalized = network.toLowerCase();
-  return Object.values(Networks).find((n) => n.toLowerCase() === normalized) ?? DEFAULT_NETWORK;
+  return Object.values(Networks).find((n) => n.toLowerCase() === normalized);
 }
+
+export function getNetworkMetadata(network: string): NetworkMetadata | undefined {
+  const normalizedNetwork = getCaseSensitiveNetwork(network);
+  return normalizedNetwork ? NETWORK_METADATA[normalizedNetwork] : undefined;
+}
+
+export function isNetworkEVM(network: Networks): network is EVMNetworks {
+  return getNetworkMetadata(network)?.isEVM ?? false;
+}
+
+export function isNetworkAssetHub(network: Networks): network is Networks.AssetHub {
+  return getNetworkMetadata(network)?.id === ASSETHUB_CHAIN_ID;
+}
+
+export function getNetworkId(network: Networks): number | undefined {
+  return getNetworkMetadata(network)?.id;
+}
+
+export function getNetworkDisplayName(network: Networks): string | undefined {
+  return getNetworkMetadata(network)?.displayName;
+}
+
+
+

--- a/shared/src/helpers/networks.ts
+++ b/shared/src/helpers/networks.ts
@@ -1,5 +1,5 @@
-import { PaymentMethod } from 'src/endpoints/payment-methods.endpoints';
 import { polygon, bsc, arbitrum, base, avalanche, moonbeam, mainnet as ethereum } from 'viem/chains';
+import { PaymentMethod } from '../endpoints/payment-methods.endpoints';
 
 export type DestinationType = Networks | PaymentMethod;
 
@@ -113,13 +113,14 @@ export function isNetworkAssetHub(network: Networks): network is Networks.AssetH
   return getNetworkMetadata(network)?.id === ASSETHUB_CHAIN_ID;
 }
 
-export function getNetworkId(network: Networks): number | undefined {
-  return getNetworkMetadata(network)?.id;
+export function getNetworkId(network: Networks): number;
+export function getNetworkId(network: unknown): number | undefined;
+export function getNetworkId(network: Networks | unknown): number | undefined {
+  return getNetworkMetadata(network as Networks)?.id;
 }
 
-export function getNetworkDisplayName(network: Networks): string | undefined {
-  return getNetworkMetadata(network)?.displayName;
+export function getNetworkDisplayName(network: Networks): string;
+export function getNetworkDisplayName(network: unknown): string | undefined;
+export function getNetworkDisplayName(network: Networks | unknown): string | undefined {
+  return getNetworkMetadata(network as Networks)?.displayName;
 }
-
-
-

--- a/shared/src/tokens/utils/helpers.ts
+++ b/shared/src/tokens/utils/helpers.ts
@@ -5,13 +5,13 @@
 import { RampCurrency, FiatToken, OnChainToken } from '../types/base';
 import { EvmToken } from '../types/evm';
 import { AssetHubToken } from '../types/base';
-import { TokenDetails, OnChainTokenDetails, FiatTokenDetails } from './typeGuards';
+import { OnChainTokenDetails, FiatTokenDetails } from './typeGuards';
 import { evmTokenConfig } from '../evm/config';
 import { assetHubTokenConfig } from '../assethub/config';
 import { stellarTokenConfig } from '../stellar/config';
 import { moonbeamTokenConfig } from '../moonbeam/config';
 import { MoonbeamTokenDetails } from '../types/moonbeam';
-import { Networks, PaymentMethod } from '../../helpers';
+import { Networks } from '../../helpers';
 import { StellarTokenDetails } from '../types/stellar';
 
 /**


### PR DESCRIPTION
Add:
- [x] `/supported-payment-methods` with params: `type={ sell (default) | buy }`, `fiat={ ars, brl, eur }`

Example response:
```
{
    paymentMethods: [
      { id: 'sepa', name: 'SEPA', supportedFiats: ['eurc'], limits: { min: 10, max: 50000 } },
      { id: 'pix', name: 'PIX', supportedFiats: ['brl'], limits: { min: 1, max: 500000 } },
      { id: 'cbu', name: 'CBU', supportedFiats: ['ars'], limits: { min: 1, max: 500000 } },
    ],
};
```

- [x] `supported-cryptocurrencies` with params: `network={ polygon(default), assethub... ...base }`

Example response:
```
{
    cryptocurrencies: [
      {
        assetSymbol: 'USDC',
        assetContractAddress: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
        assetNetwork: 'polygon',
        assetDecimals: 6,
      },
      {
        assetSymbol: 'USDT',
        assetContractAddress: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
        assetNetwork: 'polygon',
        assetDecimals: 6,
      },
      {
        assetSymbol: 'USDC.e',
        assetContractAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
        assetNetwork: 'polygon',
        assetDecimals: 6,
      },
    ],
  };
  ```

For the implementation I used the tokens already defined in the `shared` so we have only one-source-of-truth for the tokens config.