### PR TITLE
Improve vortex rate display

### DIFF
--- a/frontend/src/components/RampFeeCollapse/index.tsx
+++ b/frontend/src/components/RampFeeCollapse/index.tsx
@@ -23,13 +23,16 @@ function calculateInterbankExchangeRate(
   const inputAmount = Big(inputAmountString);
   const outputAmount = Big(outputAmountString);
 
+  let effectiveInputAmount = inputAmount;
+  let effectiveOutputAmount = outputAmount;
+
   if (rampType === 'on') {
-    const inputAmountWithoutFees = inputAmount.minus(fee.total);
-    return inputAmountWithoutFees.gt(0) ? outputAmount.div(inputAmountWithoutFees).toNumber() : 0;
+    effectiveInputAmount = inputAmount.minus(fee.total);
   } else {
-    const outputAmountWithoutFees = outputAmount.plus(fee.total);
-    return inputAmount.gt(0) ? outputAmountWithoutFees.div(inputAmount).toNumber() : 0;
+    effectiveOutputAmount = outputAmount.plus(fee.total);
   }
+
+  return effectiveInputAmount.gt(0) ? effectiveOutputAmount.div(effectiveInputAmount).toNumber() : 0;
 }
 
 // Calculate all-in exchange rate

--- a/frontend/src/components/RampFeeCollapse/index.tsx
+++ b/frontend/src/components/RampFeeCollapse/index.tsx
@@ -4,12 +4,40 @@ import { useQuote } from '../../stores/ramp/useQuoteStore';
 import { useFiatToken, useOnChainToken } from '../../stores/ramp/useRampFormStore';
 import { useRampDirection } from '../../stores/rampDirectionStore';
 import { RampDirection } from '../RampToggle';
-import { ArrowDownIcon, InformationCircleIcon } from '@heroicons/react/20/solid';
+import { InformationCircleIcon } from '@heroicons/react/20/solid';
+import { QuoteEndpoints } from 'shared';
 
 interface FeeItem {
   label: string;
   tooltip?: string;
   value: string;
+}
+
+// This function calculates the interbank exchange rate based on the quote response, neglecting any fees.
+function calculateInterbankExchangeRate(
+  rampType: string,
+  inputAmountString: Big.BigSource,
+  outputAmountString: Big.BigSource,
+  fee: QuoteEndpoints.FeeStructure,
+) {
+  const inputAmount = Big(inputAmountString);
+  const outputAmount = Big(outputAmountString);
+
+  if (rampType === 'on') {
+    const inputAmountWithoutFees = inputAmount.minus(fee.total);
+    return inputAmountWithoutFees.gt(0) ? outputAmount.div(inputAmountWithoutFees).toNumber() : 0;
+  } else {
+    const outputAmountWithoutFees = outputAmount.plus(fee.total);
+    return inputAmount.gt(0) ? outputAmountWithoutFees.div(inputAmount).toNumber() : 0;
+  }
+}
+
+// Calculate all-in exchange rate
+function calculateNetExchangeRate(inputAmountString: Big.BigSource, outputAmountString: Big.BigSource) {
+  const inputAmount = Big(inputAmountString);
+  const outputAmount = Big(outputAmountString);
+
+  return inputAmount.gt(0) ? outputAmount.div(inputAmount).toNumber() : 0;
 }
 
 export function RampFeeCollapse() {
@@ -24,21 +52,23 @@ export function RampFeeCollapse() {
   const quote = availableQuote
     ? availableQuote
     : {
+        rampType: 'on',
         inputAmount: 0,
         outputAmount: 0,
         inputCurrency: rampDirection === RampDirection.ONRAMP ? fiatToken : onChainToken,
         outputCurrency: rampDirection === RampDirection.ONRAMP ? onChainToken : fiatToken,
-        fee: { total: 0, network: 0, vortex: 0, anchor: 0, partnerMarkup: 0, currency: fiatToken },
+        fee: { total: '0', network: '0', vortex: '0', anchor: '0', partnerMarkup: '0', currency: fiatToken },
       };
 
-  // Calculate exchange rate
-  const inputAmount = Big(quote.inputAmount);
-  const outputAmount = Big(quote.outputAmount);
   const inputCurrency = quote.inputCurrency.toUpperCase();
   const outputCurrency = quote.outputCurrency.toUpperCase();
-
-  // Calculate exchange rate (how much outputCurrency you get for 1 inputCurrency)
-  const exchangeRate = inputAmount.gt(0) ? outputAmount.div(inputAmount).toNumber() : 0;
+  const interbankExchangeRate = calculateInterbankExchangeRate(
+    quote.rampType,
+    quote.inputAmount,
+    quote.outputAmount,
+    quote.fee,
+  );
+  const netExchangeRate = calculateNetExchangeRate(quote.inputAmount, quote.outputAmount);
 
   // Generate fee items for display
   const feeItems: FeeItem[] = [];
@@ -64,7 +94,7 @@ export function RampFeeCollapse() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-center text-sm text-gray-600">
-        {`1 ${inputCurrency} ≈ ${exchangeRate.toFixed(4)} ${outputCurrency}`}
+        {`1 ${inputCurrency} ≈ ${interbankExchangeRate.toFixed(4)} ${outputCurrency}`}
       </div>
       <div className="border border-blue-700 collapse-arrow collapse overflow-visible">
         <input type="checkbox" />
@@ -94,6 +124,19 @@ export function RampFeeCollapse() {
               <span>
                 {quote.fee.total} {quote.fee.currency.toUpperCase()}
               </span>
+            </div>
+          </div>
+          <div className="flex justify-between pt-2">
+            <div
+              className="tooltip tooltip-primary tooltip-top before:whitespace-pre-wrap before:content-[attr(data-tip)]"
+              data-tip={t('components.feeCollapse.netRate.tooltip')}
+            >
+              <strong className="flex items-center font-bold">
+                {t('components.feeCollapse.netRate.label')} <InformationCircleIcon className="w-4 h-4 ml-1" />
+              </strong>
+            </div>
+            <div className="flex">
+              <span>{`1 ${inputCurrency} ≈ ${netExchangeRate.toFixed(4)} ${outputCurrency}`}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -328,6 +328,10 @@
         "tooltip": "The cost to transfer funds to your wallet, which varies with selected network and network congestion."
       },
       "totalFee": "Total Fee",
+      "netRate": {
+        "label": "Effective Rate",
+        "tooltip": "This is the exchange rate you receive after all processing and network fees have been deducted."
+      },
       "finalAmount": "Final Amount"
     },
     "transactionStatusBanner": {

--- a/frontend/src/translations/pt.json
+++ b/frontend/src/translations/pt.json
@@ -326,6 +326,10 @@
         "label": "Taxa de rede",
         "tooltip": "O custo para transferir fundos para sua carteira, que varia conforme a rede selecionada e a congestão da rede."
       },
+      "netRate": {
+        "label": "Taxa Efetiva",
+        "tooltip": "Esta é a taxa de câmbio que você recebe após a dedução de todas as taxas de processamento e de rede."
+      },
       "totalFee": "Taxa total",
       "finalAmount": "Valor final"
     },

--- a/frontend/src/translations/pt.json
+++ b/frontend/src/translations/pt.json
@@ -327,7 +327,7 @@
         "tooltip": "O custo para transferir fundos para sua carteira, que varia conforme a rede selecionada e a congestão da rede."
       },
       "netRate": {
-        "label": "Taxa Efetiva",
+        "label": "Câmbio Efetiva",
         "tooltip": "Esta é a taxa de câmbio que você recebe após a dedução de todas as taxas de processamento e de rede."
       },
       "totalFee": "Taxa total",


### PR DESCRIPTION
This pull request enhances the `RampFeeCollapse` component by introducing calculations for both interbank and net exchange rates, updating the UI to display these rates, and adding corresponding translations. The changes aim to provide users with a clearer understanding of the exchange rates they receive, both before and after fees.

### Exchange Rate Calculations and Display:
* Added two new functions, `calculateInterbankExchangeRate` and `calculateNetExchangeRate`, to compute the interbank exchange rate (ignoring fees) and the net exchange rate (after deducting fees). (`frontend/src/components/RampFeeCollapse/index.tsx`, [frontend/src/components/RampFeeCollapse/index.tsxL7-R45](diffhunk://#diff-aafd6e84d4339f34656167d9a2bdae68368d7af12cd5338c718c46727d08e9feL7-R45))
* Updated the `RampFeeCollapse` component to calculate and display the interbank exchange rate in the main text and the net exchange rate in a new section with a tooltip. (`frontend/src/components/RampFeeCollapse/index.tsx`, [[1]](diffhunk://#diff-aafd6e84d4339f34656167d9a2bdae68368d7af12cd5338c718c46727d08e9feR58-R74) [[2]](diffhunk://#diff-aafd6e84d4339f34656167d9a2bdae68368d7af12cd5338c718c46727d08e9feL67-R100) [[3]](diffhunk://#diff-aafd6e84d4339f34656167d9a2bdae68368d7af12cd5338c718c46727d08e9feR132-R144)

### Translations:
* Added English translations for the net exchange rate label and tooltip. (`frontend/src/translations/en.json`, [frontend/src/translations/en.jsonR331-R334](diffhunk://#diff-0284357a540467f9b3e399aa03cd8a14989442c00b77d7f526eb4928900659a2R331-R334))
* Added Portuguese translations for the net exchange rate label and tooltip. (`frontend/src/translations/pt.json`, [frontend/src/translations/pt.jsonR329-R332](diffhunk://#diff-a5a11c1132c8bb939cc51c82ef80e25e90c36f2ea7c5d4a2c45041c512ac681bR329-R332))