### PR TITLE
Fix inputAmount used for remaining limit comparison for on and offramp

### DIFF
--- a/frontend/src/hooks/offramp/useSubmitRamp.ts
+++ b/frontend/src/hooks/offramp/useSubmitRamp.ts
@@ -83,7 +83,11 @@ export const useSubmitRamp = () => {
                   ? remainingLimitResponse.remainingLimitOfframp
                   : remainingLimitResponse.remainingLimitOnramp;
 
-              const amountNum = Number(executionInput.quote.inputAmount);
+              const amountNum = Number(
+                rampDirection === RampDirection.OFFRAMP
+                  ? executionInput.quote.outputAmount
+                  : executionInput.quote.inputAmount,
+              );
               const remainingLimitNum = Number(remainingLimitInUnits);
               if (amountNum > remainingLimitNum) {
                 // Check for a kyc level 1 here is implicit, due to checks in `useRampAmountWithinAllowedLimits` and


### PR DESCRIPTION
This pull request updates the `useSubmitRamp` hook to improve the calculation of `amountNum` by making it conditional on the ramp direction (`RampDirection.OFFRAMP` or `RampDirection.ONRAMP`).

Key change:

* [`frontend/src/hooks/offramp/useSubmitRamp.ts`](diffhunk://#diff-0018c5c5bdba4cc84de168b4ad2f3df159e417b2feadd34dd412bfc24c88b08bL86-R90): Modified the calculation of `amountNum` to use `executionInput.quote.outputAmount` for off-ramp transactions and `executionInput.quote.inputAmount` for on-ramp transactions, ensuring the correct value is used based on the ramp direction.