### PR TITLE
fix supported-payment-methods data format

### DIFF
--- a/apps/api/src/api/controllers/payment-methods.controller.ts
+++ b/apps/api/src/api/controllers/payment-methods.controller.ts
@@ -26,8 +26,8 @@ function getPaymentMethodsByType(type: PaymentMethodType): PaymentMethodConfig[]
  * @param fiat - Fiat currency to filter by
  * @returns Filtered payment methods that support the specified fiat
  */
-function getPaymentMethodsByFiat(paymentMethods: PaymentMethodConfig[], fiat: FiatToken): PaymentMethodConfig[] {
-  return paymentMethods.filter((method) => method.supportedFiats.includes(fiat));
+function getPaymentMethodsByFiat(paymentMethods: PaymentMethodConfig[], fiatId: FiatToken): PaymentMethodConfig[] {
+  return paymentMethods.filter((method) => method.supportedFiats.some((supportedFiat) => supportedFiat.id === fiatId));
 }
 
 export const getSupportedPaymentMethods = async (

--- a/apps/api/src/config/payment-methods.config.ts
+++ b/apps/api/src/config/payment-methods.config.ts
@@ -1,33 +1,48 @@
 import { FiatToken, PaymentMethodConfig, PaymentMethodName, PaymentMethodType } from '@packages/shared';
 
-const SEPA_PAYMENT_METHOD: PaymentMethodConfig = {
-  id: 'sepa',
-  name: PaymentMethodName.SEPA,
-  supportedFiats: [FiatToken.EURC],
+const EUR = {
+  id: FiatToken.EURC,
+  name: 'Euro',
   limits: {
     min: 10,
     max: 50000,
   },
 };
 
+const BRL = {
+  id: FiatToken.BRL,
+  name: 'Brazilian Real',
+  limits: {
+    min: 10,
+    max: 50000,
+  },
+};
+
+const ARS = {
+  id: FiatToken.ARS,
+  name: 'Argentine Peso',
+  limits: {
+    min: 10,
+    max: 50000,
+  },
+};
+
+const SEPA_PAYMENT_METHOD: PaymentMethodConfig = {
+  id: 'sepa',
+  name: PaymentMethodName.SEPA,
+  supportedFiats: [EUR],
+};
+
 const PIX_PAYMENT_METHOD: PaymentMethodConfig = {
   id: 'pix',
   name: PaymentMethodName.PIX,
-  supportedFiats: [FiatToken.BRL],
-  limits: {
-    min: 1,
-    max: 500000,
-  },
+  supportedFiats: [BRL],
 };
 
 const CBU_PAYMENT_METHOD: PaymentMethodConfig = {
   id: 'cbu',
   name: PaymentMethodName.CBU,
-  supportedFiats: [FiatToken.ARS],
-  limits: {
-    min: 1,
-    max: 500000,
-  },
+  supportedFiats: [ARS],
 };
 
 export const PAYMENT_METHODS_CONFIG: Record<PaymentMethodType, PaymentMethodConfig[]> = {

--- a/packages/shared/src/endpoints/payment-methods.endpoints.ts
+++ b/packages/shared/src/endpoints/payment-methods.endpoints.ts
@@ -20,11 +20,16 @@ export interface PaymentMethodLimits {
   max: number;
 }
 
+export interface PaymentMethodConfigFiatToken {
+  id: FiatToken;
+  name: string;
+  limits: PaymentMethodLimits;
+}
+
 export interface PaymentMethodConfig {
   id: PaymentMethod;
   name: PaymentMethodName;
-  supportedFiats: FiatToken[];
-  limits: PaymentMethodLimits;
+  supportedFiats: PaymentMethodConfigFiatToken[];
 }
 
 export interface GetSupportedPaymentMethodsRequest {


### PR DESCRIPTION
Refactored `supported-payment-methods` endpoint data format.

Before:
```
paymentMethods: [
      { id: 'sepa', name: 'SEPA', supportedFiats: ['eur'], limits: { min: 10, max: 50000 } },
      { id: 'pix', name: 'PIX', supportedFiats: ['brl'], limits: { min: 1, max: 500000 } },
      { id: 'cbu', name: 'CBU', supportedFiats: ['ars'], limits: { min: 1, max: 500000 } },
    ]
```

After:
```
paymentMethods: [
  { id: 'sepa', name: 'SEPA', supportedFiats: [{
  	id: 'eur',
    name: 'EURO',
    limits: { min: 10, max: 50000 }
  }]
  },
  { id: 'pix', name: 'PIX', supportedFiats: [{
  	id: 'brl',
    name: 'Brazilian Real',
    limits: { min: 1, max: 500000 }
  }]
  },
  { id: 'cbu', name: 'CBU', supportedFiats: [{
    id: 'ars',
    name: 'Argentine Peso',
    limits: { min: 1, max: 500000 }
  }]
  },
]
```