### PR TITLE
Update the default state of the app

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/apps/frontend/src/helpers/path/index.tsx
+++ b/apps/frontend/src/helpers/path/index.tsx
@@ -1,4 +1,5 @@
 import { RampDirection } from '../../components/RampToggle';
+import { Language, getLanguageFromPath } from '../../translations/helpers';
 
 const DEFAULT_RAMP_DIRECTION = RampDirection.ONRAMP;
 
@@ -10,7 +11,12 @@ const getRampDirectionFromPath = (): RampDirection => {
   const params = new URLSearchParams(window.location.search);
   const rampParam = params.get('ramp')?.toLowerCase();
 
-  const rampDirection = rampParam === 'sell' ? RampDirection.OFFRAMP : RampDirection.ONRAMP;
+  const rampDirection =
+    rampParam === 'buy'
+      ? RampDirection.ONRAMP
+      : getLanguageFromPath() === Language.Portuguese_Brazil
+        ? RampDirection.ONRAMP
+        : RampDirection.OFFRAMP;
 
   return rampDirection;
 };

--- a/apps/frontend/src/hooks/useRampUrlParams.ts
+++ b/apps/frontend/src/hooks/useRampUrlParams.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_BRL_AMOUNT,
   DEFAULT_EURC_AMOUNT,
   DEFAULT_EVM_ONCHAIN_TOKEN,
+  defaultFiatTokenAmounts,
   useRampFormStoreActions,
 } from '../stores/ramp/useRampFormStore';
 import { useRampDirection, useRampDirectionToggle } from '../stores/rampDirectionStore';
@@ -23,12 +24,6 @@ interface RampUrlParams {
   fromAmount?: string;
   partnerId?: string;
 }
-
-const defaultFiatTokenAmounts: Record<FiatToken, string> = {
-  eur: DEFAULT_EURC_AMOUNT,
-  ars: DEFAULT_ARS_AMOUNT,
-  brl: DEFAULT_BRL_AMOUNT,
-};
 
 function findFiatToken(fiatToken?: string, rampDirection?: RampDirection): FiatToken | undefined {
   if (!fiatToken) {

--- a/apps/frontend/src/hooks/useRampUrlParams.ts
+++ b/apps/frontend/src/hooks/useRampUrlParams.ts
@@ -5,15 +5,7 @@ import { getFirstEnabledFiatToken, isFiatTokenEnabled } from '../config/tokenAva
 import { useNetwork } from '../contexts/network';
 import { DEFAULT_RAMP_DIRECTION } from '../helpers/path';
 import { useSetPartnerId } from '../stores/partnerStore';
-import {
-  DEFAULT_ARS_AMOUNT,
-  DEFAULT_ASSETHUB_ONCHAIN_TOKEN,
-  DEFAULT_BRL_AMOUNT,
-  DEFAULT_EURC_AMOUNT,
-  DEFAULT_EVM_ONCHAIN_TOKEN,
-  defaultFiatTokenAmounts,
-  useRampFormStoreActions,
-} from '../stores/ramp/useRampFormStore';
+import { defaultFiatTokenAmounts, useRampFormStoreActions } from '../stores/ramp/useRampFormStore';
 import { useRampDirection, useRampDirectionToggle } from '../stores/rampDirectionStore';
 
 interface RampUrlParams {
@@ -59,7 +51,7 @@ function findOnChainToken(tokenStr?: string, networkType?: Networks | string): O
     const matchedToken = assetHubTokenEntries.find(([_, token]) => token.toLowerCase() === tokenStr);
 
     if (!matchedToken) {
-      return DEFAULT_ASSETHUB_ONCHAIN_TOKEN;
+      return AssetHubToken.USDC;
     }
 
     const [_, tokenValue] = matchedToken;
@@ -69,7 +61,7 @@ function findOnChainToken(tokenStr?: string, networkType?: Networks | string): O
     const matchedToken = evmTokenEntries.find(([_, token]) => token.toLowerCase() === tokenStr);
 
     if (!matchedToken) {
-      return DEFAULT_EVM_ONCHAIN_TOKEN;
+      return EvmToken.USDC;
     }
 
     const [_, tokenValue] = matchedToken;

--- a/apps/frontend/src/stores/ramp/useRampFormStore.ts
+++ b/apps/frontend/src/stores/ramp/useRampFormStore.ts
@@ -9,11 +9,20 @@ export const DEFAULT_BRL_AMOUNT = '100';
 export const DEFAULT_EURC_AMOUNT = '20';
 export const DEFAULT_ARS_AMOUNT = '20';
 
+export const defaultFiatTokenAmounts: Record<FiatToken, string> = {
+  [FiatToken.EURC]: DEFAULT_EURC_AMOUNT,
+  [FiatToken.ARS]: DEFAULT_ARS_AMOUNT,
+  [FiatToken.BRL]: DEFAULT_BRL_AMOUNT,
+};
+
 export const DEFAULT_ASSETHUB_ONCHAIN_TOKEN = AssetHubToken.USDC;
 export const DEFAULT_EVM_ONCHAIN_TOKEN = EvmToken.USDC;
 
 const defaultFiatToken =
   getLanguageFromPath() === Language.Portuguese_Brazil ? DEFAULT_PT_BR_TOKEN : DEFAULT_FIAT_TOKEN;
+
+const defaultFiatAmount =
+  getLanguageFromPath() === Language.Portuguese_Brazil ? DEFAULT_BRL_AMOUNT : defaultFiatTokenAmounts[defaultFiatToken];
 
 interface RampFormState {
   inputAmount?: string;
@@ -38,7 +47,7 @@ interface RampFormActions {
 const storedNetwork = localStorage.getItem('SELECTED_NETWORK');
 
 export const DEFAULT_RAMP_FORM_STORE_VALUES: RampFormState = {
-  inputAmount: DEFAULT_BRL_AMOUNT,
+  inputAmount: defaultFiatAmount,
   onChainToken: storedNetwork !== null && storedNetwork === Networks.AssetHub ? EvmToken.USDC : EvmToken.USDT,
   fiatToken: defaultFiatToken,
   taxId: undefined,

--- a/apps/frontend/src/stores/ramp/useRampFormStore.ts
+++ b/apps/frontend/src/stores/ramp/useRampFormStore.ts
@@ -1,5 +1,7 @@
 import { AssetHubToken, EvmToken, FiatToken, Networks, OnChainToken, getOnChainTokenDetails } from '@packages/shared';
 import { create } from 'zustand';
+import { RampDirection } from '../../components/RampToggle';
+import { getRampDirectionFromPath } from '../../helpers/path';
 import { Language, getLanguageFromPath } from '../../translations/helpers';
 
 export const DEFAULT_FIAT_TOKEN = FiatToken.EURC;
@@ -15,14 +17,20 @@ export const defaultFiatTokenAmounts: Record<FiatToken, string> = {
   [FiatToken.BRL]: DEFAULT_BRL_AMOUNT,
 };
 
-export const DEFAULT_ASSETHUB_ONCHAIN_TOKEN = AssetHubToken.USDC;
-export const DEFAULT_EVM_ONCHAIN_TOKEN = EvmToken.USDC;
-
 const defaultFiatToken =
   getLanguageFromPath() === Language.Portuguese_Brazil ? DEFAULT_PT_BR_TOKEN : DEFAULT_FIAT_TOKEN;
 
 const defaultFiatAmount =
   getLanguageFromPath() === Language.Portuguese_Brazil ? DEFAULT_BRL_AMOUNT : defaultFiatTokenAmounts[defaultFiatToken];
+
+const storedNetwork = localStorage.getItem('SELECTED_NETWORK');
+
+const defaultOnChainToken =
+  getRampDirectionFromPath() === RampDirection.ONRAMP
+    ? storedNetwork === Networks.AssetHub
+      ? AssetHubToken.USDC
+      : EvmToken.USDT
+    : EvmToken.USDC;
 
 interface RampFormState {
   inputAmount?: string;
@@ -44,11 +52,9 @@ interface RampFormActions {
   };
 }
 
-const storedNetwork = localStorage.getItem('SELECTED_NETWORK');
-
 export const DEFAULT_RAMP_FORM_STORE_VALUES: RampFormState = {
   inputAmount: defaultFiatAmount,
-  onChainToken: storedNetwork !== null && storedNetwork === Networks.AssetHub ? EvmToken.USDC : EvmToken.USDT,
+  onChainToken: defaultOnChainToken,
   fiatToken: defaultFiatToken,
   taxId: undefined,
   pixId: undefined,


### PR DESCRIPTION
This pull request introduces several changes to improve code readability, standardize configurations, and enhance functionality in handling language-specific defaults. The most important changes include updates to the `.prettierrc` file for consistent formatting, adjustments to ramp direction logic based on language, and refactoring of default fiat token amounts for better maintainability.

### Code formatting and configuration:

* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2R1-R8): Added a configuration file to enforce consistent code formatting, including rules for semicolons, trailing commas, single quotes, and print width.

### Ramp direction logic improvements:

* [`apps/frontend/src/helpers/path/index.tsx`](diffhunk://#diff-4ac51ced9b890244282de7f65870cbdbbf2e180451c45678712bcdba6114c08eL13-R19): Updated the `getRampDirectionFromPath` function to account for language-specific behavior. If the language is Portuguese (Brazil), the ramp direction defaults to `ONRAMP`.

### Refactoring and maintainability:

* [`apps/frontend/src/stores/ramp/useRampFormStore.ts`](diffhunk://#diff-a81b54d312cb052f248c5bbc70a13939307048cc32a39c59d39bbecfeec9fbaeR12-R26): Refactored default fiat token amounts into a centralized `defaultFiatTokenAmounts` object for better maintainability. Introduced `defaultFiatAmount` to dynamically determine the default fiat amount based on language. [[1]](diffhunk://#diff-a81b54d312cb052f248c5bbc70a13939307048cc32a39c59d39bbecfeec9fbaeR12-R26) [[2]](diffhunk://#diff-a81b54d312cb052f248c5bbc70a13939307048cc32a39c59d39bbecfeec9fbaeL41-R50)
* [`apps/frontend/src/hooks/useRampUrlParams.ts`](diffhunk://#diff-9e7fd15d5c161f9ac851dabdb6536ed2b4b3af9ce67bc84763033f40ea41d0a3R14): Removed redundant `defaultFiatTokenAmounts` definition and imported the centralized version from `useRampFormStore`. [[1]](diffhunk://#diff-9e7fd15d5c161f9ac851dabdb6536ed2b4b3af9ce67bc84763033f40ea41d0a3R14) [[2]](diffhunk://#diff-9e7fd15d5c161f9ac851dabdb6536ed2b4b3af9ce67bc84763033f40ea41d0a3L27-L32)