### PR TITLE
Fix quote validation and improve error handling for input amount

### DIFF
--- a/apps/frontend/src/hooks/ramp/useRampValidation.ts
+++ b/apps/frontend/src/hooks/ramp/useRampValidation.ts
@@ -178,7 +178,7 @@ export const useRampValidation = () => {
   });
 
   const getCurrentErrorMessage = useCallback(() => {
-    if (quoteError) return quoteError;
+    if (quoteError) return t(quoteError);
 
     if (isDisconnected) return;
 

--- a/apps/frontend/src/stores/ramp/useQuoteStore.ts
+++ b/apps/frontend/src/stores/ramp/useQuoteStore.ts
@@ -27,7 +27,7 @@ interface QuotePayload {
 interface QuoteState {
   quote: QuoteResponse | undefined;
   loading: boolean;
-  error: string | null;
+  error: string | null; // This is either the error message or the key of the translation
   outputAmount: Big | undefined;
   exchangeRate: number;
   fetchQuote: (params: QuoteParams) => Promise<void>;
@@ -96,12 +96,11 @@ const processQuoteResponse = (quoteResponse: QuoteResponse) => {
 export const useQuoteStore = create<QuoteState>(set => ({
   error: null,
   exchangeRate: 0,
-
   fetchQuote: async (params: QuoteParams) => {
     const { inputAmount, partnerId } = params;
 
-    if (!inputAmount) {
-      set({ error: "Invalid input parameters", loading: false });
+    if (!inputAmount || inputAmount.eq(0)) {
+      set({ error: "pages.swap.error.invalidInputAmount", loading: false, outputAmount: Big(0), quote: undefined });
       return;
     }
 
@@ -130,7 +129,7 @@ export const useQuoteStore = create<QuoteState>(set => ({
       });
     } catch (error) {
       console.error("Error fetching quote:", error);
-      const errorMessage = error instanceof Error ? error.message : "Failed to get quote";
+      const errorMessage = error instanceof Error ? error.message : "pages.swap.error.fetchingQuote";
       set({
         error: errorMessage,
         loading: false,
@@ -142,7 +141,6 @@ export const useQuoteStore = create<QuoteState>(set => ({
   loading: false,
   outputAmount: undefined,
   quote: undefined,
-
   reset: () => {
     set({
       error: null,

--- a/apps/frontend/src/translations/en.json
+++ b/apps/frontend/src/translations/en.json
@@ -374,6 +374,7 @@
         "ARS_tokenUnavailable": "Improving your ARS exit - back shortly! ",
         "BRL_tokenUnavailable": "Improving your BRL exit - back shortly! ",
         "EURC_tokenUnavailable": "Improving your EUR exit - back shortly! ",
+        "fetchingQuote": "Failed to get quote",
         "gasWarning": "Please choose a smaller amount to ensure you can pay the gas cost of the transaction.",
         "initializeFailed": {
           "default": "We're experiencing a digital traffic jam. Please hold tight while we clear the road and get things moving again!",
@@ -383,6 +384,7 @@
         },
         "insufficientFunds": "Exceeds balance. Your balance is {{userInputTokenBalance}} {{assetSymbol}}",
         "insufficientLiquidity": "The amount is temporarily not available. Please, try with a smaller amount.",
+        "invalidInputAmount": "Invalid input amount",
         "lessThanMinimumWithdrawal": {
           "buy": "Minimum buy amount is {{minAmountUnits}} {{assetSymbol}}.",
           "sell": "Minimum sell amount is {{minAmountUnits}} {{assetSymbol}}."

--- a/apps/frontend/src/translations/pt.json
+++ b/apps/frontend/src/translations/pt.json
@@ -373,6 +373,7 @@
         "ARS_tokenUnavailable": "Ajustando sua saída ARS - em breve!",
         "BRL_tokenUnavailable": "Ajustando sua saída BRL - em breve!",
         "EURC_tokenUnavailable": "Ajustando sua saída EUR - em breve!",
+        "fetchingQuote": "Falha ao obter cotação",
         "gasWarning": "Escolha um valor menor para garantir que você consiga pagar o custo do gás da transação.",
         "initializeFailed": {
           "default": "Estamos enfrentando um congestionamento digital. Por favor, aguarde enquanto liberamos o caminho e fazemos as coisas funcionarem novamente!",
@@ -382,6 +383,7 @@
         },
         "insufficientFunds": "Saldo insuficiente. Seu saldo é {{userInputTokenBalance}} {{assetSymbol}}",
         "insufficientLiquidity": "O valor está temporariamente indisponível. Por favor, tente com um valor menor.",
+        "invalidInputAmount": "Valor de entrada inválido",
         "lessThanMinimumWithdrawal": {
           "buy": "O valor mínimo de compra é {{minAmountUnits}} {{assetSymbol}}.",
           "sell": "O valor mínimo de venda é {{minAmountUnits}} {{assetSymbol}}."


### PR DESCRIPTION
This pull request introduces changes to improve error handling and localization in the ramp validation and quote retrieval processes. Key updates include replacing hardcoded error messages with translatable keys, adding new translation entries, and refining input validation logic.

### Error Handling and Localization Improvements:
* Updated `useRampValidation` to return localized error messages by using the `t` function for translation (`apps/frontend/src/hooks/ramp/useRampValidation.ts`).
* Modified the `error` field in `QuoteState` to store either an error message or a translation key, enabling better localization (`apps/frontend/src/stores/ramp/useQuoteStore.ts`).
* Replaced hardcoded error messages with translation keys for invalid input amounts and failed quote retrieval in `useQuoteStore` (`apps/frontend/src/stores/ramp/useQuoteStore.ts`). [[1]](diffhunk://#diff-50ff6a0778ea52890e38f176479b5e7abd1cdd1d2887751fe112564ceb45ba99L99-R103) [[2]](diffhunk://#diff-50ff6a0778ea52890e38f176479b5e7abd1cdd1d2887751fe112564ceb45ba99L133-R132)

### Translation Additions:
* Added new translation entries for `fetchingQuote` and `invalidInputAmount` in English (`apps/frontend/src/translations/en.json`). [[1]](diffhunk://#diff-5299939190b7c8ef5d8f4cb57b5a73c4c520de4181a827d82d88a6ac9ca22181R377) [[2]](diffhunk://#diff-5299939190b7c8ef5d8f4cb57b5a73c4c520de4181a827d82d88a6ac9ca22181R387)
* Added corresponding translation entries for `fetchingQuote` and `invalidInputAmount` in Portuguese (`apps/frontend/src/translations/pt.json`). [[1]](diffhunk://#diff-1132459c669bcf90aa4f884760a2566b0d6073a834abfe55c06893c686da727dR376) [[2]](diffhunk://#diff-1132459c669bcf90aa4f884760a2566b0d6073a834abfe55c06893c686da727dR386)