### PR TITLE
add bypassGuardrails param

### DIFF
--- a/apps/api/src/api/services/transactions/squidrouter/route.ts
+++ b/apps/api/src/api/services/transactions/squidrouter/route.ts
@@ -16,6 +16,7 @@ export interface RouteParams {
   toChain: string;
   toToken: string;
   toAddress: string;
+  bypassGuardrails: boolean;
   slippageConfig: {
     autoMode: number;
   };
@@ -56,6 +57,7 @@ export function createOnrampRouteParams(
   const toChainId = getNetworkId(toNetwork);
 
   return {
+    bypassGuardrails: true,
     enableExpress: true,
     fromAddress,
     fromAmount: amount,
@@ -178,6 +180,7 @@ export function createOfframpRouteParams(
   });
 
   return {
+    bypassGuardrails: true,
     enableExpress: true,
     fromAddress,
     fromAmount: amount,
@@ -243,6 +246,7 @@ export function createGenericRouteParams(
   const toChainId = getNetworkId(toNetwork);
 
   return {
+    bypassGuardrails: true,
     enableExpress: true,
     fromAddress,
     fromAmount: amount,
@@ -266,11 +270,13 @@ export async function testRoute(
   const { fromChainId, toChainId, axlUSDC_MOONBEAM } = getSquidRouterConfig(fromNetwork);
 
   const sharedRouteParams: RouteParams = {
+    bypassGuardrails: true,
     enableExpress: true,
     fromAddress: address,
     fromAmount: attemptedAmountRaw,
     fromChain: fromChainId,
     fromToken: testingToken.erc20AddressSourceChain,
+
     slippageConfig: {
       autoMode: 1
     },


### PR DESCRIPTION
Apparently the getRoute squidrouter function is estimating wrong price of axlUSDC on Moonbeam due to the liquidity movement from V3 to V4 pool. If we turn on the degen mode the squidrouter allows us to get the correct quote.