### PR TITLE
Increase slippage threshold for squidrouter

### DIFF
--- a/packages/shared/src/services/squidrouter/route.ts
+++ b/packages/shared/src/services/squidrouter/route.ts
@@ -118,9 +118,9 @@ export async function getRoute(params: RouteParams): Promise<SquidrouterRouteRes
     const route = result.data.route;
     if (route.estimate?.aggregateSlippage !== undefined) {
       const slippage = route.estimate.aggregateSlippage;
-      if (slippage > 1) {
+      if (slippage > 2.5) {
         logger.current.error(`Received route with high slippage: ${slippage}%. Request ID: ${requestId}`);
-        throw new Error(`Received route with high slippage: ${slippage}%. Please try again later.`);
+        throw new Error(`The slippage of the route is too high: ${slippage}%. Please try again later.`);
       }
     }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the slippage threshold in the `getRoute` function, increasing the limit for what is considered "high slippage" and slightly rewording the error message.

- Increased the threshold for high slippage from 1% to 2.5% in the `getRoute` function, and updated the error message for clarity (`packages/shared/src/services/squidrouter/route.ts`).

Closes #833. 