### PR TITLE
Enable Avenia onramps and offramps

### DIFF
--- a/apps/api/src/api/controllers/brla.controller.ts
+++ b/apps/api/src/api/controllers/brla.controller.ts
@@ -181,7 +181,6 @@ export const getAveniaUserRemainingLimit = async (
       return;
     }
     const limitsData = await brlaApiService.getSubaccountUsedLimit(taxIdRecord.subAccountId);
-    console.log("Limits data from BRLA:", limitsData);
 
     if (!limitsData || !limitsData.limitInfo || !limitsData.limitInfo.limits) {
       res.status(httpStatus.NOT_FOUND).json({ error: "Limits not found" });

--- a/apps/api/src/api/controllers/brla.controller.ts
+++ b/apps/api/src/api/controllers/brla.controller.ts
@@ -193,7 +193,7 @@ export const getAveniaUserRemainingLimit = async (
 
     if (!brlLimits) {
       // Our current assumption is that BRL limits won't exist for an account without a KYC.
-      // But to be safe, we check the status and return a proper status.
+      // But to be safe, we check the status and return a proper error.
       const accountInfo = await brlaApiService.subaccountInfo(taxIdRecord.subAccountId);
       if (!accountInfo || accountInfo.accountInfo.identityStatus !== "CONFIRMED") {
         res.status(httpStatus.BAD_REQUEST).json({ error: "KYC invalid" });

--- a/apps/api/src/api/services/phases/handlers/brla-onramp-mint-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/brla-onramp-mint-handler.ts
@@ -3,7 +3,6 @@ import {
   BalanceCheckErrorType,
   checkEvmBalancePeriodically,
   FiatToken,
-  generateReferenceLabel,
   getAnyFiatTokenDetailsMoonbeam,
   Networks,
   RampPhase
@@ -21,16 +20,16 @@ const EVM_BALANCE_CHECK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 // Phase description: wait for the tokens to arrive at the Moonbeam ephemeral address.
 // If the timeout is reached, we assume the user has NOT made the payment and we cancel the ramp.
-export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
+export class BrlaOnrampMintHandler extends BasePhaseHandler {
   public getPhaseName(): RampPhase {
-    return "brlaTeleport";
+    return "brlaOnrampMint";
   }
 
   protected async executePhase(state: RampState): Promise<RampState> {
     const { moonbeamEphemeralAddress, inputAmountBeforeSwapRaw } = state.state as StateMetadata;
 
     if (!moonbeamEphemeralAddress || !inputAmountBeforeSwapRaw) {
-      throw new Error("BrlaTeleportPhaseHandler: State metadata corrupted. This is a bug.");
+      throw new Error("BrlaOnrampMintHandler: State metadata corrupted. This is a bug.");
     }
 
     try {
@@ -55,7 +54,7 @@ export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
       }
 
       throw isCheckTimeout
-        ? this.createRecoverableError(`BrlaTeleportPhaseHandler: phase timeout reached with error: ${error}`)
+        ? this.createRecoverableError(`BrlaOnrampMintHandler: phase timeout reached with error: ${error}`)
         : new Error(`Error checking Moonbeam balance: ${error}`);
     }
 
@@ -65,7 +64,7 @@ export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
   protected isPaymentTimeoutReached(state: RampState): boolean {
     const thisPhaseEntry = state.phaseHistory.find(phaseHistoryEntry => phaseHistoryEntry.phase === this.getPhaseName());
     if (!thisPhaseEntry) {
-      throw new Error("BrlaTeleportPhaseHandler: Phase not found in history. State corrupted.");
+      throw new Error("BrlaOnrampMintHandler: Phase not found in history. State corrupted.");
     }
 
     const initialTimestamp = new Date(thisPhaseEntry.timestamp);
@@ -76,4 +75,4 @@ export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
   }
 }
 
-export default new BrlaTeleportPhaseHandler();
+export default new BrlaOnrampMintHandler();

--- a/apps/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
@@ -52,7 +52,7 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
 
     // We need to check for existing ticket, recovery scenario
     if (payOutTicketId) {
-      await this.checkTicketStatus({ subAccountId: taxIdRecord.subAccountId, ticketId: payOutTicketId });
+      await this.checkTicketStatusPaid({ subAccountId: taxIdRecord.subAccountId, ticketId: payOutTicketId });
       return this.transitionToNextPhase(state, "complete");
     }
 
@@ -129,8 +129,7 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
         }
       });
 
-      // Avenia migration: implement a wait and check after the request, or ticket follow-up.
-      await this.checkTicketStatus({ subAccountId: taxIdRecord.subAccountId, ticketId: payOutTicketId });
+      await this.checkTicketStatusPaid({ subAccountId: taxIdRecord.subAccountId, ticketId: payOutTicketId });
       return this.transitionToNextPhase(state, "complete");
     } catch (e) {
       console.error("Error in brlaPayoutOnMoonbeam", e);
@@ -138,7 +137,7 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
     }
   }
 
-  protected async checkTicketStatus({
+  protected async checkTicketStatusPaid({
     ticketId,
     subAccountId
   }: {

--- a/apps/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
@@ -87,7 +87,8 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
       const amountForQuote = amount.round(2, 0); // Round down to 2 decimal places
       const payOutQuote = await brlaApiService.createPayOutQuote({
         outputAmount: amountForQuote.toString(),
-        outputThirdParty: false
+        outputThirdParty: false,
+        subAccountId: taxIdRecord.subAccountId
       });
 
       logger.debug("Debug: payOutQuote", payOutQuote);

--- a/apps/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/brla-payout-moonbeam-handler.ts
@@ -48,10 +48,11 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
       outputTokenType,
       receiverTaxId,
       moonbeamEphemeralAddress,
-      payOutTicketId
+      payOutTicketId,
+      outputAmount
     } = state.state as StateMetadata;
 
-    if (!taxId || !pixDestination || !outputAmountBeforeFinalStep || !outputTokenType) {
+    if (!taxId || !pixDestination || !outputAmountBeforeFinalStep || !outputTokenType || !outputAmount) {
       throw new Error("BrlaPayoutOnMoonbeamPhaseHandler: State metadata corrupted. This is a bug.");
     }
 
@@ -128,7 +129,7 @@ export class BrlaPayoutOnMoonbeamPhaseHandler extends BasePhaseHandler {
     await pollForSufficientBalance();
 
     try {
-      const amount = new Big(outputAmountBeforeFinalStep.units);
+      const amount = new Big(outputAmount);
       const subaccount = await brlaApiService.subaccountInfo(taxIdRecord.subAccountId);
       if (!subaccount) {
         throw new Error("BrlaPayoutOnMoonbeamPhaseHandler: Subaccount must exist.");

--- a/apps/api/src/api/services/phases/handlers/brla-teleport-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/brla-teleport-handler.ts
@@ -19,15 +19,17 @@ import { StateMetadata } from "../meta-state-types";
 const PAYMENT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const EVM_BALANCE_CHECK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+// Phase description: wait for the tokens to arrive at the Moonbeam ephemeral address.
+// If the timeout is reached, we assume the user has NOT made the payment and we cancel the ramp.
 export class BrlaTeleportPhaseHandler extends BasePhaseHandler {
   public getPhaseName(): RampPhase {
     return "brlaTeleport";
   }
 
   protected async executePhase(state: RampState): Promise<RampState> {
-    const { taxId, moonbeamEphemeralAddress, inputAmountUnits, inputAmountBeforeSwapRaw } = state.state as StateMetadata;
+    const { moonbeamEphemeralAddress, inputAmountBeforeSwapRaw } = state.state as StateMetadata;
 
-    if (!taxId || !moonbeamEphemeralAddress || !inputAmountUnits || !inputAmountBeforeSwapRaw) {
+    if (!moonbeamEphemeralAddress || !inputAmountBeforeSwapRaw) {
       throw new Error("BrlaTeleportPhaseHandler: State metadata corrupted. This is a bug.");
     }
 

--- a/apps/api/src/api/services/phases/handlers/initial-phase-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/initial-phase-handler.ts
@@ -34,7 +34,7 @@ export class InitialPhaseHandler extends BasePhaseHandler {
     }
 
     if (state.type === RampDirection.BUY && state.state.inputCurrency === FiatToken.BRL) {
-      return this.transitionToNextPhase(state, "brlaTeleport");
+      return this.transitionToNextPhase(state, "brlaOnrampMint");
     } else if (state.type === RampDirection.BUY && state.state.inputCurrency === FiatToken.EURC) {
       return this.transitionToNextPhase(state, "moneriumOnrampMint");
     }

--- a/apps/api/src/api/services/phases/handlers/monerium-onramp-mint-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/monerium-onramp-mint-handler.ts
@@ -11,7 +11,7 @@ import RampState from "../../../../models/rampState.model";
 import { BasePhaseHandler } from "../base-phase-handler";
 import { StateMetadata } from "../meta-state-types";
 
-// Same rationale as in brla-teleport-handler.ts
+// Same rationale as in brla-onramp-mint-handler.ts
 const PAYMENT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const EVM_BALANCE_CHECK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 

--- a/apps/api/src/api/services/phases/meta-state-types.ts
+++ b/apps/api/src/api/services/phases/meta-state-types.ts
@@ -46,6 +46,7 @@ export interface StateMetadata {
   unhandledPaymentAlertSent: boolean;
   pendulumToMoonbeamXcmHash?: string;
   depositQrCode: string | undefined;
+  payOutTicketId: string | undefined;
   // Only used in onramp, offramp - monerium
   polygonEphemeralAddress: string;
   ibanPaymentData: IbanPaymentData;

--- a/apps/api/src/api/services/phases/register-handlers.ts
+++ b/apps/api/src/api/services/phases/register-handlers.ts
@@ -1,6 +1,6 @@
 import logger from "../../../config/logger";
+import brlaOnrampMintHandler from "./handlers/brla-onramp-mint-handler";
 import brlaPayoutMoonbeamHandler from "./handlers/brla-payout-moonbeam-handler";
-import brlaTeleportHandler from "./handlers/brla-teleport-handler";
 import distributeFeesHandler from "./handlers/distribute-fees-handler";
 import fundEphemeralHandler from "./handlers/fund-ephemeral-handler";
 import initialPhaseHandler from "./handlers/initial-phase-handler";
@@ -39,7 +39,7 @@ export function registerPhaseHandlers(): void {
   phaseRegistry.registerHandler(brlaPayoutMoonbeamHandler);
   phaseRegistry.registerHandler(moonbeamToPendulumXcmHandler);
   phaseRegistry.registerHandler(fundEphemeralHandler);
-  phaseRegistry.registerHandler(brlaTeleportHandler);
+  phaseRegistry.registerHandler(brlaOnrampMintHandler);
   phaseRegistry.registerHandler(pendulumToAssethubPhaseHandler);
   phaseRegistry.registerHandler(squidRouterPayPhaseHandler);
   phaseRegistry.registerHandler(distributeFeesHandler);

--- a/apps/api/src/api/services/ramp/ramp.service.ts
+++ b/apps/api/src/api/services/ramp/ramp.service.ts
@@ -625,22 +625,21 @@ export class RampService extends BaseRampService {
     }
 
     // To make it harder to extract information, both the pixKey and the receiverTaxId are required to be correct.
-    // try {
-    //   //const pixKeyData = await brlaApiService.validatePixKey(pixKey);
-
-    //   //validate the recipient's taxId with partial information
-    //   if (!validateMaskedNumber(pixKeyData.taxId, receiverTaxId)) {
-    //     throw new APIError({
-    //       message: "Invalid pixKey or receiverTaxId.",
-    //       status: httpStatus.BAD_REQUEST
-    //     });
-    //   }
-    // } catch (_error) {
-    //   throw new APIError({
-    //     message: "Invalid pixKey or receiverTaxId.",
-    //     status: httpStatus.BAD_REQUEST
-    //   });
-    // }
+    try {
+      const pixKeyData = await brlaApiService.validatePixKey(pixKey);
+      //validate the recipient's taxId with partial information
+      if (!validateMaskedNumber(pixKeyData.taxId, receiverTaxId)) {
+        throw new APIError({
+          message: "Invalid pixKey or receiverTaxId.",
+          status: httpStatus.BAD_REQUEST
+        });
+      }
+    } catch (_error) {
+      throw new APIError({
+        message: "Invalid pixKey or receiverTaxId.",
+        status: httpStatus.BAD_REQUEST
+      });
+    }
 
     const brlLimits = subaccountLimits.limitInfo.limits.find(limit => limit.currency === BrlaCurrency.BRL);
     if (!brlLimits) {

--- a/apps/api/src/api/services/ramp/ramp.service.ts
+++ b/apps/api/src/api/services/ramp/ramp.service.ts
@@ -650,7 +650,7 @@ export class RampService extends BaseRampService {
       });
     }
 
-    if (Number(amount) > Number(brlLimits.maxFiatOut)) {
+    if (Number(amount) > Number(brlLimits.maxFiatOut) - Number(brlLimits.usedLimit.usedFiatOut)) {
       throw new APIError({
         message: "Amount exceeds limit.",
         status: httpStatus.BAD_REQUEST
@@ -697,9 +697,9 @@ export class RampService extends BaseRampService {
         status: httpStatus.BAD_REQUEST
       });
     }
-    const { maxFiatIn } = brlaLimits[0] || {};
+    const { maxFiatIn, usedLimit } = brlaLimits[0] || {};
 
-    if (Number(amount) > Number(maxFiatIn)) {
+    if (Number(amount) > Number(maxFiatIn) - Number(usedLimit.usedFiatIn)) {
       throw new APIError({
         message: "Amount exceeds KYC limits.",
         status: httpStatus.BAD_REQUEST

--- a/apps/api/src/api/services/ramp/ramp.service.ts
+++ b/apps/api/src/api/services/ramp/ramp.service.ts
@@ -1,8 +1,8 @@
 import {
   AccountMeta,
+  AveniaPaymentMethod,
   BrlaApiService,
   BrlaCurrency,
-  BrlaPaymentMethod,
   EvmNetworks,
   FiatToken,
   GetRampHistoryResponse,
@@ -686,26 +686,30 @@ export class RampService extends BaseRampService {
     const aveniaQuote = await brlaApiService.createPayInQuote({
       inputAmount: String(amount),
       inputCurrency: BrlaCurrency.BRL,
-      inputPaymentMethod: BrlaPaymentMethod.PIX,
+      inputPaymentMethod: AveniaPaymentMethod.PIX,
       inputThirdParty: false,
       outputCurrency: BrlaCurrency.BRLA,
-      outputPaymentMethod: BrlaPaymentMethod.MOONBEAM,
+      outputPaymentMethod: AveniaPaymentMethod.MOONBEAM,
       outputThirdParty: false,
       subAccountId: taxIdRecord.subAccountId
     });
     console.log("DEBUG: created avenia quote: ", aveniaQuote);
-    const aveniaTicket = await brlaApiService.createPixInputTicket({
-      quoteToken: aveniaQuote.quoteToken,
-      ticketBlockchainOutput: {
-        walletAddress: moonbeamEphemeralAddress,
-        walletChain: "Moonbeam"
+    const aveniaTicket = await brlaApiService.createPixInputTicket(
+      {
+        quoteToken: aveniaQuote.quoteToken,
+        ticketBlockchainOutput: {
+          walletAddress: moonbeamEphemeralAddress,
+          walletChain: AveniaPaymentMethod.MOONBEAM
+        },
+        ticketBrlPixInput: {
+          additionalData: generateReferenceLabel(quote)
+        }
       },
-      ticketBrlPixInput: {
-        additionalData: generateReferenceLabel(quote)
-      }
-    });
+      taxIdRecord.subAccountId
+    );
+
     console.log("DEBUG: created avenia ticket: ", aveniaTicket);
-    return { aveniaTicketId: aveniaTicket.ticket.id, brCode: aveniaTicket.brlPixInputInfo.brCode };
+    return { aveniaTicketId: aveniaTicket.id, brCode: aveniaTicket.brCode };
   }
 }
 

--- a/apps/frontend/src/hooks/ramp/useRampSubmission.ts
+++ b/apps/frontend/src/hooks/ramp/useRampSubmission.ts
@@ -124,7 +124,7 @@ export const useRampSubmission = () => {
         if (!data) {
           throw new Error("Invalid ramp data.");
         }
-
+        console.log("DEBUG: Ramp Submission Data: ", data);
         const executionInput = prepareExecutionInput(data);
 
         // This callback is generic and used for any ramp type.

--- a/apps/frontend/src/machines/ramp.machine.ts
+++ b/apps/frontend/src/machines/ramp.machine.ts
@@ -1,4 +1,4 @@
-import { RampDirection } from "@packages/shared";
+import { FiatToken, RampDirection } from "@packages/shared";
 import { WalletAccount } from "@talismn/connect-wallets";
 import { assign, emit, fromPromise, setup } from "xstate";
 import { ToastMessage } from "../helpers/notifications";
@@ -230,12 +230,19 @@ export const rampMachine = setup({
     RampRequested: {
       invoke: {
         input: ({ context }) => context,
-        onDone: {
-          guard: ({ event }: any) => event.output.kycNeeded,
-          // The guard checks validateKyc output
-          // do nothing otherwise, as we wait for modal confirmation.
-          target: "KYC"
-        },
+        onDone: [
+          {
+            guard: ({ event }: any) => event.output.kycNeeded,
+            // The guard checks validateKyc output
+            // do nothing otherwise, as we wait for modal confirmation.
+            target: "KYC"
+          },
+          {
+            // If Avenia (BRL) flow and user is valid, we can simply go to the summary card.
+            guard: ({ context, event }) => !event.output.kycNeeded && context.executionInput?.fiatToken === FiatToken.BRL,
+            target: "RegisterRamp"
+          }
+        ],
         onError: "Idle",
         src: "validateKyc"
       },

--- a/apps/frontend/src/pages/progress/index.tsx
+++ b/apps/frontend/src/pages/progress/index.tsx
@@ -16,8 +16,8 @@ import { getMessageForPhase } from "./phaseMessages";
 
 const PHASE_DURATIONS: Record<RampPhase, number> = {
   assethubToPendulum: 24,
+  brlaOnrampMint: 5 * 60,
   brlaPayoutOnMoonbeam: 30,
-  brlaTeleport: 5 * 60,
   complete: 0,
   distributeFees: 24,
   failed: 0,
@@ -90,7 +90,7 @@ export const PHASE_FLOWS = {
 
   onramp_brl: [
     "initial",
-    "brlaTeleport",
+    "brlaOnrampMint",
     "fundEphemeral",
     "moonbeamToPendulumXcm",
     "subsidizePreSwap",
@@ -125,7 +125,7 @@ function getRampFlow(rampState: RampState | undefined): keyof typeof PHASE_FLOWS
 
   if (type === RampDirection.BUY) {
     if (
-      currentPhase === "brlaTeleport" ||
+      currentPhase === "brlaOnrampMint" ||
       rampState.quote?.outputCurrency === FiatToken.BRL ||
       rampState.quote?.inputCurrency === FiatToken.BRL
     ) {

--- a/apps/frontend/src/pages/progress/phaseMessages.ts
+++ b/apps/frontend/src/pages/progress/phaseMessages.ts
@@ -51,8 +51,8 @@ export function getMessageForPhase(ramp: RampState | undefined, t: TFunction<"tr
     assethubToPendulum: t("pages.progress.assethubToPendulum", {
       assetSymbol: inputAssetSymbol
     }),
+    brlaOnrampMint: t("pages.progress.brlaOnrampMint"),
     brlaPayoutOnMoonbeam: getTransferringMessage(),
-    brlaTeleport: t("pages.progress.brlaTeleport"),
     complete: "",
     distributeFees: getSwappingMessage(),
     failed: "",

--- a/apps/frontend/src/translations/en.json
+++ b/apps/frontend/src/translations/en.json
@@ -422,7 +422,7 @@
     "progress": {
       "assethubToPendulum": "Bridging {{assetSymbol}} from AssetHub --> Pendulum",
       "bridgingEVM": "Bridging {{assetSymbol}} from {{network}} --> Moonbeam",
-      "brlaTeleport": "Your payment is being processed. This can take up to 5 minutes.",
+      "brlaOnrampMint": "Your payment is being processed. This can take up to 5 minutes.",
       "closeProgressScreenText": "💡 You’re all set! You can now close this tab or grab a coffee while we finish up in the background.",
       "createStellarAccount": "Creating Stellar account",
       "estimatedTimeAssetHub": "This usually takes 4-6 minutes.",

--- a/apps/frontend/src/translations/pt.json
+++ b/apps/frontend/src/translations/pt.json
@@ -421,7 +421,7 @@
     "progress": {
       "assethubToPendulum": "Transferindo {{assetSymbol}} de AssetHub --> Pendulum",
       "bridgingEVM": "Transferindo {{assetSymbol}} de {{network}} --> Moonbeam",
-      "brlaTeleport": "Seu pagamento está sendo processado. Isso pode levar até 5 minutos.",
+      "brlaOnrampMint": "Seu pagamento está sendo processado. Isso pode levar até 5 minutos.",
       "closeProgressScreenText": "💡 Tudo pronto! Você já pode fechar esta aba ou pegar um café enquanto finalizamos o processo em segundo plano.",
       "createStellarAccount": "Criando conta Stellar",
       "estimatedTimeAssetHub": "Isso geralmente leva de 4 a 6 minutos.",

--- a/packages/shared/src/endpoints/ramp.endpoints.ts
+++ b/packages/shared/src/endpoints/ramp.endpoints.ts
@@ -22,7 +22,7 @@ export type RampPhase =
   | "subsidizePreSwap"
   | "subsidizePostSwap"
   | "distributeFees"
-  | "brlaTeleport"
+  | "brlaOnrampMint"
   | "brlaPayoutOnMoonbeam"
   | "failed"
   | "timedOut"

--- a/packages/shared/src/services/brla/brlaApiService.ts
+++ b/packages/shared/src/services/brla/brlaApiService.ts
@@ -275,7 +275,8 @@ export class BrlaApiService {
       outputAmount: quoteParams.outputAmount, // Fixed to FIAT out
       outputCurrency: BrlaCurrency.BRL,
       outputPaymentMethod: AveniaPaymentMethod.PIX,
-      outputThirdParty: String(quoteParams.outputThirdParty)
+      outputThirdParty: String(quoteParams.outputThirdParty),
+      subAccountId: quoteParams.subAccountId
     }).toString();
     return await this.sendRequest(Endpoint.FixedRateQuote, "GET", query);
   }

--- a/packages/shared/src/services/brla/brlaApiService.ts
+++ b/packages/shared/src/services/brla/brlaApiService.ts
@@ -193,9 +193,8 @@ export class BrlaApiService {
   }
 
   public async validatePixKey(pixKey: string): Promise<PixKeyData> {
-    // const query = `pixKey=${encodeURIComponent(pixKey)}`;
-    return { bankName: "", name: "", taxId: pixKey };
-    // return await this.sendRequest(Endpoint.PixInfo, 'GET', query);
+    const query = `pixKey=${pixKey}&decodePixKey=true`;
+    return await this.sendRequest(Endpoint.PixInfo, "GET", query);
   }
 
   public async getPayInHistory(userId: string): Promise<DepositLog[]> {

--- a/packages/shared/src/services/brla/brlaApiService.ts
+++ b/packages/shared/src/services/brla/brlaApiService.ts
@@ -13,6 +13,7 @@ import logger from "../../logger";
 import { Endpoint, EndpointMapping, Endpoints, Methods } from "./mappings";
 import {
   AccountLimitsResponse,
+  AveniaAccountBalanceResponse,
   AveniaAccountInfoResponse,
   AveniaAccountType,
   AveniaDocumentGetResponse,
@@ -316,5 +317,10 @@ export class BrlaApiService {
   public async getKycAttempts(subAccountId: string): Promise<GetKycAttemptResponse> {
     const query = `subAccountId=${encodeURIComponent(subAccountId)}`;
     return await this.sendRequest(Endpoint.GetKycAttempt, "GET", query, undefined);
+  }
+
+  public async getAccountBalance(subAccountId: string): Promise<AveniaAccountBalanceResponse> {
+    const query = `subAccountId=${encodeURIComponent(subAccountId)}`;
+    return await this.sendRequest(Endpoint.Balances, "GET", query);
   }
 }

--- a/packages/shared/src/services/brla/brlaApiService.ts
+++ b/packages/shared/src/services/brla/brlaApiService.ts
@@ -19,6 +19,7 @@ import {
   AveniaDocumentGetResponse,
   AveniaDocumentType,
   AveniaPaymentMethod,
+  AveniaPayoutTicket,
   AveniaQuoteResponse,
   AveniaSubaccount,
   BlockchainSendMethod,
@@ -323,5 +324,11 @@ export class BrlaApiService {
   public async getAccountBalance(subAccountId: string): Promise<AveniaAccountBalanceResponse> {
     const query = `subAccountId=${encodeURIComponent(subAccountId)}`;
     return await this.sendRequest(Endpoint.Balances, "GET", query);
+  }
+
+  public async getAveniaPayoutTicket(ticketId: string, subAccountId: string): Promise<AveniaPayoutTicket> {
+    const query = `subAccountId=${encodeURIComponent(subAccountId)}`;
+    const { ticket } = await this.sendRequest(Endpoint.Tickets, "GET", query, undefined, ticketId);
+    return ticket;
   }
 }

--- a/packages/shared/src/services/brla/mappings.ts
+++ b/packages/shared/src/services/brla/mappings.ts
@@ -38,7 +38,7 @@ export enum Endpoint {
   AccountLimits = "/v2/account/limits",
   UsedLimit = "/used-limit",
   WebhookEvents = "/webhooks/events",
-  PixInfo = "/pay-out/pix-info",
+  PixInfo = "v2/account/bank-accounts/brl/pix-info",
   PixHistory = "/pay-in/pix/history",
   SwapHistory = "/swap/history",
   FastQuote = "/fast-quote",

--- a/packages/shared/src/services/brla/mappings.ts
+++ b/packages/shared/src/services/brla/mappings.ts
@@ -4,6 +4,7 @@ import {
   AveniaAccountBalanceResponse,
   AveniaAccountInfoResponse,
   AveniaDocumentGetResponse,
+  AveniaPayoutTicket,
   AveniaQuoteResponse,
   AveniaSubaccount,
   DepositLog,
@@ -20,6 +21,7 @@ import {
   PixInputTicketOutput,
   PixInputTicketPayload,
   PixKeyData,
+  PixOutputTicketOutput,
   PixOutputTicketPayload,
   RegisterSubaccountPayload,
   SubaccountData,
@@ -282,11 +284,11 @@ export interface EndpointMapping {
   [Endpoint.Tickets]: {
     POST: {
       body: PixInputTicketPayload | PixOutputTicketPayload;
-      response: PixInputTicketOutput | { id: string };
+      response: PixInputTicketOutput | PixOutputTicketOutput;
     };
     GET: {
       body: undefined;
-      response: undefined;
+      response: { ticket: AveniaPayoutTicket };
     };
     PATCH: {
       body: undefined;

--- a/packages/shared/src/services/brla/mappings.ts
+++ b/packages/shared/src/services/brla/mappings.ts
@@ -1,6 +1,7 @@
 import { AveniaAccountType } from "../../../src/services/brla";
 import {
   AccountLimitsResponse,
+  AveniaAccountBalanceResponse,
   AveniaAccountInfoResponse,
   AveniaDocumentGetResponse,
   AveniaQuoteResponse,
@@ -49,7 +50,8 @@ export enum Endpoint {
   Tickets = "/v2/account/tickets",
   AccountInfo = "/v2/account/account-info",
   Documents = "/v2/documents",
-  GetKycAttempt = "/v2/kyc/attempts"
+  GetKycAttempt = "/v2/kyc/attempts",
+  Balances = "/v2/account/balances"
 }
 
 export interface EndpointMapping {
@@ -327,6 +329,20 @@ export interface EndpointMapping {
     GET: {
       body: undefined;
       response: GetKycAttemptResponse;
+    };
+    PATCH: {
+      body: undefined;
+      response: undefined;
+    };
+  };
+  [Endpoint.Balances]: {
+    POST: {
+      body: undefined;
+      response: undefined;
+    };
+    GET: {
+      body: undefined;
+      response: AveniaAccountBalanceResponse;
     };
     PATCH: {
       body: undefined;

--- a/packages/shared/src/services/brla/mappings.ts
+++ b/packages/shared/src/services/brla/mappings.ts
@@ -38,7 +38,7 @@ export enum Endpoint {
   AccountLimits = "/v2/account/limits",
   UsedLimit = "/used-limit",
   WebhookEvents = "/webhooks/events",
-  PixInfo = "v2/account/bank-accounts/brl/pix-info",
+  PixInfo = "/v2/account/bank-accounts/brl/pix-info",
   PixHistory = "/pay-in/pix/history",
   SwapHistory = "/swap/history",
   FastQuote = "/fast-quote",

--- a/packages/shared/src/services/brla/types.ts
+++ b/packages/shared/src/services/brla/types.ts
@@ -306,7 +306,7 @@ export enum BrlaCurrency {
   USDM = "USDM"
 }
 
-export enum BrlaPaymentMethod {
+export enum AveniaPaymentMethod {
   PIX = "PIX",
   INTERNAL = "INTERNAL",
   BASE = "BASE",
@@ -320,10 +320,10 @@ export enum BrlaPaymentMethod {
 
 export interface PayInQuoteParams {
   inputCurrency: BrlaCurrency;
-  inputPaymentMethod: BrlaPaymentMethod;
+  inputPaymentMethod: AveniaPaymentMethod;
   inputAmount: string;
   outputCurrency: BrlaCurrency;
-  outputPaymentMethod: BrlaPaymentMethod;
+  outputPaymentMethod: AveniaPaymentMethod;
   inputThirdParty: boolean;
   outputThirdParty: boolean;
   subAccountId: string;
@@ -367,22 +367,9 @@ export interface PixInputTicketPayload {
 }
 
 export interface PixInputTicketOutput {
-  ticket: BaseTicket;
-  brlPixInputInfo: {
-    id: string;
-    ticketId: string;
-    referenceLabel: string;
-    additionalData: string;
-    brCode: string;
-  };
-  blockchainReceiverInfo: {
-    id: string;
-    ticketId: string;
-    walletAddress: string;
-    walletChain: string;
-    walletMemo: string;
-    txHash: string;
-  };
+  id: string;
+  brCode: string;
+  expiration: Date;
 }
 
 // TODO verify ticket endpoint outputs for this modality

--- a/packages/shared/src/services/brla/types.ts
+++ b/packages/shared/src/services/brla/types.ts
@@ -560,3 +560,12 @@ export interface AveniaDocumentGetResponse {
     }
   ];
 }
+
+export interface AveniaAccountBalanceResponse {
+  balances: {
+    BRLA: number;
+    USDC: number;
+    USDM: number;
+    USDT: number;
+  };
+}

--- a/packages/shared/src/services/brla/types.ts
+++ b/packages/shared/src/services/brla/types.ts
@@ -340,15 +340,22 @@ export interface PayOutQuoteParams {
   subAccountId: string;
 }
 
+export enum AveniaTicketStatus {
+  PENDING = "PENDING",
+  PAID = "PAID",
+  FAILED = "FAILED"
+}
+
 // /account/tickets endpoint related types
 export interface BaseTicket {
   id: string;
-  status: string;
+  status: AveniaTicketStatus;
+  userId: string;
   reason: string;
   failureReason: string;
-  createdAt: string;
-  updatedAt: string;
-  expiresAt: string;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
   quote: {
     id: string;
     ticketId: string;
@@ -373,6 +380,10 @@ export interface PixInputTicketOutput {
   expiration: Date;
 }
 
+export interface PixOutputTicketOutput {
+  id: string;
+}
+
 // TODO verify ticket endpoint outputs for this modality
 export interface PixOutputTicketPayload {
   quoteToken: string;
@@ -391,8 +402,7 @@ export interface PixOutputTicketPayload {
   };
 }
 
-export interface PixOutputTicketOutput {
-  ticket: BaseTicket;
+export interface AveniaPayoutTicket extends BaseTicket {
   brazilianFiatReceiverInfo: {
     id: string;
     ticketId: string;
@@ -423,6 +433,7 @@ export interface PixOutputTicketOutput {
     personalSignature: string;
     personalSignatureDeadline: number;
   };
+  RefundableParameter: string;
 }
 
 // Limit types

--- a/packages/shared/src/services/brla/types.ts
+++ b/packages/shared/src/services/brla/types.ts
@@ -337,6 +337,7 @@ export enum BlockchainSendMethod {
 export interface PayOutQuoteParams {
   outputThirdParty: boolean;
   outputAmount: string;
+  subAccountId: string;
 }
 
 // /account/tickets endpoint related types


### PR DESCRIPTION
This PR includes changes required to create onramp and offramp quotes and tickets. It also modifies accordingly backend   phase handlers.

### Changes 
- Modify Avenia's API service, quote and ticket query params.
- Modify `BrlaTeleportPhaseHandler`. The name of the phase is kept for the moment, yet no teleport seems to be required, we only wait for the mint on the destination chain.
- Adjust `BrlaPayoutOnMoonbeamPhaseHandler`.