### PR TITLE
Add minimum balance check to rebalancer

### DIFF
--- a/apps/rebalancer/src/index.ts
+++ b/apps/rebalancer/src/index.ts
@@ -1,6 +1,7 @@
 import { rebalanceBrlaToUsdcAxl } from "./rebalance/brla-to-axlusdc";
+import { checkInitialPendulumBalance } from "./rebalance/brla-to-axlusdc/steps.ts";
 import { getSwapPoolsWithCoverageRatio } from "./services/indexer";
-import { getConfig } from "./utils/config.ts";
+import { getConfig, getPendulumAccount } from "./utils/config.ts";
 
 async function checkForRebalancing() {
   const swapPoolsWithCoverage = await getSwapPoolsWithCoverageRatio();
@@ -24,7 +25,16 @@ async function checkForRebalancing() {
   ) {
     console.log("Coverage ratios of BRLA and USDC.axl require rebalancing.");
     // Proceed with rebalancing
-    const amountAxlUsdc = process.env.REBALANCING_AMOUNT_USD_TO_BRL || "1";
+    const amountAxlUsdc = config.rebalancingUsdToBrlAmount;
+
+    const pendulumAccount = getPendulumAccount();
+    const rebalancerAccountBalance = await checkInitialPendulumBalance(pendulumAccount.address, amountAxlUsdc);
+    if (config.rebalancingUsdToBrlMinBalance && rebalancerAccountBalance.lt(config.rebalancingUsdToBrlMinBalance)) {
+      throw new Error(
+        `Rebalancer account balance ${rebalancerAccountBalance} is below the minimum required balance of ${config.rebalancingUsdToBrlMinBalance} to perform rebalancing.`
+      );
+    }
+
     await rebalanceBrlaToUsdcAxl(amountAxlUsdc);
   }
 }

--- a/apps/rebalancer/src/services/indexer/index.ts
+++ b/apps/rebalancer/src/services/indexer/index.ts
@@ -1,8 +1,5 @@
+import { getConfig } from "../../utils/config.ts";
 import { fetchLatestBlockFromIndexer, fetchNablaInstance } from "./graphql.ts";
-
-const INDEXER_FRESHNESS_THRESHOLD_MINUTES = process.env.INDEXER_FRESHNESS_THRESHOLD_MINUTES
-  ? Number(process.env.INDEXER_FRESHNESS_THRESHOLD_MINUTES)
-  : 5;
 
 /// This function retrieves all swap pools from the Nabla instance and checks their coverage ratios.
 /// If the coverage ratio of a pool is below the specified threshold, it adds that pool to the list of non-sufficient pools.
@@ -14,11 +11,13 @@ export async function getSwapPoolsWithCoverageRatio() {
     throw Error("Failed to fetch latest block or timestamp is missing");
   }
 
+  const config = getConfig();
+
   const currentTime = Date.now();
   const blockTime = new Date(latestBlock.timestamp).getTime();
-  if (currentTime - blockTime > INDEXER_FRESHNESS_THRESHOLD_MINUTES * 60 * 1000) {
+  if (currentTime - blockTime > config.indexerFreshnessThresholdMinutes * 60 * 1000) {
     throw Error(
-      `Latest block returned from indexer is older than ${INDEXER_FRESHNESS_THRESHOLD_MINUTES} minutes, data may not be fresh`
+      `Latest block returned from indexer is older than ${config.indexerFreshnessThresholdMinutes} minutes, data may not be fresh`
     );
   }
 

--- a/apps/rebalancer/src/utils/config.ts
+++ b/apps/rebalancer/src/utils/config.ts
@@ -13,11 +13,20 @@ export function getConfig() {
 
     brlaBusinessAccountAddress: process.env.BRLA_BUSINESS_ACCOUNT_ADDRESS || "0xDF5Fb34B90e5FDF612372dA0c774A516bF5F08b2",
 
+    indexerFreshnessThresholdMinutes: process.env.INDEXER_FRESHNESS_THRESHOLD_MINUTES
+      ? Number(process.env.INDEXER_FRESHNESS_THRESHOLD_MINUTES)
+      : 5,
+
     moonbeamAccountSecret: process.env.MOONBEAM_ACCOUNT_SECRET,
     pendulumAccountSecret: process.env.PENDULUM_ACCOUNT_SECRET,
     polygonAccountSecret: process.env.POLYGON_ACCOUNT_SECRET,
+
     /// The threshold above and below the optimal coverage ratio at which the rebalancing will be triggered.
-    rebalancingThreshold: Number(process.env.REBALANCING_THRESHOLD) || 0.25 // Default to 0.25 if not set
+    rebalancingThreshold: Number(process.env.REBALANCING_THRESHOLD) || 0.25,
+    /// The amount in USD to rebalance from the USD pool to the BRL pool on Pendulum during each execution.
+    rebalancingUsdToBrlAmount: process.env.REBALANCING_USD_TO_BRL_AMOUNT || "1",
+    /// The minimum balance in USD that the rebalancer account on Pendulum must have to allow rebalancing to occur.
+    rebalancingUsdToBrlMinBalance: process.env.REBALANCING_USD_TO_BRL_MIN_BALANCE || undefined
   };
 }
 


### PR DESCRIPTION
This pull request introduces several configuration-driven improvements to the rebalancer service, focusing on making operational thresholds and parameters configurable rather than hard-coded. The main changes include moving environment variable access into the `getConfig` utility, enforcing a minimum balance check before rebalancing, and improving the freshness check for indexer data.

**Configuration enhancements and operational safeguards:**

* Added new configuration parameters to `getConfig`, including `indexerFreshnessThresholdMinutes`, `rebalancingUsdToBrlAmount`, and `rebalancingUsdToBrlMinBalance`, allowing these values to be set via environment variables for greater flexibility.
* Updated the indexer data freshness check in `getSwapPoolsWithCoverageRatio` to use the new `indexerFreshnessThresholdMinutes` configuration value instead of a hard-coded or environment variable-based constant. [[1]](diffhunk://#diff-573884002404e48e7936d41c247a4a8724f39335354b6955220392936335ff2dR1-L6) [[2]](diffhunk://#diff-573884002404e48e7936d41c247a4a8724f39335354b6955220392936335ff2dR14-R20)

**Rebalancing logic improvements:**

* Modified the rebalancing process in `checkForRebalancing` to use the configured rebalancing amount and to check the Pendulum account's balance before proceeding, throwing an error if the balance is below the configured minimum. [[1]](diffhunk://#diff-796fcfa3a31a68afa4e2b53c27c797d58b3fdca9f8b67575d54cb299481d26c5R2-R4) [[2]](diffhunk://#diff-796fcfa3a31a68afa4e2b53c27c797d58b3fdca9f8b67575d54cb299481d26c5L27-R37)