### PR TITLE
Add oracle price to quote metadata

### DIFF
--- a/apps/api/src/api/services/priceFeed.service.ts
+++ b/apps/api/src/api/services/priceFeed.service.ts
@@ -377,7 +377,7 @@ export class PriceFeedService {
    * @throws Error if the price cannot be fetched or currency is not found
    */
   public async getOnchainOraclePrice(currency: RampCurrency): Promise<{
-    price: number;
+    price: Big;
     lastUpdateTimestamp: number;
     name: string;
   }> {
@@ -413,8 +413,11 @@ export class PriceFeedService {
       };
 
       // Remove commas from numeric strings and parse
-      const price = parseFloat(priceData.price.replaceAll(",", ""));
+      const priceRaw = parseFloat(priceData.price.replaceAll(",", ""));
       const lastUpdateTimestamp = parseInt(priceData.lastUpdateTimestamp.replaceAll(",", ""), 10);
+
+      // Convert price from raw to decimal number by dividing by 10^12
+      const price = Big(priceRaw).div(1_000_000_000_000);
 
       logger.debug(`Oracle price for ${currency}: ${price}, Last update: ${lastUpdateTimestamp}, Name: ${priceData.name}`);
 

--- a/apps/api/src/api/services/quote/core/types.ts
+++ b/apps/api/src/api/services/quote/core/types.ts
@@ -122,7 +122,7 @@ export interface QuoteContext {
     outputToken: string; // ERC20 wrapper address
     effectiveExchangeRate?: string;
     outputCurrency: RampCurrency;
-    oraclePrice?: number;
+    oraclePrice?: Big;
   };
 
   hydrationSwap?: {

--- a/apps/api/src/api/services/quote/engines/nabla-swap/index.ts
+++ b/apps/api/src/api/services/quote/engines/nabla-swap/index.ts
@@ -93,7 +93,7 @@ export abstract class BaseNablaSwapEngine implements Stage {
     inputAmountForSwapRaw: string,
     inputToken: PendulumTokenDetails,
     outputToken: PendulumTokenDetails,
-    oraclePrice?: number
+    oraclePrice?: Big
   ): void {
     ctx.nablaSwap = {
       ...ctx.nablaSwap,


### PR DESCRIPTION
This pull request introduces support for fetching and using on-chain oracle price data within the Nabla Swap quoting engine. The main changes involve adding a new method to retrieve oracle prices, integrating this data into the swap computation flow, and updating relevant types and interfaces to handle the new information.

**On-chain Oracle Price Integration:**

* Added a new method `getOnchainOraclePrice` to `PriceFeedService` that fetches and parses price data from the on-chain oracle for a given `RampCurrency`. The method includes error handling and logging for robustness.
* Integrated oracle price fetching into the Nabla Swap engine (`BaseNablaSwapEngine`). The engine now attempts to retrieve the oracle price for the relevant currency and logs a warning if the fetch fails, proceeding without it if necessary.

**Type and Interface Updates:**

* Updated the `QuoteContext` and `NablaSwapComputation` interfaces to include an optional `oraclePrice` field, allowing downstream consumers to access this data. [[1]](diffhunk://#diff-629d2bcfaec19e57ad2e490bd2d8aa5c76da4c8042c2899e0d9348170496a41dR125) [[2]](diffhunk://#diff-4012106003d6a4c290bad4d91ad2f64381b82566572ab1ecddde86aa897f580bR14)
* Modified the `assignNablaSwapContext` method and its usage to accept and propagate the `oraclePrice` value within the Nabla Swap context. [[1]](diffhunk://#diff-4012106003d6a4c290bad4d91ad2f64381b82566572ab1ecddde86aa897f580bL80-R96) [[2]](diffhunk://#diff-4012106003d6a4c290bad4d91ad2f64381b82566572ab1ecddde86aa897f580bR107)

**Dependency and Logging Enhancements:**

* Imported the `priceFeedService` and logger into the Nabla Swap engine to support the new functionality and provide better observability.