### PR TITLE
Increase TTL for pending quotes by adjusting expiration criteria

### DIFF
--- a/apps/api/src/api/services/ramp/base.service.ts
+++ b/apps/api/src/api/services/ramp/base.service.ts
@@ -12,10 +12,12 @@ export class BaseRampService {
    * Clean up expired quotes by deleting them from the database
    */
   public async cleanupExpiredQuotes(): Promise<number> {
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+
     const count = await QuoteTicket.destroy({
       where: {
         expiresAt: {
-          [Op.lt]: new Date()
+          [Op.lt]: sixtyDaysAgo
         },
         status: "pending"
       }


### PR DESCRIPTION
This pull request updates the logic for cleaning up expired quotes in the `BaseRampService`. The main change is to only delete quotes that have been expired for more than 60 days, rather than deleting all quotes that have expired up to the current time.

Cleanup logic update:

* Modified the `cleanupExpiredQuotes` method in `base.service.ts` to only remove quotes that expired more than 60 days ago, instead of all quotes with an expiration date in the past.