### PR TITLE
Remove polygon funding when not needed on the flow

### DIFF
--- a/apps/api/src/api/services/phases/handlers/fund-ephemeral-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/fund-ephemeral-handler.ts
@@ -57,6 +57,22 @@ export class FundEphemeralPhaseHandler extends BasePhaseHandler {
     return true;
   }
 
+  protected getRequiresPolygonEphemeralAddress(state: RampState, inputCurrency?: string): boolean {
+    // Only required for Monerium onramps.
+    if (isOnramp(state) && inputCurrency === FiatToken.EURC) {
+      return true;
+    }
+    return false;
+  }
+
+  protected getRequiresMoonbeamEphemeralAddress(state: RampState, inputCurrency?: string): boolean {
+    // Only required for BRLA onramps.
+    if (isOnramp(state) && inputCurrency === FiatToken.BRL) {
+      return true;
+    }
+    return false;
+  }
+
   protected async executePhase(state: RampState): Promise<RampState> {
     const quote = await QuoteTicket.findByPk(state.quoteId);
     if (!quote) {
@@ -69,6 +85,8 @@ export class FundEphemeralPhaseHandler extends BasePhaseHandler {
 
     const { evmEphemeralAddress, substrateEphemeralAddress } = state.state as StateMetadata;
     const requiresPendulumEphemeralAddress = this.getRequiresPendulumEphemeralAddress(state, quote.inputCurrency);
+    const requiresPolygonEphemeralAddress = this.getRequiresPolygonEphemeralAddress(state, quote.inputCurrency);
+    const requiresMoonbeamEphemeralAddress = this.getRequiresMoonbeamEphemeralAddress(state, quote.inputCurrency);
 
     // Ephemeral checks.
     if (!substrateEphemeralAddress && requiresPendulumEphemeralAddress) {
@@ -86,11 +104,11 @@ export class FundEphemeralPhaseHandler extends BasePhaseHandler {
         ? await isPendulumEphemeralFunded(substrateEphemeralAddress, pendulumNode)
         : true;
 
-      const isMoonbeamFunded =
-        isOnramp(state) && evmEphemeralAddress ? await isMoonbeamEphemeralFunded(evmEphemeralAddress, moonbeamNode) : true;
+      const isMoonbeamFunded = requiresMoonbeamEphemeralAddress
+        ? await isMoonbeamEphemeralFunded(evmEphemeralAddress, moonbeamNode)
+        : true;
 
-      const isPolygonFunded =
-        isOnramp(state) && evmEphemeralAddress ? await isPolygonEphemeralFunded(evmEphemeralAddress) : true;
+      const isPolygonFunded = requiresPolygonEphemeralAddress ? await isPolygonEphemeralFunded(evmEphemeralAddress) : true;
 
       if (state.state.stellarTarget) {
         const isFunded = await isStellarEphemeralFunded(


### PR DESCRIPTION

These changes solve an unnecessary funding of the polygon ephemeral address, that was being funded for other ramps besides EURO onramp.