### PR TITLE
Refactor subsidy calculation logic in post-swap handler

### DIFF
--- a/apps/api/src/api/services/phases/handlers/subsidize-post-swap-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/subsidize-post-swap-handler.ts
@@ -2,7 +2,6 @@ import {
   ApiManager,
   AssetHubToken,
   FiatToken,
-  multiplyByPowerOfTen,
   nativeToDecimal,
   RampDirection,
   RampPhase,
@@ -46,10 +45,6 @@ export class SubsidizePostSwapPhaseHandler extends BasePhaseHandler {
       throw new Error("Missing subsidy information in quote metadata");
     }
 
-    if (!quote.metadata.fees?.usd) {
-      throw new Error("Missing fee information in quote metadata");
-    }
-
     try {
       const balanceResponse = await pendulumNode.api.query.tokens.accounts(
         substrateEphemeralAddress,
@@ -62,27 +57,26 @@ export class SubsidizePostSwapPhaseHandler extends BasePhaseHandler {
         throw new Error("Invalid phase: input token did not arrive yet on pendulum");
       }
 
-      // Add the (potential) subsidy amount to the expected swap output to get the target balance
+      // Add a default/base expected output amount from the swap
       let expectedSwapOutputAmountRaw = Big(quote.metadata.nablaSwap.outputAmountRaw).plus(
         quote.metadata.subsidy.subsidyAmountInOutputTokenRaw
       );
 
-      // For onramps, the fees are distributed between the nablaSwap and the subsidy, so we need to subtract them from the expected output
+      // Try to find the required amount to subsidize on the quote metadata
       if (state.type === RampDirection.BUY) {
-        // Onramps always have a USD-stablecoin as the output, so we can use the USD fee structure
-        const usdFeeStructure = quote.metadata.fees.usd;
-        const totalFeeDistributedUsd = Big(usdFeeStructure.network)
-          .plus(usdFeeStructure.vortex)
-          .plus(usdFeeStructure.partnerMarkup);
-
-        const totalFeeDistributedUsdRaw = multiplyByPowerOfTen(
-          totalFeeDistributedUsd,
-          quote.metadata.nablaSwap.outputDecimals
-        ).toFixed(0, 0);
-
-        expectedSwapOutputAmountRaw = Big(quote.metadata.nablaSwap.outputAmountRaw)
-          .minus(totalFeeDistributedUsdRaw)
-          .plus(quote.metadata.subsidy.subsidyAmountInOutputTokenRaw);
+        if (quote.metadata.pendulumToHydrationXcm) {
+          expectedSwapOutputAmountRaw = Big(quote.metadata.pendulumToHydrationXcm.inputAmountRaw);
+        } else if (quote.metadata.pendulumToAssethubXcm) {
+          expectedSwapOutputAmountRaw = Big(quote.metadata.pendulumToAssethubXcm.inputAmountRaw);
+        } else if (quote.metadata.pendulumToMoonbeamXcm) {
+          expectedSwapOutputAmountRaw = Big(quote.metadata.pendulumToMoonbeamXcm.inputAmountRaw);
+        }
+      } else {
+        if (quote.metadata.pendulumToMoonbeamXcm) {
+          expectedSwapOutputAmountRaw = Big(quote.metadata.pendulumToMoonbeamXcm.inputAmountRaw);
+        } else if (quote.metadata.pendulumToStellar) {
+          expectedSwapOutputAmountRaw = Big(quote.metadata.pendulumToStellar.inputAmountRaw);
+        }
       }
 
       const requiredAmount = Big(expectedSwapOutputAmountRaw).sub(currentBalance);


### PR DESCRIPTION
Simplifies the logic to find the expected target amount for the post swap subsidy. The required value was already calculated in the pendulum-transfer engines and exists on the `pendulumToXxx` items on the quote metadata, so we can just re-use them. 