### PR TITLE
Replace interval with timeout to prevent race condition

### DIFF
--- a/packages/shared/src/services/evm/balance.ts
+++ b/packages/shared/src/services/evm/balance.ts
@@ -53,7 +53,8 @@ export function checkEvmBalancePeriodically(
 
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
-    const intervalId = setInterval(async () => {
+
+    const checkBalance = async () => {
       try {
         const result = await evmClientManager.readContractWithRetry<string>(chain, {
           abi: erc20ABI,
@@ -66,14 +67,14 @@ export function checkEvmBalancePeriodically(
         const amountDesiredUnitsBig = new Big(amountDesiredRaw);
 
         if (someBalanceBig.gte(amountDesiredUnitsBig)) {
-          clearInterval(intervalId);
           resolve(someBalanceBig);
         } else if (Date.now() - startTime > timeoutMs) {
-          clearInterval(intervalId);
           reject(new BalanceCheckError(BalanceCheckErrorType.Timeout, `Balance did not meet the limit within ${timeoutMs}ms`));
+        } else {
+          // Schedule next check AFTER this one completes to prevent overlapping calls
+          setTimeout(checkBalance, intervalMs);
         }
       } catch (err: unknown) {
-        clearInterval(intervalId);
         reject(
           new BalanceCheckError(
             BalanceCheckErrorType.ReadFailure,
@@ -81,6 +82,9 @@ export function checkEvmBalancePeriodically(
           )
         );
       }
-    }, intervalMs);
+    };
+
+    // Start the first check immediately
+    checkBalance();
   });
 }


### PR DESCRIPTION
This pull request refactors the balance checking logic in `checkEvmBalancePeriodically` to improve reliability and prevent overlapping asynchronous calls. The main change is replacing the use of `setInterval` with a recursive `setTimeout` approach, ensuring that each balance check completes before the next one starts.

**Balance checking logic improvements:**

* Replaced `setInterval` with a recursive `setTimeout` in `checkEvmBalancePeriodically` to avoid overlapping asynchronous balance checks, improving reliability and preventing potential race conditions. [[1]](diffhunk://#diff-4b681579f1f4bca6edd4442cd82c4ab602ce97e0b9d3e048181f0c4fe99d73edL56-R57) [[2]](diffhunk://#diff-4b681579f1f4bca6edd4442cd82c4ab602ce97e0b9d3e048181f0c4fe99d73edL69-R88)
* Removed unnecessary `clearInterval` calls, as the interval mechanism is no longer used.
* The initial balance check now runs immediately, with subsequent checks scheduled only after the previous one finishes.