### PR TITLE
Move client initialization out of constructor to allow usage of different RPC on retry

### DIFF
--- a/apps/api/src/api/services/phases/handlers/monerium-onramp-self-transfer-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/monerium-onramp-self-transfer-handler.ts
@@ -7,7 +7,7 @@ import {
   RampPhase
 } from "@vortexfi/shared";
 import Big from "big.js";
-import { encodeFunctionData, PublicClient } from "viem";
+import { encodeFunctionData } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import logger from "../../../../config/logger";
 import { MOONBEAM_EXECUTOR_PRIVATE_KEY } from "../../../../constants/constants";
@@ -20,15 +20,6 @@ import { BasePhaseHandler } from "../base-phase-handler";
  * Handler for the monerium self-transfer phase
  */
 export class MoneriumOnrampSelfTransferHandler extends BasePhaseHandler {
-  private polygonClient: PublicClient;
-  private evmClientManager: EvmClientManager;
-
-  constructor() {
-    super();
-    this.evmClientManager = EvmClientManager.getInstance();
-    this.polygonClient = this.evmClientManager.getClient(Networks.Polygon);
-  }
-
   /**
    * Get the phase name
    */
@@ -112,7 +103,8 @@ export class MoneriumOnrampSelfTransferHandler extends BasePhaseHandler {
           ],
           functionName: "permit"
         });
-        permitHash = await this.evmClientManager.sendTransactionWithBlindRetry(Networks.Polygon, account, {
+        const evmClientManager = EvmClientManager.getInstance();
+        permitHash = await evmClientManager.sendTransactionWithBlindRetry(Networks.Polygon, account, {
           data: permitData,
           to: ERC20_EURE_POLYGON_V2
         });
@@ -174,8 +166,10 @@ export class MoneriumOnrampSelfTransferHandler extends BasePhaseHandler {
    * @param chainId The chain ID
    */
   private async waitForTransactionConfirmation(txHash: string): Promise<void> {
+    const evmClientManager = EvmClientManager.getInstance();
     try {
-      const receipt = await this.polygonClient.waitForTransactionReceipt({
+      const polygonClient = evmClientManager.getClient(Networks.Polygon);
+      const receipt = await polygonClient.waitForTransactionReceipt({
         hash: txHash as `0x${string}`
       });
       if (!receipt || receipt.status !== "success") {

--- a/apps/api/src/api/services/phases/handlers/squid-router-phase-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/squid-router-phase-handler.ts
@@ -17,16 +17,6 @@ import { BasePhaseHandler } from "../base-phase-handler";
  * Handler for the squidRouter phase
  */
 export class SquidRouterPhaseHandler extends BasePhaseHandler {
-  private moonbeamClient: PublicClient;
-  private polygonClient: PublicClient;
-
-  constructor() {
-    super();
-    const evmClientManager = EvmClientManager.getInstance();
-    this.moonbeamClient = evmClientManager.getClient(Networks.Moonbeam);
-    this.polygonClient = evmClientManager.getClient(Networks.Polygon);
-  }
-
   /**
    * Get the phase name
    */
@@ -120,6 +110,8 @@ export class SquidRouterPhaseHandler extends BasePhaseHandler {
    * @returns The appropriate public client
    */
   private async getPublicClient(state: RampState): Promise<PublicClient> {
+    const evmClientManager = EvmClientManager.getInstance();
+
     try {
       const quote = await QuoteTicket.findByPk(state.quoteId);
       if (!quote) {
@@ -127,18 +119,18 @@ export class SquidRouterPhaseHandler extends BasePhaseHandler {
       }
 
       if (quote.inputCurrency === FiatToken.EURC) {
-        return this.polygonClient;
+        return evmClientManager.getClient(Networks.Polygon);
       } else if (quote.inputCurrency === FiatToken.BRL) {
-        return this.moonbeamClient;
+        return evmClientManager.getClient(Networks.Moonbeam);
       } else {
         logger.info(
           `SquidRouterPhaseHandler: Using Moonbeam client as default for input currency: ${quote.inputCurrency}. This is a bug.`
         );
-        return this.moonbeamClient;
+        return evmClientManager.getClient(Networks.Moonbeam);
       }
     } catch (error) {
       logger.error("SquidRouterPhaseHandler: Error determining public client, defaulting to moonbeam", error);
-      return this.moonbeamClient;
+      return evmClientManager.getClient(Networks.Moonbeam);
     }
   }
 


### PR DESCRIPTION
This pull request refactors the phase handler classes related to EVM client management in the API service. The main improvement is the removal of per-instance EVM client and wallet client properties in favor of fetching the required clients on-demand using the `EvmClientManager` singleton. This change simplifies the code, reduces memory usage, and avoids potential issues with stale or misconfigured client instances.