### PR TITLE
Enforce light-only color scheme

### DIFF
--- a/apps/frontend/App.css
+++ b/apps/frontend/App.css
@@ -1,10 +1,11 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
 @plugin "daisyui";
 
 :root {
+  color-scheme: only light;
+
   /* DaisyUI theme colors */
   --color-primary: oklch(0.45 0.2 260);
   --color-primary-content: oklch(1 0 0);


### PR DESCRIPTION
The app is designed as a light-only UI. However, users with a dark OS theme would see browser-native elements (scrollbars,
  date pickers, <select> dropdowns, form inputs) auto-darkened by the browser — Tailwind/DaisyUI have no control over
 those. Additionally, a dead @custom-variant dark was registered in Tailwind but never activated (it required a .dark class
  that is never applied anywhere).