### PR TITLE
[READY] reset scroll to top on route and widget screen transitions

### DIFF
--- a/apps/frontend/src/components/widget-steps/SummaryStep/BRLOnrampDetails.tsx
+++ b/apps/frontend/src/components/widget-steps/SummaryStep/BRLOnrampDetails.tsx
@@ -37,7 +37,7 @@ export const BRLOnrampDetails: FC = () => {
         </InfoBox>
       </div>
       <p className="text-center">{t("components.SummaryPage.BRLOnrampDetails.copyCode")}</p>
-      <CopyButton className="mt-4 mb-4 w-full py-10" text={rampState.ramp?.depositQrCode} />
+      <CopyButton className="mt-4 mb-20 w-full py-10" text={rampState.ramp?.depositQrCode} />
     </>
   );
 };

--- a/apps/frontend/src/hooks/ramp/useRampNavigation.ts
+++ b/apps/frontend/src/hooks/ramp/useRampNavigation.ts
@@ -1,6 +1,19 @@
-import { ReactNode, useCallback } from "react";
+import { ReactNode, useCallback, useEffect } from "react";
 import { useIsQuoteComponentDisplayed } from "./useIsQuoteComponentDisplayed";
 import { useRampComponentState } from "./useRampComponentState";
+
+function getActiveScreen(
+  currentPhase: string | undefined,
+  rampStateDefined: boolean,
+  machineValue: string,
+  isQuoteDisplayed: boolean
+): string {
+  if (currentPhase === "complete") return "success";
+  if (currentPhase === "failed") return "failure";
+  if (rampStateDefined && machineValue === "RampFollowUp") return "progress";
+  if (isQuoteDisplayed) return "quote";
+  return "form";
+}
 
 export const useRampNavigation = (
   successComponent: ReactNode,
@@ -11,6 +24,18 @@ export const useRampNavigation = (
 ) => {
   const { rampState, rampMachineState } = useRampComponentState();
   const isQuoteDisplayed = useIsQuoteComponentDisplayed();
+
+  const activeScreen = getActiveScreen(
+    rampState?.ramp?.currentPhase,
+    rampState !== undefined,
+    String(rampMachineState.value),
+    isQuoteDisplayed
+  );
+
+  useEffect(() => {
+    console.log("activeScreen", activeScreen);
+    window.scrollTo({ behavior: "instant", top: 0 });
+  }, [activeScreen]);
 
   const getCurrentComponent = useCallback(() => {
     if (rampState?.ramp?.currentPhase === "complete") {

--- a/apps/frontend/src/hooks/ramp/useRampNavigation.ts
+++ b/apps/frontend/src/hooks/ramp/useRampNavigation.ts
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect } from "react";
+import { ReactNode, useCallback, useLayoutEffect } from "react";
 import { useIsQuoteComponentDisplayed } from "./useIsQuoteComponentDisplayed";
 import { useRampComponentState } from "./useRampComponentState";
 
@@ -32,9 +32,10 @@ export const useRampNavigation = (
     isQuoteDisplayed
   );
 
-  useEffect(() => {
-    console.log("activeScreen", activeScreen);
-    window.scrollTo({ behavior: "instant", top: 0 });
+  useLayoutEffect(() => {
+    if (activeScreen === "progress" || activeScreen === "success" || activeScreen === "failure") {
+      window.scrollTo({ behavior: "instant", top: 0 });
+    }
   }, [activeScreen]);
 
   const getCurrentComponent = useCallback(() => {

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -60,7 +60,7 @@ i18n.use(initReactI18next).init({
   }
 });
 
-const router = createRouter({ routeTree, scrollRestoration: true });
+const router = createRouter({ routeTree });
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/contracts/relayer/typechain-types/contracts/TokenRelayer.ts
+++ b/contracts/relayer/typechain-types/contracts/TokenRelayer.ts
@@ -124,7 +124,7 @@ export interface TokenRelayerInterface extends Interface {
 export namespace EIP712DomainChangedEvent {
   export type InputTuple = [];
   export type OutputTuple = [];
-  export interface OutputObject {}
+  export type OutputObject = {};
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
   export type Log = TypedEventLog<Event>;


### PR DESCRIPTION
Remove `scrollRestoration: true` from `createRouter` to restore browser's native scroll-to-top on route changes. 
Add useEffect in useRampNavigation to scroll to top when the active widget screen changes (Summary → Progress → Success/Failure), which TanStack Router cannot handle as these are in-route state transitions.

Closes: #1067 