### PR TITLE
Normalize tax ID for Avenia

### DIFF
--- a/apps/api/src/api/controllers/brla.controller.ts
+++ b/apps/api/src/api/controllers/brla.controller.ts
@@ -28,6 +28,7 @@ import {
   KycFailureReason,
   KycLevel1Payload,
   KycLevel1Response,
+  normalizeTaxId,
   RampDirection
 } from "@vortexfi/shared";
 import { Request, Response } from "express";
@@ -40,6 +41,7 @@ import { APIError } from "../errors/api-error";
 // Helper functions for TaxId updates
 
 async function updateTaxIdToAccepted(taxId: string, quoteId?: string, sessionId?: string): Promise<void> {
+  const normalized = normalizeTaxId(taxId);
   await TaxId.update(
     {
       finalQuoteId: quoteId,
@@ -50,13 +52,14 @@ async function updateTaxIdToAccepted(taxId: string, quoteId?: string, sessionId?
     {
       where: {
         internalStatus: TaxIdInternalStatus.Requested,
-        taxId
+        taxId: normalized
       }
     }
   );
 }
 
 async function updateTaxIdToRejected(taxId: string, quoteId?: string, sessionId?: string): Promise<void> {
+  const normalized = normalizeTaxId(taxId);
   await TaxId.update(
     {
       finalQuoteId: quoteId,
@@ -67,7 +70,7 @@ async function updateTaxIdToRejected(taxId: string, quoteId?: string, sessionId?
     {
       where: {
         internalStatus: TaxIdInternalStatus.Requested,
-        taxId
+        taxId: normalized
       }
     }
   );
@@ -152,7 +155,7 @@ export const getAveniaUser = async (
         internalStatus: {
           [Op.ne]: TaxIdInternalStatus.Consulted
         },
-        taxId
+        taxId: normalizeTaxId(taxId)
       }
     });
     if (!taxIdRecord) {
@@ -201,7 +204,7 @@ export const recordInitialKycAttempt = async (
 
     const taxIdRecord = await TaxId.findOne({
       where: {
-        taxId
+        taxId: normalizeTaxId(taxId)
       }
     });
 
@@ -245,7 +248,7 @@ export const getAveniaUserRemainingLimit = async (
       return;
     }
 
-    const taxIdRecord = await TaxId.findByPk(taxId);
+    const taxIdRecord = await TaxId.findByPk(normalizeTaxId(taxId));
     if (!taxIdRecord) {
       throw new APIError({
         message: "Ramp disabled",
@@ -309,7 +312,7 @@ export const createSubaccount = async (
     const brlaApiService = BrlaApiService.getInstance();
     const { id } = await brlaApiService.createAveniaSubaccount(accountType, name);
 
-    const existingTaxId = await TaxId.findByPk(taxId);
+    const existingTaxId = await TaxId.findByPk(normalizeTaxId(taxId));
 
     if (existingTaxId) {
       await existingTaxId.update({
@@ -353,7 +356,7 @@ export const fetchSubaccountKycStatus = async (
       return;
     }
 
-    const taxIdRecord = await TaxId.findByPk(taxId);
+    const taxIdRecord = await TaxId.findByPk(normalizeTaxId(taxId));
     if (!taxIdRecord) {
       res.status(httpStatus.NOT_FOUND).json({ error: "Subaccount not found" });
       return;
@@ -445,7 +448,7 @@ export const getSelfieLivenessUrl = async (
       return;
     }
 
-    const taxIdRecord = await TaxId.findByPk(taxId);
+    const taxIdRecord = await TaxId.findByPk(normalizeTaxId(taxId));
     if (!taxIdRecord) {
       res.status(httpStatus.BAD_REQUEST).json({ error: "Ramp disabled" });
       return;
@@ -503,7 +506,7 @@ export const getUploadUrls = async (
       return;
     }
 
-    const taxIdRecord = await TaxId.findByPk(taxId);
+    const taxIdRecord = await TaxId.findByPk(normalizeTaxId(taxId));
     if (!taxIdRecord) {
       // Invalid state. Cannot happen since we create the subaccount first for every tax.
       res.status(httpStatus.BAD_REQUEST).json({ error: "Ramp disabled" });

--- a/apps/api/src/api/services/ramp/ramp.service.ts
+++ b/apps/api/src/api/services/ramp/ramp.service.ts
@@ -20,6 +20,7 @@ import {
   IbanPaymentData,
   MoneriumErrors,
   Networks,
+  normalizeTaxId,
   QuoteError,
   RampDirection,
   RampErrorLog,
@@ -46,7 +47,6 @@ import RampState from "../../../models/rampState.model";
 import TaxId from "../../../models/taxId.model";
 import { APIError } from "../../errors/api-error";
 import { ActivePartner, handleQuoteConsumptionForDiscountState } from "../../services/quote/engines/discount/helpers";
-import { SupabaseAuthService } from "../auth/supabase.service";
 import { createEpcQrCodeData, getIbanForAddress, getMoneriumUserProfile } from "../monerium";
 import { StateMetadata } from "../phases/meta-state-types";
 import phaseProcessor from "../phases/phase-processor";
@@ -665,7 +665,7 @@ export class RampService extends BaseRampService {
   ): Promise<{ wallets: { evm: string }; brCode: string }> {
     const brlaApiService = BrlaApiService.getInstance();
 
-    const taxIdRecord = await TaxId.findByPk(taxId);
+    const taxIdRecord = await TaxId.findByPk(normalizeTaxId(taxId));
     if (!taxIdRecord) {
       throw new APIError({
         message: "Subaccount not found",
@@ -685,7 +685,7 @@ export class RampService extends BaseRampService {
     try {
       const pixKeyData = await brlaApiService.validatePixKey(pixKey);
       //validate the recipient's taxId with partial information
-      if (!validateMaskedNumber(pixKeyData.taxId, receiverTaxId)) {
+      if (!validateMaskedNumber(normalizeTaxId(pixKeyData.taxId), normalizeTaxId(receiverTaxId))) {
         throw new APIError({
           message: "Invalid pixKey or receiverTaxId.",
           status: httpStatus.BAD_REQUEST
@@ -736,7 +736,7 @@ export class RampService extends BaseRampService {
   ): Promise<{ brCode: string; aveniaTicketId: string }> {
     const brlaApiService = BrlaApiService.getInstance();
 
-    const taxIdRecord = await TaxId.findByPk(taxId);
+    const taxIdRecord = await TaxId.findByPk(normalizeTaxId(taxId));
     if (!taxIdRecord) {
       throw new APIError({
         message: "Subaccount not found.",

--- a/apps/api/src/api/services/transactions/offramp/common/validation.ts
+++ b/apps/api/src/api/services/transactions/offramp/common/validation.ts
@@ -7,6 +7,7 @@ import {
   isFiatToken,
   isOnChainToken,
   isStellarTokenDetails,
+  normalizeTaxId,
   PaymentData,
   StellarTokenDetails
 } from "@vortexfi/shared";
@@ -95,7 +96,7 @@ export function validateBRLOfframp(
     offrampAmountBeforeAnchorFeesRaw: quote.metadata.pendulumToMoonbeamXcm.outputAmountRaw,
     pixDestination,
     receiverTaxId,
-    taxId
+    taxId: normalizeTaxId(taxId)
   };
 }
 

--- a/apps/api/src/api/services/transactions/onramp/routes/avenia-to-assethub.ts
+++ b/apps/api/src/api/services/transactions/onramp/routes/avenia-to-assethub.ts
@@ -6,6 +6,7 @@ import {
   getPendulumDetails,
   isAssetHubTokenDetails,
   Networks,
+  normalizeTaxId,
   UnsignedTx
 } from "@vortexfi/shared";
 import { StateMetadata } from "../../../phases/meta-state-types";
@@ -44,7 +45,7 @@ export async function prepareAveniaToAssethubOnrampTransactions({
     destinationAddress,
     evmEphemeralAddress: evmEphemeralEntry.address,
     substrateEphemeralAddress: substrateEphemeralEntry.address,
-    taxId
+    taxId: normalizeTaxId(taxId)
   };
 
   // Moonbeam: Initial BRLA transfer to Pendulum

--- a/apps/api/src/api/services/transactions/onramp/routes/avenia-to-evm.ts
+++ b/apps/api/src/api/services/transactions/onramp/routes/avenia-to-evm.ts
@@ -16,6 +16,7 @@ import {
   isNativeEvmToken,
   multiplyByPowerOfTen,
   Networks,
+  normalizeTaxId,
   UnsignedTx
 } from "@vortexfi/shared";
 import { privateKeyToAccount } from "viem/accounts";
@@ -62,7 +63,7 @@ export async function prepareAveniaToEvmOnrampTransactions({
     destinationAddress,
     evmEphemeralAddress: evmEphemeralEntry.address,
     substrateEphemeralAddress: substrateEphemeralEntry.address,
-    taxId
+    taxId: normalizeTaxId(taxId)
   };
 
   let moonbeamNonce = 0;

--- a/apps/api/src/api/workers/unhandled-payment.worker.ts
+++ b/apps/api/src/api/workers/unhandled-payment.worker.ts
@@ -1,4 +1,4 @@
-import { BrlaApiService, generateReferenceLabel } from "@vortexfi/shared";
+import { BrlaApiService, generateReferenceLabel, normalizeTaxId } from "@vortexfi/shared";
 import { CronJob } from "cron";
 import { Op } from "sequelize";
 import logger from "../../config/logger";
@@ -151,7 +151,7 @@ class UnhandledPaymentWorker {
 
     for (const taxId in statesByTaxId) {
       try {
-        const taxIdRecord = await TaxId.findOne({ where: { taxId } });
+        const taxIdRecord = await TaxId.findOne({ where: { taxId: normalizeTaxId(taxId) } });
         if (!taxIdRecord) {
           logger.warn(`No TaxId record found for taxId: ${taxId}. Skipping states.`);
           statesByTaxId[taxId].forEach(state => this.processedStateIds.add(state.id));

--- a/apps/api/src/database/migrations/025-normalize-tax-ids.ts
+++ b/apps/api/src/database/migrations/025-normalize-tax-ids.ts
@@ -1,0 +1,11 @@
+import { QueryInterface } from "sequelize";
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(
+    `UPDATE "tax_ids" SET "tax_id" = regexp_replace("tax_id", '[^0-9]', '', 'g') WHERE "tax_id" ~ '[^0-9]'`
+  );
+}
+
+export async function down(_queryInterface: QueryInterface): Promise<void> {
+  // Irreversible: original formatting cannot be reconstructed from digits-only values.
+}

--- a/apps/api/src/database/migrations/025-normalize-tax-ids.ts
+++ b/apps/api/src/database/migrations/025-normalize-tax-ids.ts
@@ -1,9 +1,35 @@
 import { QueryInterface } from "sequelize";
 
 export async function up(queryInterface: QueryInterface): Promise<void> {
-  await queryInterface.sequelize.query(
-    `UPDATE "tax_ids" SET "tax_id" = regexp_replace("tax_id", '[^0-9]', '', 'g') WHERE "tax_id" ~ '[^0-9]'`
-  );
+  // Normalizes all tax_id values to digits-only (e.g. "758.444.017-77" → "75844401777").
+  //
+  // If both a formatted and unformatted entry exist for the same digits, a naive UPDATE would
+  // hit a primary key collision. To handle this:
+  //   1. Partition rows by their normalized digits and rank them — prefer the row with a
+  //      non-empty sub_account_id, then most recent updated_at.
+  //   2. Delete all lower-ranked duplicates.
+  //   3. UPDATE the surviving rows to digits-only (now collision-free).
+  await queryInterface.sequelize.query(`
+    WITH normalized AS (
+      SELECT
+        ctid,
+        "tax_id",
+        regexp_replace("tax_id", '[^0-9]', '', 'g') AS digits,
+        ROW_NUMBER() OVER (
+          PARTITION BY regexp_replace("tax_id", '[^0-9]', '', 'g')
+          ORDER BY
+            CASE WHEN "sub_account_id" IS NOT NULL AND "sub_account_id" <> '' THEN 0 ELSE 1 END,
+            "updated_at" DESC
+        ) AS rn
+      FROM "tax_ids"
+    )
+    DELETE FROM "tax_ids"
+    WHERE ctid IN (SELECT ctid FROM normalized WHERE rn > 1);
+
+    UPDATE "tax_ids"
+    SET "tax_id" = regexp_replace("tax_id", '[^0-9]', '', 'g')
+    WHERE "tax_id" ~ '[^0-9]';
+  `);
 }
 
 export async function down(_queryInterface: QueryInterface): Promise<void> {

--- a/apps/api/src/models/taxId.model.ts
+++ b/apps/api/src/models/taxId.model.ts
@@ -1,4 +1,4 @@
-import { AveniaAccountType } from "@vortexfi/shared";
+import { AveniaAccountType, normalizeTaxId } from "@vortexfi/shared";
 import { DataTypes, Model, Optional } from "sequelize";
 import sequelize from "../config/database";
 
@@ -143,6 +143,16 @@ TaxId.init(
     }
   },
   {
+    hooks: {
+      beforeCreate: instance => {
+        instance.taxId = normalizeTaxId(instance.taxId);
+      },
+      beforeUpdate: instance => {
+        if (instance.changed("taxId")) {
+          instance.taxId = normalizeTaxId(instance.taxId);
+        }
+      }
+    },
     indexes: [
       {
         fields: ["sub_account_id"],

--- a/packages/shared/src/services/brla/helpers.ts
+++ b/packages/shared/src/services/brla/helpers.ts
@@ -15,6 +15,14 @@ export function generateReferenceLabel(quote: Quote): string {
   return quote.id.slice(0, 8);
 }
 
+/**
+ * Strips all non-digit characters from a tax ID so that
+ * "758.444.017-77" and "75844401777" are stored/compared identically.
+ */
+export function normalizeTaxId(taxId: string): string {
+  return taxId.replace(/\D/g, "");
+}
+
 export const CPF_REGEX = /^\d{3}(\.\d{3}){2}-\d{2}$|^\d{11}$/;
 export const CNPJ_REGEX = /^(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})$/;
 


### PR DESCRIPTION
This PR adds changes to ensure that only the normalized version of the tax ID is used when necessary, so that the formatting does not matter. 
It also adds a migration that normalizes the taxIds that are already in the table. 