### PR TITLE
[READY] Alfredpay currency limits

### DIFF
--- a/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
@@ -1,23 +1,20 @@
 import {
   AlfredpayApiService,
   AlfredpayConfigPair,
-  AlfredpayCustomerKey,
   AlfredpayCustomerType,
-  AlfredpayLimitsBucket,
   AlfredpayStablecoinKey,
   FiatToken,
   getAnyFiatTokenDetails,
-  isAlfredpayToken
+  RampDirection,
+  RawAmountLimits
 } from "@vortexfi/shared";
 import Big from "big.js";
 import logger from "../../../config/logger";
 
-export type AlfredpayLimitsDirection = "onramp" | "offramp";
-
 /** Refreshed once on startup, then daily. Limits don't change often, so this avoids beating the API. */
 const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-const CUSTOMER_TYPES: AlfredpayCustomerKey[] = ["INDIVIDUAL", "BUSINESS"];
+const CUSTOMER_TYPES: AlfredpayCustomerType[] = [AlfredpayCustomerType.INDIVIDUAL, AlfredpayCustomerType.BUSINESS];
 
 const ALFREDPAY_FIATS: Record<string, FiatToken> = {
   COP: FiatToken.COP,
@@ -30,10 +27,10 @@ function isStablecoinSymbol(symbol: string): symbol is AlfredpayStablecoinKey {
 }
 
 function cacheKey(
-  direction: AlfredpayLimitsDirection,
+  direction: RampDirection,
   fiat: FiatToken,
   stablecoin: AlfredpayStablecoinKey,
-  customer: AlfredpayCustomerKey
+  customer: AlfredpayCustomerType
 ): string {
   return `${direction}:${fiat}:${stablecoin}:${customer}`;
 }
@@ -42,10 +39,16 @@ function toRaw(quantityDecimal: string, decimals: number): string {
   return new Big(quantityDecimal).mul(new Big(10).pow(decimals)).round(0, Big.roundDown).toFixed(0);
 }
 
+interface DerivedAxes {
+  direction: RampDirection;
+  fiat: FiatToken;
+  stablecoin: AlfredpayStablecoinKey;
+}
+
 export class AlfredpayLimitsService {
   private static instance: AlfredpayLimitsService;
 
-  private cache = new Map<string, AlfredpayLimitsBucket>();
+  private cache = new Map<string, RawAmountLimits>();
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
 
   public static getInstance(): AlfredpayLimitsService {
@@ -59,6 +62,7 @@ export class AlfredpayLimitsService {
     if (this.intervalHandle) return;
     void this.refresh();
     this.intervalHandle = setInterval(() => void this.refresh(), REFRESH_INTERVAL_MS);
+    this.intervalHandle.unref();
   }
 
   public stop(): void {
@@ -69,7 +73,7 @@ export class AlfredpayLimitsService {
   }
 
   /**
-   * Returns the limits bucket for the given key. Falls back to hardcoded values when the cache is empty
+   * Returns raw limits for the given key. Falls back to hardcoded values when the cache is empty
    * (first fetch hasn't succeeded yet) or doesn't contain a matching entry.
    *
    * Onramp raw values are scaled by the fiat's decimals; offramp raw values by the stablecoin's decimals (6).
@@ -77,9 +81,9 @@ export class AlfredpayLimitsService {
   public getLimits(
     fiat: FiatToken,
     stablecoin: AlfredpayStablecoinKey,
-    customerType: AlfredpayCustomerKey,
-    direction: AlfredpayLimitsDirection
-  ): AlfredpayLimitsBucket {
+    customerType: AlfredpayCustomerType,
+    direction: RampDirection
+  ): RawAmountLimits {
     const cached = this.cache.get(cacheKey(direction, fiat, stablecoin, customerType));
     if (cached) return cached;
     return this.fallback(fiat, stablecoin, customerType, direction);
@@ -88,21 +92,21 @@ export class AlfredpayLimitsService {
   private fallback(
     fiat: FiatToken,
     stablecoin: AlfredpayStablecoinKey,
-    customerType: AlfredpayCustomerKey,
-    direction: AlfredpayLimitsDirection
-  ): AlfredpayLimitsBucket {
+    customerType: AlfredpayCustomerType,
+    direction: RampDirection
+  ): RawAmountLimits {
     const hardcoded = getAnyFiatTokenDetails(fiat).alfredpayLimits;
     if (!hardcoded) {
-      // Should never happen for AlfredPay tokens. Return permissive sentinel so we don't reject quotes outright.
-      return { maxRaw: "0", minRaw: "0" };
+      throw new Error(`AlfredPay limits missing for ${fiat} — token config is out of sync`);
     }
-    return hardcoded[direction][stablecoin][customerType];
+    const table = direction === RampDirection.BUY ? hardcoded.onramp : hardcoded.offramp;
+    return table[stablecoin][customerType];
   }
 
   private async refresh(): Promise<void> {
     try {
       const { supportedPairs } = await AlfredpayApiService.getInstance().getAllConfigs();
-      const nextCache = new Map<string, AlfredpayLimitsBucket>();
+      const nextCache = new Map<string, RawAmountLimits>();
       for (const pair of supportedPairs) {
         this.indexPair(nextCache, pair);
       }
@@ -113,62 +117,40 @@ export class AlfredpayLimitsService {
     }
   }
 
-  private indexPair(target: Map<string, AlfredpayLimitsBucket>, pair: AlfredpayConfigPair): void {
+  private indexPair(target: Map<string, RawAmountLimits>, pair: AlfredpayConfigPair): void {
     const decimals = Number(pair.decimals);
     if (!Number.isFinite(decimals)) return;
 
-    const direction = this.deriveDirection(pair);
-    if (!direction) return;
+    const axes = this.deriveAxes(pair);
+    if (!axes) return;
 
-    const { fiat, stablecoin } = direction;
-    const bucket: AlfredpayLimitsBucket = {
+    const { direction, fiat, stablecoin } = axes;
+    const limits: RawAmountLimits = {
       maxRaw: toRaw(pair.maxQuantity, decimals),
       minRaw: toRaw(pair.minQuantity, decimals)
     };
 
-    const customers: AlfredpayCustomerKey[] = pair.typeCustomer ? [pair.typeCustomer as AlfredpayCustomerKey] : CUSTOMER_TYPES;
+    const customers: AlfredpayCustomerType[] = pair.typeCustomer ? [pair.typeCustomer] : CUSTOMER_TYPES;
+    const isWildcard = !pair.typeCustomer;
     for (const customer of customers) {
-      const key = cacheKey(direction.direction, fiat, stablecoin, customer);
-      // The API can return overlapping rows (typeCustomer=null + a specific BUSINESS row). Specific wins by sorting last.
-      target.set(key, bucket);
+      const key = cacheKey(direction, fiat, stablecoin, customer);
+      // Specific customer rows take precedence over the wildcard (null) row, regardless of response order.
+      if (!isWildcard || !target.has(key)) {
+        target.set(key, limits);
+      }
     }
   }
 
-  private deriveDirection(
-    pair: AlfredpayConfigPair
-  ): { direction: AlfredpayLimitsDirection; fiat: FiatToken; stablecoin: AlfredpayStablecoinKey } | null {
+  private deriveAxes(pair: AlfredpayConfigPair): DerivedAxes | null {
     const fromFiat = ALFREDPAY_FIATS[pair.fromCurrency];
     const toFiat = ALFREDPAY_FIATS[pair.toCurrency];
 
     if (fromFiat && isStablecoinSymbol(pair.toCurrency)) {
-      return { direction: "onramp", fiat: fromFiat, stablecoin: pair.toCurrency };
+      return { direction: RampDirection.BUY, fiat: fromFiat, stablecoin: pair.toCurrency };
     }
     if (toFiat && isStablecoinSymbol(pair.fromCurrency)) {
-      return { direction: "offramp", fiat: toFiat, stablecoin: pair.fromCurrency };
+      return { direction: RampDirection.SELL, fiat: toFiat, stablecoin: pair.fromCurrency };
     }
     return null;
   }
-
-  /**
-   * Test helper: pre-seed the cache without going through the API.
-   */
-  public _setForTesting(entries: Iterable<[string, AlfredpayLimitsBucket]>): void {
-    this.cache = new Map(entries);
-  }
-}
-
-export function resolveAlfredpayLimits(
-  fiat: FiatToken,
-  stablecoin: AlfredpayStablecoinKey,
-  customerType: AlfredpayCustomerKey,
-  direction: AlfredpayLimitsDirection
-): AlfredpayLimitsBucket {
-  if (!isAlfredpayToken(fiat)) {
-    throw new Error(`resolveAlfredpayLimits called with non-AlfredPay fiat: ${fiat}`);
-  }
-  return AlfredpayLimitsService.getInstance().getLimits(fiat, stablecoin, customerType, direction);
-}
-
-export function normalizeCustomerType(type: AlfredpayCustomerType | null | undefined): AlfredpayCustomerKey {
-  return type === AlfredpayCustomerType.BUSINESS ? "BUSINESS" : "INDIVIDUAL";
 }

--- a/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
@@ -1,0 +1,174 @@
+import {
+  AlfredpayApiService,
+  AlfredpayConfigPair,
+  AlfredpayCustomerKey,
+  AlfredpayCustomerType,
+  AlfredpayLimitsBucket,
+  AlfredpayStablecoinKey,
+  FiatToken,
+  getAnyFiatTokenDetails,
+  isAlfredpayToken
+} from "@vortexfi/shared";
+import Big from "big.js";
+import logger from "../../../config/logger";
+
+export type AlfredpayLimitsDirection = "onramp" | "offramp";
+
+/** Refreshed once on startup, then daily. Limits don't change often, so this avoids beating the API. */
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+const CUSTOMER_TYPES: AlfredpayCustomerKey[] = ["INDIVIDUAL", "BUSINESS"];
+
+const ALFREDPAY_FIATS: Record<string, FiatToken> = {
+  COP: FiatToken.COP,
+  MXN: FiatToken.MXN,
+  USD: FiatToken.USD
+};
+
+function isStablecoinSymbol(symbol: string): symbol is AlfredpayStablecoinKey {
+  return symbol === "USDC" || symbol === "USDT";
+}
+
+function cacheKey(
+  direction: AlfredpayLimitsDirection,
+  fiat: FiatToken,
+  stablecoin: AlfredpayStablecoinKey,
+  customer: AlfredpayCustomerKey
+): string {
+  return `${direction}:${fiat}:${stablecoin}:${customer}`;
+}
+
+function toRaw(quantityDecimal: string, decimals: number): string {
+  return new Big(quantityDecimal).mul(new Big(10).pow(decimals)).round(0, Big.roundDown).toFixed(0);
+}
+
+export class AlfredpayLimitsService {
+  private static instance: AlfredpayLimitsService;
+
+  private cache = new Map<string, AlfredpayLimitsBucket>();
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  public static getInstance(): AlfredpayLimitsService {
+    if (!AlfredpayLimitsService.instance) {
+      AlfredpayLimitsService.instance = new AlfredpayLimitsService();
+    }
+    return AlfredpayLimitsService.instance;
+  }
+
+  public start(): void {
+    if (this.intervalHandle) return;
+    void this.refresh();
+    this.intervalHandle = setInterval(() => void this.refresh(), REFRESH_INTERVAL_MS);
+  }
+
+  public stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+
+  /**
+   * Returns the limits bucket for the given key. Falls back to hardcoded values when the cache is empty
+   * (first fetch hasn't succeeded yet) or doesn't contain a matching entry.
+   *
+   * Onramp raw values are scaled by the fiat's decimals; offramp raw values by the stablecoin's decimals (6).
+   */
+  public getLimits(
+    fiat: FiatToken,
+    stablecoin: AlfredpayStablecoinKey,
+    customerType: AlfredpayCustomerKey,
+    direction: AlfredpayLimitsDirection
+  ): AlfredpayLimitsBucket {
+    const cached = this.cache.get(cacheKey(direction, fiat, stablecoin, customerType));
+    if (cached) return cached;
+    return this.fallback(fiat, stablecoin, customerType, direction);
+  }
+
+  private fallback(
+    fiat: FiatToken,
+    stablecoin: AlfredpayStablecoinKey,
+    customerType: AlfredpayCustomerKey,
+    direction: AlfredpayLimitsDirection
+  ): AlfredpayLimitsBucket {
+    const hardcoded = getAnyFiatTokenDetails(fiat).alfredpayLimits;
+    if (!hardcoded) {
+      // Should never happen for AlfredPay tokens. Return permissive sentinel so we don't reject quotes outright.
+      return { maxRaw: "0", minRaw: "0" };
+    }
+    return hardcoded[direction][stablecoin][customerType];
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      const { supportedPairs } = await AlfredpayApiService.getInstance().getAllConfigs();
+      const nextCache = new Map<string, AlfredpayLimitsBucket>();
+      for (const pair of supportedPairs) {
+        this.indexPair(nextCache, pair);
+      }
+      this.cache = nextCache;
+      logger.info(`[AlfredpayLimits] refreshed: ${supportedPairs.length} pairs, ${nextCache.size} cache entries`);
+    } catch (err) {
+      logger.warn("[AlfredpayLimits] refresh failed, retaining previous cache (or hardcoded fallback if empty)", err);
+    }
+  }
+
+  private indexPair(target: Map<string, AlfredpayLimitsBucket>, pair: AlfredpayConfigPair): void {
+    const decimals = Number(pair.decimals);
+    if (!Number.isFinite(decimals)) return;
+
+    const direction = this.deriveDirection(pair);
+    if (!direction) return;
+
+    const { fiat, stablecoin } = direction;
+    const bucket: AlfredpayLimitsBucket = {
+      maxRaw: toRaw(pair.maxQuantity, decimals),
+      minRaw: toRaw(pair.minQuantity, decimals)
+    };
+
+    const customers: AlfredpayCustomerKey[] = pair.typeCustomer ? [pair.typeCustomer as AlfredpayCustomerKey] : CUSTOMER_TYPES;
+    for (const customer of customers) {
+      const key = cacheKey(direction.direction, fiat, stablecoin, customer);
+      // The API can return overlapping rows (typeCustomer=null + a specific BUSINESS row). Specific wins by sorting last.
+      target.set(key, bucket);
+    }
+  }
+
+  private deriveDirection(
+    pair: AlfredpayConfigPair
+  ): { direction: AlfredpayLimitsDirection; fiat: FiatToken; stablecoin: AlfredpayStablecoinKey } | null {
+    const fromFiat = ALFREDPAY_FIATS[pair.fromCurrency];
+    const toFiat = ALFREDPAY_FIATS[pair.toCurrency];
+
+    if (fromFiat && isStablecoinSymbol(pair.toCurrency)) {
+      return { direction: "onramp", fiat: fromFiat, stablecoin: pair.toCurrency };
+    }
+    if (toFiat && isStablecoinSymbol(pair.fromCurrency)) {
+      return { direction: "offramp", fiat: toFiat, stablecoin: pair.fromCurrency };
+    }
+    return null;
+  }
+
+  /**
+   * Test helper: pre-seed the cache without going through the API.
+   */
+  public _setForTesting(entries: Iterable<[string, AlfredpayLimitsBucket]>): void {
+    this.cache = new Map(entries);
+  }
+}
+
+export function resolveAlfredpayLimits(
+  fiat: FiatToken,
+  stablecoin: AlfredpayStablecoinKey,
+  customerType: AlfredpayCustomerKey,
+  direction: AlfredpayLimitsDirection
+): AlfredpayLimitsBucket {
+  if (!isAlfredpayToken(fiat)) {
+    throw new Error(`resolveAlfredpayLimits called with non-AlfredPay fiat: ${fiat}`);
+  }
+  return AlfredpayLimitsService.getInstance().getLimits(fiat, stablecoin, customerType, direction);
+}
+
+export function normalizeCustomerType(type: AlfredpayCustomerType | null | undefined): AlfredpayCustomerKey {
+  return type === AlfredpayCustomerType.BUSINESS ? "BUSINESS" : "INDIVIDUAL";
+}

--- a/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
@@ -10,7 +10,10 @@ import {
   RampDirection
 } from "@vortexfi/shared";
 import Big from "big.js";
+import { Op } from "sequelize";
 import AlfredPayCustomer from "../../../models/alfredPayCustomer.model";
+import QuoteTicket from "../../../models/quoteTicket.model";
+import RampState from "../../../models/rampState.model";
 import { multiplyByPowerOfTen } from "../pendulum/helpers";
 import { AlfredpayLimitsService } from "./alfredpay-limits.service";
 
@@ -91,4 +94,32 @@ export async function resolveAlfredpayQuoteLimits(args: {
     min: multiplyByPowerOfTen(new Big(raw.minRaw), -decimals).toFixed(),
     stablecoin
   };
+}
+
+function startOfCurrentUtcMonth(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
+/** Returned in input-currency human units: fiat on onramp, stablecoin on offramp. */
+export async function getAlfredpayMonthlyUsage(userId: string, direction: RampDirection, fiat: FiatToken): Promise<Big> {
+  const isOnramp = direction === RampDirection.BUY;
+  const fiatSide = isOnramp ? { inputCurrency: fiat } : { outputCurrency: fiat };
+
+  const completedRamps = await RampState.findAll({
+    include: [{ as: "quote", model: QuoteTicket, required: true, where: fiatSide }],
+    where: {
+      createdAt: { [Op.gte]: startOfCurrentUtcMonth() },
+      currentPhase: "complete",
+      type: direction,
+      userId
+    }
+  });
+
+  let total = new Big(0);
+  for (const ramp of completedRamps) {
+    const quote = (ramp as RampState & { quote: QuoteTicket }).quote;
+    total = total.plus(quote.inputAmount);
+  }
+  return total;
 }

--- a/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
@@ -1,8 +1,8 @@
 import {
   AlfredPayCountry,
-  AlfredpayCustomerKey,
   AlfredpayCustomerType,
   AlfredpayStablecoinKey,
+  AmountLimits,
   FiatToken,
   getAnyFiatTokenDetails,
   isAlfredpayToken,
@@ -12,7 +12,7 @@ import {
 import Big from "big.js";
 import AlfredPayCustomer from "../../../models/alfredPayCustomer.model";
 import { multiplyByPowerOfTen } from "../pendulum/helpers";
-import { AlfredpayLimitsDirection, AlfredpayLimitsService, normalizeCustomerType } from "./alfredpay-limits.service";
+import { AlfredpayLimitsService } from "./alfredpay-limits.service";
 
 const FIAT_TO_COUNTRY: Partial<Record<FiatToken, AlfredPayCountry>> = {
   [FiatToken.COP]: AlfredPayCountry.CO,
@@ -32,15 +32,12 @@ export function alfredpayCountryForFiat(fiat: FiatToken): AlfredPayCountry | und
  * Defaulting to INDIVIDUAL is intentional — it's the more restrictive bucket on USD/COP, so an
  * anonymous quote that would later route through a Business customer just sees tighter limits at first.
  */
-export async function lookupAlfredpayCustomerType(
-  userId: string | undefined,
-  fiat: FiatToken
-): Promise<"INDIVIDUAL" | "BUSINESS"> {
-  if (!userId) return "INDIVIDUAL";
+export async function lookupAlfredpayCustomerType(userId: string | undefined, fiat: FiatToken): Promise<AlfredpayCustomerType> {
+  if (!userId) return AlfredpayCustomerType.INDIVIDUAL;
   const country = alfredpayCountryForFiat(fiat);
-  if (!country) return "INDIVIDUAL";
+  if (!country) return AlfredpayCustomerType.INDIVIDUAL;
   const customer = await AlfredPayCustomer.findOne({ where: { country, userId } });
-  return normalizeCustomerType(customer?.type as AlfredpayCustomerType | undefined);
+  return customer?.type === AlfredpayCustomerType.BUSINESS ? AlfredpayCustomerType.BUSINESS : AlfredpayCustomerType.INDIVIDUAL;
 }
 
 /**
@@ -48,54 +45,50 @@ export async function lookupAlfredpayCustomerType(
  * Returns null if the currency isn't a recognized AlfredPay stablecoin.
  */
 export function stablecoinFromCurrency(currency: RampCurrency): AlfredpayStablecoinKey | null {
-  const symbol = String(currency);
-  if (symbol === "USDC" || symbol === "USDT") return symbol;
-  return null;
+  return currency === "USDC" || currency === "USDT" ? currency : null;
 }
 
-export interface AlfredpayQuoteLimitsContext {
+/** AlfredPay limits resolved for a specific quote — includes the axes used to pick them. */
+export interface ResolvedAlfredpayLimits extends AmountLimits {
   fiat: FiatToken;
   stablecoin: AlfredpayStablecoinKey;
-  customerType: AlfredpayCustomerKey;
-  direction: AlfredpayLimitsDirection;
-  /** Limits expressed in human units of `inputCurrency` (the side the validator checks). */
-  inputLimits: { min: string; max: string };
+  customer: AlfredpayCustomerType;
+  direction: RampDirection;
 }
 
 /**
  * Resolves AlfredPay limits for a quote request, returning null when the quote isn't an AlfredPay quote.
  * Throws when the on-chain side isn't a recognized AlfredPay stablecoin.
+ *
+ * Returned limits are in human units of `inputCurrency` (the side the validator checks).
  */
 export async function resolveAlfredpayQuoteLimits(args: {
   rampType: RampDirection;
   inputCurrency: RampCurrency;
   outputCurrency: RampCurrency;
   userId?: string;
-}): Promise<AlfredpayQuoteLimitsContext | null> {
+}): Promise<ResolvedAlfredpayLimits | null> {
   const { rampType, inputCurrency, outputCurrency, userId } = args;
-  const direction: AlfredpayLimitsDirection = rampType === RampDirection.BUY ? "onramp" : "offramp";
-  const fiatCandidate = (direction === "onramp" ? inputCurrency : outputCurrency) as FiatToken;
+  const isOnramp = rampType === RampDirection.BUY;
+  const fiatCandidate = isOnramp ? inputCurrency : outputCurrency;
+  const onchainCurrency = isOnramp ? outputCurrency : inputCurrency;
   if (!isAlfredpayToken(fiatCandidate)) return null;
 
-  const stablecoin = stablecoinFromCurrency(direction === "onramp" ? outputCurrency : inputCurrency);
+  const stablecoin = stablecoinFromCurrency(onchainCurrency);
   if (!stablecoin) {
-    throw new Error(
-      `Unsupported AlfredPay ${direction} stablecoin: ${direction === "onramp" ? outputCurrency : inputCurrency}`
-    );
+    throw new Error(`Unsupported AlfredPay stablecoin: ${onchainCurrency}`);
   }
 
-  const customerType = await lookupAlfredpayCustomerType(userId, fiatCandidate);
-  const bucket = AlfredpayLimitsService.getInstance().getLimits(fiatCandidate, stablecoin, customerType, direction);
-  const decimals = direction === "onramp" ? getAnyFiatTokenDetails(fiatCandidate).decimals : 6;
+  const customer = await lookupAlfredpayCustomerType(userId, fiatCandidate);
+  const raw = AlfredpayLimitsService.getInstance().getLimits(fiatCandidate, stablecoin, customer, rampType);
+  const decimals = isOnramp ? getAnyFiatTokenDetails(fiatCandidate).decimals : 6;
 
   return {
-    customerType,
-    direction,
+    customer,
+    direction: rampType,
     fiat: fiatCandidate,
-    inputLimits: {
-      max: multiplyByPowerOfTen(new Big(bucket.maxRaw), -decimals).toFixed(),
-      min: multiplyByPowerOfTen(new Big(bucket.minRaw), -decimals).toFixed()
-    },
+    max: multiplyByPowerOfTen(new Big(raw.maxRaw), -decimals).toFixed(),
+    min: multiplyByPowerOfTen(new Big(raw.minRaw), -decimals).toFixed(),
     stablecoin
   };
 }

--- a/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
@@ -106,7 +106,7 @@ export async function getAlfredpayMonthlyUsage(userId: string, direction: RampDi
   const isOnramp = direction === RampDirection.BUY;
   const fiatSide = isOnramp ? { inputCurrency: fiat } : { outputCurrency: fiat };
 
-  const completedRamps = await RampState.findAll({
+  const completedRamps = (await RampState.findAll({
     include: [{ as: "quote", model: QuoteTicket, required: true, where: fiatSide }],
     where: {
       createdAt: { [Op.gte]: startOfCurrentUtcMonth() },
@@ -114,12 +114,11 @@ export async function getAlfredpayMonthlyUsage(userId: string, direction: RampDi
       type: direction,
       userId
     }
-  });
+  })) as Array<RampState & { quote: QuoteTicket }>;
 
   let total = new Big(0);
   for (const ramp of completedRamps) {
-    const quote = (ramp as RampState & { quote: QuoteTicket }).quote;
-    total = total.plus(quote.inputAmount);
+    total = total.plus(ramp.quote.inputAmount);
   }
   return total;
 }

--- a/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
@@ -39,7 +39,7 @@ export async function lookupAlfredpayCustomerType(userId: string | undefined, fi
   if (!userId) return AlfredpayCustomerType.INDIVIDUAL;
   const country = alfredpayCountryForFiat(fiat);
   if (!country) return AlfredpayCustomerType.INDIVIDUAL;
-  const customer = await AlfredPayCustomer.findOne({ where: { country, userId } });
+  const customer = await AlfredPayCustomer.findOne({ order: [["type", "ASC"]], where: { country, userId } });
   return customer?.type === AlfredpayCustomerType.BUSINESS ? AlfredpayCustomerType.BUSINESS : AlfredpayCustomerType.INDIVIDUAL;
 }
 
@@ -102,12 +102,18 @@ function startOfCurrentUtcMonth(): Date {
 }
 
 /** Returned in input-currency human units: fiat on onramp, stablecoin on offramp. */
-export async function getAlfredpayMonthlyUsage(userId: string, direction: RampDirection, fiat: FiatToken): Promise<Big> {
+export async function getAlfredpayMonthlyUsage(
+  userId: string,
+  direction: RampDirection,
+  fiat: FiatToken,
+  stablecoin: AlfredpayStablecoinKey
+): Promise<Big> {
   const isOnramp = direction === RampDirection.BUY;
   const fiatSide = isOnramp ? { inputCurrency: fiat } : { outputCurrency: fiat };
+  const stablecoinSide = isOnramp ? { outputCurrency: stablecoin } : { inputCurrency: stablecoin };
 
   const completedRamps = (await RampState.findAll({
-    include: [{ as: "quote", model: QuoteTicket, required: true, where: fiatSide }],
+    include: [{ as: "quote", model: QuoteTicket, required: true, where: { ...fiatSide, ...stablecoinSide } }],
     where: {
       createdAt: { [Op.gte]: startOfCurrentUtcMonth() },
       currentPhase: "complete",

--- a/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay.helpers.ts
@@ -1,0 +1,101 @@
+import {
+  AlfredPayCountry,
+  AlfredpayCustomerKey,
+  AlfredpayCustomerType,
+  AlfredpayStablecoinKey,
+  FiatToken,
+  getAnyFiatTokenDetails,
+  isAlfredpayToken,
+  RampCurrency,
+  RampDirection
+} from "@vortexfi/shared";
+import Big from "big.js";
+import AlfredPayCustomer from "../../../models/alfredPayCustomer.model";
+import { multiplyByPowerOfTen } from "../pendulum/helpers";
+import { AlfredpayLimitsDirection, AlfredpayLimitsService, normalizeCustomerType } from "./alfredpay-limits.service";
+
+const FIAT_TO_COUNTRY: Partial<Record<FiatToken, AlfredPayCountry>> = {
+  [FiatToken.COP]: AlfredPayCountry.CO,
+  [FiatToken.MXN]: AlfredPayCountry.MX,
+  [FiatToken.USD]: AlfredPayCountry.US
+};
+
+export function alfredpayCountryForFiat(fiat: FiatToken): AlfredPayCountry | undefined {
+  return FIAT_TO_COUNTRY[fiat];
+}
+
+/**
+ * Returns the AlfredPay customer type for a user+country, defaulting to INDIVIDUAL when:
+ * - no userId is available (unauthenticated quote)
+ * - the user has no alfredpay_customer row for that country (KYC not started)
+ *
+ * Defaulting to INDIVIDUAL is intentional — it's the more restrictive bucket on USD/COP, so an
+ * anonymous quote that would later route through a Business customer just sees tighter limits at first.
+ */
+export async function lookupAlfredpayCustomerType(
+  userId: string | undefined,
+  fiat: FiatToken
+): Promise<"INDIVIDUAL" | "BUSINESS"> {
+  if (!userId) return "INDIVIDUAL";
+  const country = alfredpayCountryForFiat(fiat);
+  if (!country) return "INDIVIDUAL";
+  const customer = await AlfredPayCustomer.findOne({ where: { country, userId } });
+  return normalizeCustomerType(customer?.type as AlfredpayCustomerType | undefined);
+}
+
+/**
+ * Resolves the stablecoin axis (USDC vs USDT) from the on-chain currency in a quote request.
+ * Returns null if the currency isn't a recognized AlfredPay stablecoin.
+ */
+export function stablecoinFromCurrency(currency: RampCurrency): AlfredpayStablecoinKey | null {
+  const symbol = String(currency);
+  if (symbol === "USDC" || symbol === "USDT") return symbol;
+  return null;
+}
+
+export interface AlfredpayQuoteLimitsContext {
+  fiat: FiatToken;
+  stablecoin: AlfredpayStablecoinKey;
+  customerType: AlfredpayCustomerKey;
+  direction: AlfredpayLimitsDirection;
+  /** Limits expressed in human units of `inputCurrency` (the side the validator checks). */
+  inputLimits: { min: string; max: string };
+}
+
+/**
+ * Resolves AlfredPay limits for a quote request, returning null when the quote isn't an AlfredPay quote.
+ * Throws when the on-chain side isn't a recognized AlfredPay stablecoin.
+ */
+export async function resolveAlfredpayQuoteLimits(args: {
+  rampType: RampDirection;
+  inputCurrency: RampCurrency;
+  outputCurrency: RampCurrency;
+  userId?: string;
+}): Promise<AlfredpayQuoteLimitsContext | null> {
+  const { rampType, inputCurrency, outputCurrency, userId } = args;
+  const direction: AlfredpayLimitsDirection = rampType === RampDirection.BUY ? "onramp" : "offramp";
+  const fiatCandidate = (direction === "onramp" ? inputCurrency : outputCurrency) as FiatToken;
+  if (!isAlfredpayToken(fiatCandidate)) return null;
+
+  const stablecoin = stablecoinFromCurrency(direction === "onramp" ? outputCurrency : inputCurrency);
+  if (!stablecoin) {
+    throw new Error(
+      `Unsupported AlfredPay ${direction} stablecoin: ${direction === "onramp" ? outputCurrency : inputCurrency}`
+    );
+  }
+
+  const customerType = await lookupAlfredpayCustomerType(userId, fiatCandidate);
+  const bucket = AlfredpayLimitsService.getInstance().getLimits(fiatCandidate, stablecoin, customerType, direction);
+  const decimals = direction === "onramp" ? getAnyFiatTokenDetails(fiatCandidate).decimals : 6;
+
+  return {
+    customerType,
+    direction,
+    fiat: fiatCandidate,
+    inputLimits: {
+      max: multiplyByPowerOfTen(new Big(bucket.maxRaw), -decimals).toFixed(),
+      min: multiplyByPowerOfTen(new Big(bucket.minRaw), -decimals).toFixed()
+    },
+    stablecoin
+  };
+}

--- a/apps/api/src/api/services/quote/core/types.ts
+++ b/apps/api/src/api/services/quote/core/types.ts
@@ -2,6 +2,7 @@
 // Shared types and contracts used by the quote pipeline.
 
 import {
+  AmountLimits,
   CreateQuoteRequest,
   DestinationType,
   EvmToken,
@@ -267,10 +268,10 @@ export interface QuoteContext {
   builtResponse?: QuoteResponse;
 
   /**
-   * Resolved AlfredPay input-side limits in human units of `inputCurrency`.
+   * Resolved AlfredPay input-side amount limits in human units of `inputCurrency`.
    * Set by the finalize engine during validation for AlfredPay quotes; surfaced on the QuoteResponse.
    */
-  alfredpayInputLimits?: { min: string; max: string };
+  alfredpayInputLimits?: AmountLimits;
 
   // Flag to skip database persistence (for best quote comparison)
   skipPersistence?: boolean;

--- a/apps/api/src/api/services/quote/core/types.ts
+++ b/apps/api/src/api/services/quote/core/types.ts
@@ -266,6 +266,12 @@ export interface QuoteContext {
   // Allow engines to supply a ready response (used by special-case engine and finalize stage)
   builtResponse?: QuoteResponse;
 
+  /**
+   * Resolved AlfredPay input-side limits in human units of `inputCurrency`.
+   * Set by the finalize engine during validation for AlfredPay quotes; surfaced on the QuoteResponse.
+   */
+  alfredpayInputLimits?: { min: string; max: string };
+
   // Flag to skip database persistence (for best quote comparison)
   skipPersistence?: boolean;
 

--- a/apps/api/src/api/services/quote/core/validation-helpers.ts
+++ b/apps/api/src/api/services/quote/core/validation-helpers.ts
@@ -2,7 +2,11 @@ import { FiatToken, getAnyFiatTokenDetails, RampDirection } from "@vortexfi/shar
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../errors/api-error";
-import { ResolvedAlfredpayLimits, resolveAlfredpayQuoteLimits } from "../../alfredpay/alfredpay.helpers";
+import {
+  getAlfredpayMonthlyUsage,
+  ResolvedAlfredpayLimits,
+  resolveAlfredpayQuoteLimits
+} from "../../alfredpay/alfredpay.helpers";
 import { multiplyByPowerOfTen } from "../../pendulum/helpers";
 import { QuoteContext } from "./types";
 
@@ -70,15 +74,15 @@ export function validateAlfredpayLimits(amount: Big.BigSource, limits: ResolvedA
   }
   if (amountBig.gt(max)) {
     throw new APIError({
-      message: `Input amount exceeds maximum ${verb} limit of ${max.toFixed(2)} ${unitSymbol}`,
+      message: `Input amount exceeds monthly ${verb} limit of ${max.toFixed(2)} ${unitSymbol}`,
       status: httpStatus.BAD_REQUEST
     });
   }
 }
 
 /**
- * Resolves AlfredPay limits for the quote, records them on the context, and validates the given amount.
  * Returns true when the quote routes through AlfredPay (caller should skip generic validation).
+ * The max is a monthly cap; unauthenticated quotes only get per-tx checks.
  */
 export async function applyAlfredpayLimits(ctx: QuoteContext, amount: Big.BigSource): Promise<boolean> {
   const alfredpayLimits = await resolveAlfredpayQuoteLimits({
@@ -90,5 +94,19 @@ export async function applyAlfredpayLimits(ctx: QuoteContext, amount: Big.BigSou
   if (!alfredpayLimits) return false;
   ctx.alfredpayInputLimits = { max: alfredpayLimits.max, min: alfredpayLimits.min };
   validateAlfredpayLimits(amount, alfredpayLimits);
-  return true;
+
+  const { userId } = ctx.request;
+  if (!userId) return true;
+
+  const used = await getAlfredpayMonthlyUsage(userId, alfredpayLimits.direction, alfredpayLimits.fiat);
+  const max = new Big(alfredpayLimits.max);
+  if (used.plus(new Big(amount)).lte(max)) return true;
+
+  const isOnramp = alfredpayLimits.direction === RampDirection.BUY;
+  const verb = isOnramp ? "onramp" : "offramp";
+  const unitSymbol = isOnramp ? getAnyFiatTokenDetails(alfredpayLimits.fiat).fiat.symbol : alfredpayLimits.stablecoin;
+  throw new APIError({
+    message: `Monthly ${verb} limit of ${max.toFixed(2)} ${unitSymbol} would be exceeded (already used ${used.toFixed(2)} ${unitSymbol} this month).`,
+    status: httpStatus.BAD_REQUEST
+  });
 }

--- a/apps/api/src/api/services/quote/core/validation-helpers.ts
+++ b/apps/api/src/api/services/quote/core/validation-helpers.ts
@@ -98,7 +98,12 @@ export async function applyAlfredpayLimits(ctx: QuoteContext, amount: Big.BigSou
   const { userId } = ctx.request;
   if (!userId) return true;
 
-  const used = await getAlfredpayMonthlyUsage(userId, alfredpayLimits.direction, alfredpayLimits.fiat);
+  const used = await getAlfredpayMonthlyUsage(
+    userId,
+    alfredpayLimits.direction,
+    alfredpayLimits.fiat,
+    alfredpayLimits.stablecoin
+  );
   const max = new Big(alfredpayLimits.max);
   if (used.plus(new Big(amount)).lte(max)) return true;
 

--- a/apps/api/src/api/services/quote/core/validation-helpers.ts
+++ b/apps/api/src/api/services/quote/core/validation-helpers.ts
@@ -2,6 +2,7 @@ import { FiatToken, getAnyFiatTokenDetails, RampDirection } from "@vortexfi/shar
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../errors/api-error";
+import { AlfredpayQuoteLimitsContext } from "../../alfredpay/alfredpay.helpers";
 import { multiplyByPowerOfTen } from "../../pendulum/helpers";
 
 /**
@@ -43,6 +44,30 @@ export function validateAmountLimits(
   if (shouldThrowError) {
     throw new APIError({
       message: errorMessage,
+      status: httpStatus.BAD_REQUEST
+    });
+  }
+}
+
+/**
+ * Validate an amount against precomputed AlfredPay limits. The amount is in the same units as the limits:
+ * onramp → fiat units; offramp → stablecoin units.
+ */
+export function validateAlfredpayLimits(amount: Big.BigSource, limits: AlfredpayQuoteLimitsContext): void {
+  const amountBig = new Big(amount);
+  const min = new Big(limits.inputLimits.min);
+  const max = new Big(limits.inputLimits.max);
+  const unitSymbol = limits.direction === "onramp" ? getAnyFiatTokenDetails(limits.fiat).fiat.symbol : limits.stablecoin;
+
+  if (amountBig.lt(min)) {
+    throw new APIError({
+      message: `Input amount below minimum ${limits.direction} limit of ${min.toFixed(2)} ${unitSymbol}`,
+      status: httpStatus.BAD_REQUEST
+    });
+  }
+  if (amountBig.gt(max)) {
+    throw new APIError({
+      message: `Input amount exceeds maximum ${limits.direction} limit of ${max.toFixed(2)} ${unitSymbol}`,
       status: httpStatus.BAD_REQUEST
     });
   }

--- a/apps/api/src/api/services/quote/core/validation-helpers.ts
+++ b/apps/api/src/api/services/quote/core/validation-helpers.ts
@@ -2,8 +2,9 @@ import { FiatToken, getAnyFiatTokenDetails, RampDirection } from "@vortexfi/shar
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../errors/api-error";
-import { AlfredpayQuoteLimitsContext } from "../../alfredpay/alfredpay.helpers";
+import { ResolvedAlfredpayLimits, resolveAlfredpayQuoteLimits } from "../../alfredpay/alfredpay.helpers";
 import { multiplyByPowerOfTen } from "../../pendulum/helpers";
+import { QuoteContext } from "./types";
 
 /**
  * Get token limit units for a given fiat token, limit type, and operation type
@@ -53,22 +54,41 @@ export function validateAmountLimits(
  * Validate an amount against precomputed AlfredPay limits. The amount is in the same units as the limits:
  * onramp → fiat units; offramp → stablecoin units.
  */
-export function validateAlfredpayLimits(amount: Big.BigSource, limits: AlfredpayQuoteLimitsContext): void {
+export function validateAlfredpayLimits(amount: Big.BigSource, limits: ResolvedAlfredpayLimits): void {
   const amountBig = new Big(amount);
-  const min = new Big(limits.inputLimits.min);
-  const max = new Big(limits.inputLimits.max);
-  const unitSymbol = limits.direction === "onramp" ? getAnyFiatTokenDetails(limits.fiat).fiat.symbol : limits.stablecoin;
+  const min = new Big(limits.min);
+  const max = new Big(limits.max);
+  const isOnramp = limits.direction === RampDirection.BUY;
+  const verb = isOnramp ? "onramp" : "offramp";
+  const unitSymbol = isOnramp ? getAnyFiatTokenDetails(limits.fiat).fiat.symbol : limits.stablecoin;
 
   if (amountBig.lt(min)) {
     throw new APIError({
-      message: `Input amount below minimum ${limits.direction} limit of ${min.toFixed(2)} ${unitSymbol}`,
+      message: `Input amount below minimum ${verb} limit of ${min.toFixed(2)} ${unitSymbol}`,
       status: httpStatus.BAD_REQUEST
     });
   }
   if (amountBig.gt(max)) {
     throw new APIError({
-      message: `Input amount exceeds maximum ${limits.direction} limit of ${max.toFixed(2)} ${unitSymbol}`,
+      message: `Input amount exceeds maximum ${verb} limit of ${max.toFixed(2)} ${unitSymbol}`,
       status: httpStatus.BAD_REQUEST
     });
   }
+}
+
+/**
+ * Resolves AlfredPay limits for the quote, records them on the context, and validates the given amount.
+ * Returns true when the quote routes through AlfredPay (caller should skip generic validation).
+ */
+export async function applyAlfredpayLimits(ctx: QuoteContext, amount: Big.BigSource): Promise<boolean> {
+  const alfredpayLimits = await resolveAlfredpayQuoteLimits({
+    inputCurrency: ctx.request.inputCurrency,
+    outputCurrency: ctx.request.outputCurrency,
+    rampType: ctx.request.rampType,
+    userId: ctx.request.userId
+  });
+  if (!alfredpayLimits) return false;
+  ctx.alfredpayInputLimits = { max: alfredpayLimits.max, min: alfredpayLimits.min };
+  validateAlfredpayLimits(amount, alfredpayLimits);
+  return true;
 }

--- a/apps/api/src/api/services/quote/engines/finalize/index.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/index.ts
@@ -116,8 +116,8 @@ export abstract class BaseFinalizeEngine implements Stage {
         createdAt: new Date(),
         expiresAt,
         feeCurrency: fiatFees.currency,
-        from: request.from, // Temporary ID for comparison
-        id: "temp-" + Date.now(),
+        from: request.from,
+        id: "temp-" + Date.now(), // Temporary ID for comparison
         inputAmount: trimTrailingZeros(request.inputAmount),
         inputCurrency: request.inputCurrency,
         network: request.network,

--- a/apps/api/src/api/services/quote/engines/finalize/index.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/index.ts
@@ -48,6 +48,7 @@ export function buildQuoteResponse(quoteTicket: QuoteTicket): QuoteResponse {
     from: quoteTicket.from,
     id: quoteTicket.id,
     inputAmount: trimTrailingZeros(quoteTicket.inputAmount),
+    inputAmountLimits: quoteTicket.metadata.alfredpayInputLimits,
     inputCurrency: quoteTicket.inputCurrency,
     network: quoteTicket.network,
     networkFeeFiat: fiatFees.network,
@@ -87,7 +88,7 @@ export abstract class BaseFinalizeEngine implements Stage {
     }
 
     const computation = await this.computeOutput(ctx);
-    this.validate(ctx, computation);
+    await this.validate(ctx, computation);
 
     const outputAmountStr = computation.amount.toFixed(computation.decimals, 0);
 
@@ -117,6 +118,7 @@ export abstract class BaseFinalizeEngine implements Stage {
         from: request.from,
         id: "temp-" + Date.now(), // Temporary ID for comparison
         inputAmount: trimTrailingZeros(request.inputAmount),
+        inputAmountLimits: ctx.alfredpayInputLimits,
         inputCurrency: request.inputCurrency,
         network: request.network,
         networkFeeFiat: fiatFees.network,
@@ -170,7 +172,7 @@ export abstract class BaseFinalizeEngine implements Stage {
 
   protected abstract computeOutput(ctx: QuoteContext): Promise<FinalizeComputation>;
 
-  protected validate(ctx: QuoteContext, result: FinalizeComputation): void {
+  protected async validate(_ctx: QuoteContext, _result: FinalizeComputation): Promise<void> {
     // Implemented by subclasses when necessary
   }
 }

--- a/apps/api/src/api/services/quote/engines/finalize/index.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/index.ts
@@ -40,6 +40,7 @@ export function buildQuoteResponse(quoteTicket: QuoteTicket): QuoteResponse {
   const processingFeeUsd = new Big(usdFees.anchor).plus(usdFees.vortex).toFixed();
 
   return {
+    alfredpayInputLimits: quoteTicket.metadata.alfredpayInputLimits,
     anchorFeeFiat: fiatFees.anchor,
     anchorFeeUsd: usdFees.anchor,
     createdAt: quoteTicket.createdAt,
@@ -48,7 +49,6 @@ export function buildQuoteResponse(quoteTicket: QuoteTicket): QuoteResponse {
     from: quoteTicket.from,
     id: quoteTicket.id,
     inputAmount: trimTrailingZeros(quoteTicket.inputAmount),
-    inputAmountLimits: quoteTicket.metadata.alfredpayInputLimits,
     inputCurrency: quoteTicket.inputCurrency,
     network: quoteTicket.network,
     networkFeeFiat: fiatFees.network,
@@ -110,15 +110,15 @@ export abstract class BaseFinalizeEngine implements Stage {
       const expiresAt = getExpirationDate(ctx);
 
       ctx.builtResponse = {
+        alfredpayInputLimits: ctx.alfredpayInputLimits,
         anchorFeeFiat: fiatFees.anchor,
         anchorFeeUsd: usdFees.anchor,
         createdAt: new Date(),
         expiresAt,
         feeCurrency: fiatFees.currency,
-        from: request.from,
-        id: "temp-" + Date.now(), // Temporary ID for comparison
+        from: request.from, // Temporary ID for comparison
+        id: "temp-" + Date.now(),
         inputAmount: trimTrailingZeros(request.inputAmount),
-        inputAmountLimits: ctx.alfredpayInputLimits,
         inputCurrency: request.inputCurrency,
         network: request.network,
         networkFeeFiat: fiatFees.network,

--- a/apps/api/src/api/services/quote/engines/finalize/offramp.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/offramp.ts
@@ -2,9 +2,8 @@ import { FiatToken, RampDirection } from "@vortexfi/shared";
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../../errors/api-error";
-import { resolveAlfredpayQuoteLimits } from "../../../alfredpay/alfredpay.helpers";
 import { QuoteContext } from "../../core/types";
-import { validateAlfredpayLimits, validateAmountLimits } from "../../core/validation-helpers";
+import { applyAlfredpayLimits, validateAmountLimits } from "../../core/validation-helpers";
 import { BaseFinalizeEngine, FinalizeComputation } from ".";
 
 export class OffRampFinalizeEngine extends BaseFinalizeEngine {
@@ -55,18 +54,7 @@ export class OffRampFinalizeEngine extends BaseFinalizeEngine {
   }
 
   protected async validate(ctx: QuoteContext, { amount }: FinalizeComputation): Promise<void> {
-    const alfredpayLimits = await resolveAlfredpayQuoteLimits({
-      inputCurrency: ctx.request.inputCurrency,
-      outputCurrency: ctx.request.outputCurrency,
-      rampType: ctx.request.rampType,
-      userId: ctx.request.userId
-    });
-
-    if (alfredpayLimits) {
-      ctx.alfredpayInputLimits = alfredpayLimits.inputLimits;
-      validateAlfredpayLimits(ctx.request.inputAmount, alfredpayLimits);
-      return;
-    }
+    if (await applyAlfredpayLimits(ctx, ctx.request.inputAmount)) return;
     validateAmountLimits(amount, ctx.request.outputCurrency as FiatToken, "min", ctx.request.rampType);
   }
 }

--- a/apps/api/src/api/services/quote/engines/finalize/offramp.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/offramp.ts
@@ -2,8 +2,9 @@ import { FiatToken, RampDirection } from "@vortexfi/shared";
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../../errors/api-error";
+import { resolveAlfredpayQuoteLimits } from "../../../alfredpay/alfredpay.helpers";
 import { QuoteContext } from "../../core/types";
-import { validateAmountLimits } from "../../core/validation-helpers";
+import { validateAlfredpayLimits, validateAmountLimits } from "../../core/validation-helpers";
 import { BaseFinalizeEngine, FinalizeComputation } from ".";
 
 export class OffRampFinalizeEngine extends BaseFinalizeEngine {
@@ -53,7 +54,19 @@ export class OffRampFinalizeEngine extends BaseFinalizeEngine {
     };
   }
 
-  protected validate(ctx: QuoteContext, { amount }: FinalizeComputation): void {
+  protected async validate(ctx: QuoteContext, { amount }: FinalizeComputation): Promise<void> {
+    const alfredpayLimits = await resolveAlfredpayQuoteLimits({
+      inputCurrency: ctx.request.inputCurrency,
+      outputCurrency: ctx.request.outputCurrency,
+      rampType: ctx.request.rampType,
+      userId: ctx.request.userId
+    });
+
+    if (alfredpayLimits) {
+      ctx.alfredpayInputLimits = alfredpayLimits.inputLimits;
+      validateAlfredpayLimits(ctx.request.inputAmount, alfredpayLimits);
+      return;
+    }
     validateAmountLimits(amount, ctx.request.outputCurrency as FiatToken, "min", ctx.request.rampType);
   }
 }

--- a/apps/api/src/api/services/quote/engines/finalize/onramp.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/onramp.ts
@@ -2,9 +2,8 @@ import { AssetHubToken, FiatToken, RampDirection } from "@vortexfi/shared";
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../../errors/api-error";
-import { resolveAlfredpayQuoteLimits } from "../../../alfredpay/alfredpay.helpers";
 import { QuoteContext } from "../../core/types";
-import { validateAlfredpayLimits, validateAmountLimits } from "../../core/validation-helpers";
+import { applyAlfredpayLimits, validateAmountLimits } from "../../core/validation-helpers";
 import { BaseFinalizeEngine, FinalizeComputation } from ".";
 
 export class OnRampFinalizeEngine extends BaseFinalizeEngine {
@@ -88,18 +87,7 @@ export class OnRampFinalizeEngine extends BaseFinalizeEngine {
   }
 
   protected async validate(ctx: QuoteContext): Promise<void> {
-    const alfredpayLimits = await resolveAlfredpayQuoteLimits({
-      inputCurrency: ctx.request.inputCurrency,
-      outputCurrency: ctx.request.outputCurrency,
-      rampType: ctx.request.rampType,
-      userId: ctx.request.userId
-    });
-
-    if (alfredpayLimits) {
-      ctx.alfredpayInputLimits = alfredpayLimits.inputLimits;
-      validateAlfredpayLimits(ctx.request.inputAmount, alfredpayLimits);
-      return;
-    }
+    if (await applyAlfredpayLimits(ctx, ctx.request.inputAmount)) return;
     validateAmountLimits(ctx.request.inputAmount, ctx.request.inputCurrency as FiatToken, "min", ctx.request.rampType);
   }
 }

--- a/apps/api/src/api/services/quote/engines/finalize/onramp.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/onramp.ts
@@ -2,8 +2,9 @@ import { AssetHubToken, FiatToken, RampDirection } from "@vortexfi/shared";
 import Big from "big.js";
 import httpStatus from "http-status";
 import { APIError } from "../../../../errors/api-error";
+import { resolveAlfredpayQuoteLimits } from "../../../alfredpay/alfredpay.helpers";
 import { QuoteContext } from "../../core/types";
-import { validateAmountLimits } from "../../core/validation-helpers";
+import { validateAlfredpayLimits, validateAmountLimits } from "../../core/validation-helpers";
 import { BaseFinalizeEngine, FinalizeComputation } from ".";
 
 export class OnRampFinalizeEngine extends BaseFinalizeEngine {
@@ -86,7 +87,19 @@ export class OnRampFinalizeEngine extends BaseFinalizeEngine {
     };
   }
 
-  protected validate(ctx: QuoteContext): void {
+  protected async validate(ctx: QuoteContext): Promise<void> {
+    const alfredpayLimits = await resolveAlfredpayQuoteLimits({
+      inputCurrency: ctx.request.inputCurrency,
+      outputCurrency: ctx.request.outputCurrency,
+      rampType: ctx.request.rampType,
+      userId: ctx.request.userId
+    });
+
+    if (alfredpayLimits) {
+      ctx.alfredpayInputLimits = alfredpayLimits.inputLimits;
+      validateAlfredpayLimits(ctx.request.inputAmount, alfredpayLimits);
+      return;
+    }
     validateAmountLimits(ctx.request.inputAmount, ctx.request.inputCurrency as FiatToken, "min", ctx.request.rampType);
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./constants/constants";
 import { runMigrations } from "./database/migrator";
 import "./models"; // Initialize models
+import { AlfredpayLimitsService } from "./api/services/alfredpay/alfredpay-limits.service";
 import registerPhaseHandlers from "./api/services/phases/register-handlers";
 import CleanupWorker from "./api/workers/cleanup.worker";
 import RampRecoveryWorker from "./api/workers/ramp-recovery.worker";
@@ -72,6 +73,9 @@ const initializeApp = async () => {
     new CleanupWorker().start();
     new RampRecoveryWorker().start();
     new UnhandledPaymentWorker().start();
+
+    // Start AlfredPay limits refresh loop (10 min TTL; falls back to hardcoded if stale)
+    AlfredpayLimitsService.getInstance().start();
 
     // Register phase handlers
     registerPhaseHandlers();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -74,7 +74,7 @@ const initializeApp = async () => {
     new RampRecoveryWorker().start();
     new UnhandledPaymentWorker().start();
 
-    // Start AlfredPay limits refresh loop (10 min TTL; falls back to hardcoded if stale)
+    // Start AlfredPay limits refresh loop (daily; falls back to hardcoded if stale)
     AlfredpayLimitsService.getInstance().start();
 
     // Register phase handlers

--- a/apps/frontend/src/hooks/ramp/useRampValidation.ts
+++ b/apps/frontend/src/hooks/ramp/useRampValidation.ts
@@ -1,4 +1,5 @@
 import {
+  AmountLimits,
   FiatToken,
   FiatTokenDetails,
   getAnyFiatTokenDetails,
@@ -29,30 +30,30 @@ function validateOnramp(
   {
     inputAmount,
     fromToken,
-    quoteLimits,
+    limits,
     trackEvent
   }: {
     inputAmount: Big;
     fromToken: FiatTokenDetails;
-    quoteLimits?: { min: string; max: string };
+    limits?: AmountLimits;
     trackEvent: (event: TrackableEvent) => void;
   }
 ): string | null {
-  const maxAmountUnits = quoteLimits
-    ? new Big(quoteLimits.max)
+  const maxAmountUnits = limits
+    ? new Big(limits.max)
     : multiplyByPowerOfTen(Big(fromToken.maxBuyAmountRaw), -fromToken.decimals);
-  const minAmountUnits = quoteLimits
-    ? new Big(quoteLimits.min)
+  const minAmountUnits = limits
+    ? new Big(limits.min)
     : multiplyByPowerOfTen(Big(fromToken.minBuyAmountRaw), -fromToken.decimals);
 
-  const isTooHigh = inputAmount && maxAmountUnits.lt(inputAmount);
-  const isTooLow = inputAmount && !inputAmount.eq(0) && minAmountUnits.gt(inputAmount);
+  const isTooHigh = maxAmountUnits.lt(inputAmount);
+  const isTooLow = !inputAmount.eq(0) && minAmountUnits.gt(inputAmount);
 
   if (isTooHigh || isTooLow) {
     trackEvent({
       error_message: isTooHigh ? "more_than_maximum_withdrawal" : "less_than_minimum_withdrawal",
       event: "form_error",
-      input_amount: inputAmount ? inputAmount.toString() : "0"
+      input_amount: inputAmount.toString()
     });
     const key = isTooHigh ? "pages.swap.error.amountOutOfRange.buyTooHigh" : "pages.swap.error.amountOutOfRange.buyTooLow";
     return t(key, {
@@ -72,7 +73,7 @@ function validateOfframp(
     fromToken,
     toToken,
     quote,
-    quoteLimits,
+    limits,
     userInputTokenBalance,
     isDisconnected,
     trackEvent
@@ -81,33 +82,37 @@ function validateOfframp(
     fromToken: OnChainTokenDetails;
     toToken: FiatTokenDetails;
     quote: QuoteResponse;
-    quoteLimits?: { min: string; max: string };
+    limits?: AmountLimits;
     userInputTokenBalance: string | null;
     isDisconnected: boolean;
     trackEvent: (event: TrackableEvent) => void;
   }
 ): string | null {
-  // AlfredPay quotes return stablecoin-denominated input limits; compare against `inputAmount` (stablecoin units).
-  // Legacy path (BRL/EURC) compares against fiat `outputAmount` against fiat min/max.
-  const maxAmountUnits = quoteLimits
-    ? new Big(quoteLimits.max)
-    : multiplyByPowerOfTen(Big(toToken.maxSellAmountRaw), -toToken.decimals);
-  const minAmountUnits = quoteLimits
-    ? new Big(quoteLimits.min)
-    : multiplyByPowerOfTen(Big(toToken.minSellAmountRaw), -toToken.decimals);
+  // AlfredPay path compares the stablecoin-denominated `inputAmount` against the resolved input limits.
+  // Legacy path (BRL/EURC) compares the fiat `outputAmount` against the fiat min/max on the destination token.
+  const check = limits
+    ? {
+        amount: inputAmount,
+        max: new Big(limits.max),
+        min: new Big(limits.min),
+        symbol: fromToken.assetSymbol
+      }
+    : {
+        amount: quote ? Big(quote.outputAmount) : Big(0),
+        max: multiplyByPowerOfTen(Big(toToken.maxSellAmountRaw), -toToken.decimals),
+        min: multiplyByPowerOfTen(Big(toToken.minSellAmountRaw), -toToken.decimals),
+        symbol: toToken.fiat.symbol
+      };
+  const { max: maxAmountUnits, min: minAmountUnits, amount: amountToCheck, symbol: unitSymbol } = check;
 
-  const amountOut = quote ? Big(quote.outputAmount) : Big(0);
-  const amountToCheck = quoteLimits ? inputAmount : amountOut;
-  const unitSymbol = quoteLimits ? fromToken.assetSymbol : toToken.fiat.symbol;
-
-  const isTooHigh = inputAmount && quote && maxAmountUnits.lt(amountToCheck);
+  const isTooHigh = !!quote && maxAmountUnits.lt(amountToCheck);
   const isTooLow = !amountToCheck.eq(0) && !config.test.overwriteMinimumTransferAmount && minAmountUnits.gt(amountToCheck);
 
   if (isTooHigh || isTooLow) {
     trackEvent({
       error_message: isTooHigh ? "more_than_maximum_withdrawal" : "less_than_minimum_withdrawal",
       event: "form_error",
-      input_amount: inputAmount ? inputAmount.toString() : "0"
+      input_amount: inputAmount.toString()
     });
     const key = isTooHigh ? "pages.swap.error.amountOutOfRange.sellTooHigh" : "pages.swap.error.amountOutOfRange.sellTooLow";
     return t(key, {
@@ -119,11 +124,11 @@ function validateOfframp(
 
   if (typeof userInputTokenBalance === "string" && !isDisconnected) {
     const isNativeToken = fromToken.isNative;
-    if (Big(userInputTokenBalance).lt(inputAmount ?? 0)) {
+    if (Big(userInputTokenBalance).lt(inputAmount)) {
       trackEvent({
         error_message: "insufficient_balance",
         event: "form_error",
-        input_amount: inputAmount ? inputAmount.toString() : "0"
+        input_amount: inputAmount.toString()
       });
       return t("pages.swap.error.insufficientFunds", {
         assetSymbol: fromToken?.assetSymbol,
@@ -211,13 +216,13 @@ export const useRampValidation = () => {
       });
     } else if (quoteError) return t(quoteError);
 
-    const quoteLimits = quote?.inputAmountLimits;
+    const limits = quote?.alfredpayInputLimits;
     let validationError = null;
     if (isOnramp) {
       validationError = validateOnramp(t, {
         fromToken: fromToken as FiatTokenDetails,
         inputAmount,
-        quoteLimits,
+        limits,
         trackEvent
       });
     } else {
@@ -225,8 +230,8 @@ export const useRampValidation = () => {
         fromToken: fromToken as OnChainTokenDetails,
         inputAmount,
         isDisconnected,
+        limits,
         quote: quote as QuoteResponse,
-        quoteLimits,
         toToken: toToken as FiatTokenDetails,
         trackEvent,
         userInputTokenBalance: userInputTokenBalance?.balance || "0"

--- a/apps/frontend/src/hooks/ramp/useRampValidation.ts
+++ b/apps/frontend/src/hooks/ramp/useRampValidation.ts
@@ -29,15 +29,21 @@ function validateOnramp(
   {
     inputAmount,
     fromToken,
+    quoteLimits,
     trackEvent
   }: {
     inputAmount: Big;
     fromToken: FiatTokenDetails;
+    quoteLimits?: { min: string; max: string };
     trackEvent: (event: TrackableEvent) => void;
   }
 ): string | null {
-  const maxAmountUnits = multiplyByPowerOfTen(Big(fromToken.maxBuyAmountRaw), -fromToken.decimals);
-  const minAmountUnits = multiplyByPowerOfTen(Big(fromToken.minBuyAmountRaw), -fromToken.decimals);
+  const maxAmountUnits = quoteLimits
+    ? new Big(quoteLimits.max)
+    : multiplyByPowerOfTen(Big(fromToken.maxBuyAmountRaw), -fromToken.decimals);
+  const minAmountUnits = quoteLimits
+    ? new Big(quoteLimits.min)
+    : multiplyByPowerOfTen(Big(fromToken.minBuyAmountRaw), -fromToken.decimals);
 
   const isTooHigh = inputAmount && maxAmountUnits.lt(inputAmount);
   const isTooLow = inputAmount && !inputAmount.eq(0) && minAmountUnits.gt(inputAmount);
@@ -66,6 +72,7 @@ function validateOfframp(
     fromToken,
     toToken,
     quote,
+    quoteLimits,
     userInputTokenBalance,
     isDisconnected,
     trackEvent
@@ -74,17 +81,27 @@ function validateOfframp(
     fromToken: OnChainTokenDetails;
     toToken: FiatTokenDetails;
     quote: QuoteResponse;
+    quoteLimits?: { min: string; max: string };
     userInputTokenBalance: string | null;
     isDisconnected: boolean;
     trackEvent: (event: TrackableEvent) => void;
   }
 ): string | null {
-  const maxAmountUnits = multiplyByPowerOfTen(Big(toToken.maxSellAmountRaw), -toToken.decimals);
-  const minAmountUnits = multiplyByPowerOfTen(Big(toToken.minSellAmountRaw), -toToken.decimals);
-  const amountOut = quote ? Big(quote.outputAmount) : Big(0);
+  // AlfredPay quotes return stablecoin-denominated input limits; compare against `inputAmount` (stablecoin units).
+  // Legacy path (BRL/EURC) compares against fiat `outputAmount` against fiat min/max.
+  const maxAmountUnits = quoteLimits
+    ? new Big(quoteLimits.max)
+    : multiplyByPowerOfTen(Big(toToken.maxSellAmountRaw), -toToken.decimals);
+  const minAmountUnits = quoteLimits
+    ? new Big(quoteLimits.min)
+    : multiplyByPowerOfTen(Big(toToken.minSellAmountRaw), -toToken.decimals);
 
-  const isTooHigh = inputAmount && quote && maxAmountUnits.lt(amountOut);
-  const isTooLow = !amountOut.eq(0) && !config.test.overwriteMinimumTransferAmount && minAmountUnits.gt(amountOut);
+  const amountOut = quote ? Big(quote.outputAmount) : Big(0);
+  const amountToCheck = quoteLimits ? inputAmount : amountOut;
+  const unitSymbol = quoteLimits ? fromToken.assetSymbol : toToken.fiat.symbol;
+
+  const isTooHigh = inputAmount && quote && maxAmountUnits.lt(amountToCheck);
+  const isTooLow = !amountToCheck.eq(0) && !config.test.overwriteMinimumTransferAmount && minAmountUnits.gt(amountToCheck);
 
   if (isTooHigh || isTooLow) {
     trackEvent({
@@ -94,7 +111,7 @@ function validateOfframp(
     });
     const key = isTooHigh ? "pages.swap.error.amountOutOfRange.sellTooHigh" : "pages.swap.error.amountOutOfRange.sellTooLow";
     return t(key, {
-      assetSymbol: toToken.fiat.symbol,
+      assetSymbol: unitSymbol,
       maxAmountUnits: stringifyBigWithSignificantDecimals(maxAmountUnits, 0),
       minAmountUnits: stringifyBigWithSignificantDecimals(minAmountUnits, 0)
     });
@@ -194,11 +211,13 @@ export const useRampValidation = () => {
       });
     } else if (quoteError) return t(quoteError);
 
+    const quoteLimits = quote?.inputAmountLimits;
     let validationError = null;
     if (isOnramp) {
       validationError = validateOnramp(t, {
         fromToken: fromToken as FiatTokenDetails,
         inputAmount,
+        quoteLimits,
         trackEvent
       });
     } else {
@@ -207,6 +226,7 @@ export const useRampValidation = () => {
         inputAmount,
         isDisconnected,
         quote: quote as QuoteResponse,
+        quoteLimits,
         toToken: toToken as FiatTokenDetails,
         trackEvent,
         userInputTokenBalance: userInputTokenBalance?.balance || "0"

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "vortex-monorepo",

--- a/packages/shared/src/endpoints/quote.endpoints.ts
+++ b/packages/shared/src/endpoints/quote.endpoints.ts
@@ -1,4 +1,5 @@
 import { DestinationType, Networks, PaymentMethod, RampCurrency, RampDirection } from "../index";
+import { AmountLimits } from "../tokens/types/base";
 
 // Fee structure
 export interface QuoteFeeStructure {
@@ -74,11 +75,8 @@ export interface QuoteResponse {
   createdAt: Date;
   sessionId?: string;
 
-  /**
-   * Resolved input-side amount limits for this quote. Decimal-string values in human units of `inputCurrency`.
-   * Currently populated only for AlfredPay quotes (USD/MXN/COP).
-   */
-  inputAmountLimits?: { min: string; max: string };
+  /** Resolved AlfredPay input-side amount limits in human units of `inputCurrency`. Populated for USD/MXN/COP quotes. */
+  alfredpayInputLimits?: AmountLimits;
 }
 
 // GET /quotes/:id

--- a/packages/shared/src/endpoints/quote.endpoints.ts
+++ b/packages/shared/src/endpoints/quote.endpoints.ts
@@ -73,6 +73,12 @@ export interface QuoteResponse {
   expiresAt: Date;
   createdAt: Date;
   sessionId?: string;
+
+  /**
+   * Resolved input-side amount limits for this quote. Decimal-string values in human units of `inputCurrency`.
+   * Currently populated only for AlfredPay quotes (USD/MXN/COP).
+   */
+  inputAmountLimits?: { min: string; max: string };
 }
 
 // GET /quotes/:id

--- a/packages/shared/src/services/alfredpay/alfredpayApiService.ts
+++ b/packages/shared/src/services/alfredpay/alfredpayApiService.ts
@@ -25,6 +25,7 @@ import {
   CreateAlfredpayOnrampResponse,
   FindAlfredpayCustomerResponse,
   GetAlfredpayOnrampTransactionResponse,
+  GetAllConfigsResponse,
   GetKybRedirectLinkResponse,
   GetKybStatusResponse,
   GetKybSubmissionResponse,
@@ -141,6 +142,15 @@ export class AlfredpayApiService {
       "POST",
       payload
     )) as CreateAlfredpayCustomerResponse;
+  }
+
+  /**
+   * Fetch all supported trading pairs and their per-pair / per-customer-type quantity limits.
+   * Docs: https://alfredpay.readme.io/v2.0/reference/configurationscontroller_getallconfigs-3
+   */
+  public async getAllConfigs(): Promise<GetAllConfigsResponse> {
+    const path = "/api/v1/third-party-service/penny/configurations";
+    return (await this.executeRequest<GetAllConfigsResponse>(path, "GET")) ?? { supportedPairs: [] };
   }
 
   public async findCustomer(email: string, country: string): Promise<FindAlfredpayCustomerResponse> {

--- a/packages/shared/src/services/alfredpay/types.ts
+++ b/packages/shared/src/services/alfredpay/types.ts
@@ -1,9 +1,6 @@
-import { FiatToken } from "../../tokens/types/base";
+import { AlfredpayCustomerType, FiatToken, RampCurrency } from "../../tokens/types/base";
 
-export enum AlfredpayCustomerType {
-  INDIVIDUAL = "INDIVIDUAL",
-  BUSINESS = "BUSINESS"
-}
+export { AlfredpayCustomerType };
 
 export type AlfredPayType = AlfredpayCustomerType;
 export const AlfredPayType = AlfredpayCustomerType;
@@ -356,9 +353,9 @@ export interface AlfredpayFiatAccount extends AlfredpayFiatAccountFields {
 
 export type ListAlfredpayFiatAccountsResponse = AlfredpayFiatAccount[];
 
-const ALFREDPAY_FIAT_TOKEN_SET = new Set<FiatToken>([FiatToken.USD, FiatToken.MXN, FiatToken.COP]);
+const ALFREDPAY_FIAT_TOKEN_SET: ReadonlySet<RampCurrency> = new Set([FiatToken.USD, FiatToken.MXN, FiatToken.COP]);
 
-export const isAlfredpayToken = (token: FiatToken): boolean => ALFREDPAY_FIAT_TOKEN_SET.has(token);
+export const isAlfredpayToken = (token: RampCurrency): token is FiatToken => ALFREDPAY_FIAT_TOKEN_SET.has(token);
 
 /** Raw shape returned by `GET …/configurations`. `typeCustomer: null` means the pair applies to both customer types. */
 export interface AlfredpayConfigPair {

--- a/packages/shared/src/services/alfredpay/types.ts
+++ b/packages/shared/src/services/alfredpay/types.ts
@@ -360,6 +360,24 @@ const ALFREDPAY_FIAT_TOKEN_SET = new Set<FiatToken>([FiatToken.USD, FiatToken.MX
 
 export const isAlfredpayToken = (token: FiatToken): boolean => ALFREDPAY_FIAT_TOKEN_SET.has(token);
 
+/** Raw shape returned by `GET …/configurations`. `typeCustomer: null` means the pair applies to both customer types. */
+export interface AlfredpayConfigPair {
+  id: string;
+  fromCurrency: string;
+  toCurrency: string;
+  businessId: string | null;
+  maxQuantity: string;
+  minQuantity: string;
+  decimals: string;
+  typeCustomer: AlfredpayCustomerType | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GetAllConfigsResponse {
+  supportedPairs: AlfredpayConfigPair[];
+}
+
 export class AlfredpayTradeLimitError extends Error {
   readonly minQuantity: string;
   readonly fromCurrency: string;

--- a/packages/shared/src/tokens/freeTokens/config.ts
+++ b/packages/shared/src/tokens/freeTokens/config.ts
@@ -2,7 +2,7 @@
  * Free token configuration (not bound to any network)
  */
 
-import { AlfredpayCurrencyLimits, FiatCurrencyDetails, FiatToken, TokenType } from "../types/base";
+import { AlfredpayLimitsTable, FiatCurrencyDetails, FiatToken, TokenType } from "../types/base";
 
 /**
  * Hardcoded fallback AlfredPay limits derived from limits.md (May 11 2026 snapshot).
@@ -12,7 +12,7 @@ import { AlfredpayCurrencyLimits, FiatCurrencyDetails, FiatToken, TokenType } fr
  * - offramp raw values are scaled by stablecoin decimals (USDC/USDT = 6).
  */
 
-const USD_LIMITS: AlfredpayCurrencyLimits = {
+const USD_LIMITS: AlfredpayLimitsTable = {
   offramp: {
     USDC: {
       BUSINESS: { maxRaw: "300000000000", minRaw: "1000000" },
@@ -35,7 +35,7 @@ const USD_LIMITS: AlfredpayCurrencyLimits = {
   }
 };
 
-const MXN_LIMITS: AlfredpayCurrencyLimits = {
+const MXN_LIMITS: AlfredpayLimitsTable = {
   offramp: {
     USDC: {
       BUSINESS: { maxRaw: "5000000000000", minRaw: "1000000" },
@@ -58,7 +58,7 @@ const MXN_LIMITS: AlfredpayCurrencyLimits = {
   }
 };
 
-const COP_LIMITS: AlfredpayCurrencyLimits = {
+const COP_LIMITS: AlfredpayLimitsTable = {
   offramp: {
     USDC: {
       BUSINESS: { maxRaw: "300000000000", minRaw: "1000000" },
@@ -91,8 +91,10 @@ export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = 
       name: "US Dollar",
       symbol: "USD"
     },
-    maxBuyAmountRaw: "30000000",
-    maxSellAmountRaw: "300000000000",
+    // Legacy fields = floor across customer types & stablecoins (Individual caps), used as fallback when
+    // the dynamic AlfredPay limit hasn't been resolved yet. Never above the strictest real limit.
+    maxBuyAmountRaw: "10000000",
+    maxSellAmountRaw: "100000000000",
     minBuyAmountRaw: "100",
     minSellAmountRaw: "1000000",
     type: TokenType.Fiat
@@ -106,7 +108,7 @@ export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = 
       name: "Mexican Peso",
       symbol: "MXN"
     },
-    maxBuyAmountRaw: "8699689121",
+    maxBuyAmountRaw: "8695217304",
     maxSellAmountRaw: "5000000000000",
     minBuyAmountRaw: "20000",
     minSellAmountRaw: "1000000",
@@ -121,8 +123,8 @@ export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = 
       name: "Colombian Peso",
       symbol: "COP"
     },
-    maxBuyAmountRaw: "110596799945",
-    maxSellAmountRaw: "300000000000",
+    maxBuyAmountRaw: "36865599982",
+    maxSellAmountRaw: "100000000000",
     minBuyAmountRaw: "3500000",
     minSellAmountRaw: "1000000",
     type: TokenType.Fiat

--- a/packages/shared/src/tokens/freeTokens/config.ts
+++ b/packages/shared/src/tokens/freeTokens/config.ts
@@ -2,10 +2,88 @@
  * Free token configuration (not bound to any network)
  */
 
-import { FiatCurrencyDetails, FiatToken, TokenType } from "../types/base";
+import { AlfredpayCurrencyLimits, FiatCurrencyDetails, FiatToken, TokenType } from "../types/base";
+
+/**
+ * Hardcoded fallback AlfredPay limits derived from limits.md (May 11 2026 snapshot).
+ *
+ * Storage convention:
+ * - onramp raw values are scaled by the parent fiat's decimals (USD/MXN/COP = 2).
+ * - offramp raw values are scaled by stablecoin decimals (USDC/USDT = 6).
+ */
+
+const USD_LIMITS: AlfredpayCurrencyLimits = {
+  offramp: {
+    USDC: {
+      BUSINESS: { maxRaw: "300000000000", minRaw: "1000000" },
+      INDIVIDUAL: { maxRaw: "300000000000", minRaw: "1000000" }
+    },
+    USDT: {
+      BUSINESS: { maxRaw: "300000000000", minRaw: "1000000" },
+      INDIVIDUAL: { maxRaw: "100000000000", minRaw: "1000000" }
+    }
+  },
+  onramp: {
+    USDC: {
+      BUSINESS: { maxRaw: "30000000", minRaw: "100" },
+      INDIVIDUAL: { maxRaw: "10000000", minRaw: "100" }
+    },
+    USDT: {
+      BUSINESS: { maxRaw: "30000000", minRaw: "100" },
+      INDIVIDUAL: { maxRaw: "10000000", minRaw: "100" }
+    }
+  }
+};
+
+const MXN_LIMITS: AlfredpayCurrencyLimits = {
+  offramp: {
+    USDC: {
+      BUSINESS: { maxRaw: "5000000000000", minRaw: "1000000" },
+      INDIVIDUAL: { maxRaw: "5000000000000", minRaw: "1000000" }
+    },
+    USDT: {
+      BUSINESS: { maxRaw: "5000000000000", minRaw: "1000000" },
+      INDIVIDUAL: { maxRaw: "5000000000000", minRaw: "1000000" }
+    }
+  },
+  onramp: {
+    USDC: {
+      BUSINESS: { maxRaw: "8699689121", minRaw: "20000" },
+      INDIVIDUAL: { maxRaw: "8699689121", minRaw: "20000" }
+    },
+    USDT: {
+      BUSINESS: { maxRaw: "8695217304", minRaw: "20000" },
+      INDIVIDUAL: { maxRaw: "8695217304", minRaw: "20000" }
+    }
+  }
+};
+
+const COP_LIMITS: AlfredpayCurrencyLimits = {
+  offramp: {
+    USDC: {
+      BUSINESS: { maxRaw: "300000000000", minRaw: "1000000" },
+      INDIVIDUAL: { maxRaw: "300000000000", minRaw: "1000000" }
+    },
+    USDT: {
+      BUSINESS: { maxRaw: "300000000000", minRaw: "1000000" },
+      INDIVIDUAL: { maxRaw: "100000000000", minRaw: "1000000" }
+    }
+  },
+  onramp: {
+    USDC: {
+      BUSINESS: { maxRaw: "110596799945", minRaw: "3500000" },
+      INDIVIDUAL: { maxRaw: "36865599982", minRaw: "3500000" }
+    },
+    USDT: {
+      BUSINESS: { maxRaw: "110596799945", minRaw: "3500000" },
+      INDIVIDUAL: { maxRaw: "36865599982", minRaw: "3500000" }
+    }
+  }
+};
 
 export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = {
   [FiatToken.USD]: {
+    alfredpayLimits: USD_LIMITS,
     assetSymbol: "USD",
     decimals: 2,
     fiat: {
@@ -13,13 +91,14 @@ export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = 
       name: "US Dollar",
       symbol: "USD"
     },
-    maxBuyAmountRaw: "10000000000",
-    maxSellAmountRaw: "100000000000000000000",
+    maxBuyAmountRaw: "30000000",
+    maxSellAmountRaw: "300000000000",
     minBuyAmountRaw: "100",
-    minSellAmountRaw: "100",
+    minSellAmountRaw: "1000000",
     type: TokenType.Fiat
   },
   [FiatToken.MXN]: {
+    alfredpayLimits: MXN_LIMITS,
     assetSymbol: "MXN",
     decimals: 2,
     fiat: {
@@ -27,13 +106,14 @@ export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = 
       name: "Mexican Peso",
       symbol: "MXN"
     },
-    maxBuyAmountRaw: "10000000000",
-    maxSellAmountRaw: "100000000000000000000",
-    minBuyAmountRaw: "15000",
-    minSellAmountRaw: "2000",
+    maxBuyAmountRaw: "8699689121",
+    maxSellAmountRaw: "5000000000000",
+    minBuyAmountRaw: "20000",
+    minSellAmountRaw: "1000000",
     type: TokenType.Fiat
   },
   [FiatToken.COP]: {
+    alfredpayLimits: COP_LIMITS,
     assetSymbol: "COP",
     decimals: 2,
     fiat: {
@@ -41,10 +121,10 @@ export const freeTokenConfig: Partial<Record<FiatToken, FiatCurrencyDetails>> = 
       name: "Colombian Peso",
       symbol: "COP"
     },
-    maxBuyAmountRaw: "10000000000",
-    maxSellAmountRaw: "100000000000000000000",
+    maxBuyAmountRaw: "110596799945",
+    maxSellAmountRaw: "300000000000",
     minBuyAmountRaw: "3500000",
-    minSellAmountRaw: "100",
+    minSellAmountRaw: "1000000",
     type: TokenType.Fiat
   }
 };

--- a/packages/shared/src/tokens/types/base.ts
+++ b/packages/shared/src/tokens/types/base.ts
@@ -45,6 +45,25 @@ export interface FiatDetails {
   name: string;
 }
 
+/** String-literal values match `AlfredpayCustomerType` enum in services/alfredpay/types.ts. */
+export type AlfredpayCustomerKey = "INDIVIDUAL" | "BUSINESS";
+export type AlfredpayStablecoinKey = "USDC" | "USDT";
+
+export interface AlfredpayLimitsBucket {
+  minRaw: string;
+  maxRaw: string;
+}
+
+/**
+ * Multi-axis AlfredPay limits.
+ * - `onramp` raw values are scaled by the FIAT decimals of the parent token.
+ * - `offramp` raw values are scaled by the STABLECOIN decimals (USDC/USDT = 6).
+ */
+export interface AlfredpayCurrencyLimits {
+  onramp: Record<AlfredpayStablecoinKey, Record<AlfredpayCustomerKey, AlfredpayLimitsBucket>>;
+  offramp: Record<AlfredpayStablecoinKey, Record<AlfredpayCustomerKey, AlfredpayLimitsBucket>>;
+}
+
 export interface BaseFiatTokenDetails {
   fiat: FiatDetails;
   minSellAmountRaw: string;
@@ -53,6 +72,8 @@ export interface BaseFiatTokenDetails {
   maxBuyAmountRaw: string;
   buyFeesBasisPoints?: number;
   buyFeesFixedComponent?: number;
+  /** Multi-axis AlfredPay limits; populated only for AlfredPay-routed fiats (USD/MXN/COP). */
+  alfredpayLimits?: AlfredpayCurrencyLimits;
 }
 
 export interface FiatCurrencyDetails extends BaseTokenDetails, BaseFiatTokenDetails {

--- a/packages/shared/src/tokens/types/base.ts
+++ b/packages/shared/src/tokens/types/base.ts
@@ -45,11 +45,21 @@ export interface FiatDetails {
   name: string;
 }
 
-/** String-literal values match `AlfredpayCustomerType` enum in services/alfredpay/types.ts. */
-export type AlfredpayCustomerKey = "INDIVIDUAL" | "BUSINESS";
+export enum AlfredpayCustomerType {
+  INDIVIDUAL = "INDIVIDUAL",
+  BUSINESS = "BUSINESS"
+}
+
 export type AlfredpayStablecoinKey = "USDC" | "USDT";
 
-export interface AlfredpayLimitsBucket {
+/** Min/max pair in human decimal units. */
+export interface AmountLimits {
+  min: string;
+  max: string;
+}
+
+/** Min/max pair in raw integer-string units (storage form). */
+export interface RawAmountLimits {
   minRaw: string;
   maxRaw: string;
 }
@@ -59,9 +69,9 @@ export interface AlfredpayLimitsBucket {
  * - `onramp` raw values are scaled by the FIAT decimals of the parent token.
  * - `offramp` raw values are scaled by the STABLECOIN decimals (USDC/USDT = 6).
  */
-export interface AlfredpayCurrencyLimits {
-  onramp: Record<AlfredpayStablecoinKey, Record<AlfredpayCustomerKey, AlfredpayLimitsBucket>>;
-  offramp: Record<AlfredpayStablecoinKey, Record<AlfredpayCustomerKey, AlfredpayLimitsBucket>>;
+export interface AlfredpayLimitsTable {
+  onramp: Record<AlfredpayStablecoinKey, Record<AlfredpayCustomerType, RawAmountLimits>>;
+  offramp: Record<AlfredpayStablecoinKey, Record<AlfredpayCustomerType, RawAmountLimits>>;
 }
 
 export interface BaseFiatTokenDetails {
@@ -73,7 +83,7 @@ export interface BaseFiatTokenDetails {
   buyFeesBasisPoints?: number;
   buyFeesFixedComponent?: number;
   /** Multi-axis AlfredPay limits; populated only for AlfredPay-routed fiats (USD/MXN/COP). */
-  alfredpayLimits?: AlfredpayCurrencyLimits;
+  alfredpayLimits?: AlfredpayLimitsTable;
 }
 
 export interface FiatCurrencyDetails extends BaseTokenDetails, BaseFiatTokenDetails {


### PR DESCRIPTION
Adds dynamic AlfredPay limit enforcement for USD/MXN/COP quotes, keyed by customer type × stablecoin × direction. Replaces hardcoded static caps with live limits fetched from AlfredPay's /configurations endpoint, refreshed daily, with a hardcoded fallback snapshot.

###  What changed

####  Shared types (packages/shared)
  - New reusable primitives: AmountLimits (decimal {min, max}) and RawAmountLimits (raw {minRaw, maxRaw}).
  - New AlfredpayLimitsTable type - full onramp/offramp × USDC/USDT × INDIVIDUAL/BUSINESS matrix.
  - New AlfredpayCustomerType enum and AlfredpayStablecoinKey ("USDC" | "USDT").
  - BaseFiatTokenDetails gains optional alfredpayLimits; USD/MXN/COP get hardcoded fallback values (May 11 2026 snapshot).
  - QuoteResponse gains optional alfredpayInputLimits: AmountLimits.
  - isAlfredpayToken widened to type-guard RampCurrency -> FiatToken.
  - New AlfredpayConfigPair + getAllConfigs() on the AlfredPay API service.

####  Backend (apps/api)
  - AlfredpayLimitsService - singleton that boots on server start, refreshes the cache daily, and falls back to hardcoded values when
  the upstream fetch fails. Wildcard rows (typeCustomer: null) populate both customer types but specific rows always win.
  - lookupAlfredpayCustomerType resolves user -> customer type (defaults to INDIVIDUAL when anonymous or no KYC row).
  - resolveAlfredpayQuoteLimits returns axes + decimal min/max for a quote, or null for non-AlfredPay quotes.
  - New applyAlfredpayLimits(ctx, amount) helper sets ctx.alfredpayInputLimits and validates; both finalize engines (onramp.ts,
  offramp.ts) collapse to a single call with legacy validateAmountLimits fallthrough.
  - QuoteContext and QuoteResponse builders surface alfredpayInputLimits (both persisted + in-memory skipPersistence paths).

#### Frontend (apps/frontend)
  - useRampValidation consumes quote.alfredpayInputLimits when present and validates inputAmount against those bounds; falls back to
  legacy min/maxBuy/SellAmountRaw for BRL/EURC. No new fetch - rides the existing quote response.
  - Validator branches collapsed: 4 ternaries in validateOfframp consolidated into one named check object.
  - Dropped dead inputAmount && ... / inputAmount ? ... : "0" guards (inputAmount is always a Big).

###  Why

Static, single-axis caps no longer reflect reality - AlfredPay's actual limits vary by Individual/Business KYC status, by USDC vs USDT. This change pulls them from the source of truth without coupling the request path to AlfredPay's API (cache + fallback), and surfaces them to the frontend so users see accurate bounds and localized error messages.