### PR TITLE
Make monerium vs mykobo flows distinguishable

### DIFF
--- a/apps/api/src/api/services/phases/phase-processor.ts
+++ b/apps/api/src/api/services/phases/phase-processor.ts
@@ -1,6 +1,7 @@
 import httpStatus from "http-status";
 import logger from "../../../config/logger";
 import { runWithRampContext } from "../../../config/ramp-context";
+import { config } from "../../../config/vars";
 import RampState from "../../../models/rampState.model";
 import { APIError } from "../../errors/api-error";
 import { PhaseError, RecoverablePhaseError } from "../../errors/phase-error";
@@ -38,6 +39,13 @@ export class PhaseProcessor {
           message: `Ramp with ID ${rampId} not found`,
           status: httpStatus.NOT_FOUND
         });
+      }
+
+      if (state.flowVariant !== config.flowVariant) {
+        logger.warn(
+          `Refusing to process ramp ${rampId}: belongs to flow ${state.flowVariant}, this backend is ${config.flowVariant}`
+        );
+        return;
       }
 
       // Try to acquire the lock

--- a/apps/api/src/api/services/quote/engines/finalize/index.ts
+++ b/apps/api/src/api/services/quote/engines/finalize/index.ts
@@ -1,6 +1,7 @@
 import { getPaymentMethodFromDestinations, QuoteResponse, RampDirection } from "@vortexfi/shared";
 import Big from "big.js";
 import httpStatus from "http-status";
+import { config } from "../../../../../config/vars";
 import QuoteTicket from "../../../../../models/quoteTicket.model";
 import { APIError } from "../../../../errors/api-error";
 import { trimTrailingZeros } from "../../core/helpers";
@@ -149,6 +150,7 @@ export abstract class BaseFinalizeEngine implements Stage {
       apiKey: request.apiKey || null,
       countryCode: request.countryCode,
       expiresAt,
+      flowVariant: config.flowVariant,
       from: request.from,
       inputAmount: request.inputAmount,
       inputCurrency: request.inputCurrency,

--- a/apps/api/src/api/services/quote/index.ts
+++ b/apps/api/src/api/services/quote/index.ts
@@ -15,6 +15,7 @@ import Big from "big.js";
 import httpStatus from "http-status";
 import pLimit from "p-limit";
 import logger from "../../../config/logger";
+import { config } from "../../../config/vars";
 import Partner from "../../../models/partner.model";
 import { APIError } from "../../errors/api-error";
 import { BaseRampService } from "../ramp/base.service";
@@ -35,6 +36,10 @@ export class QuoteService extends BaseRampService {
     const quote = await this.getQuoteTicket(id);
 
     if (!quote) {
+      return null;
+    }
+
+    if (quote.flowVariant !== config.flowVariant) {
       return null;
     }
 

--- a/apps/api/src/api/services/ramp/ramp.service.ts
+++ b/apps/api/src/api/services/ramp/ramp.service.ts
@@ -10,7 +10,6 @@ import {
   AveniaPaymentMethod,
   BrlaApiService,
   BrlaCurrency,
-  CreateAlfredpayOfframpRequest,
   CreateAlfredpayOnrampRequest,
   EphemeralAccountType,
   ERC20_EURE_POLYGON_TOKEN_NAME,
@@ -47,6 +46,7 @@ import { Op, Transaction, WhereOptions } from "sequelize";
 import { StrKey } from "stellar-sdk";
 import { isAddress } from "viem";
 import logger from "../../../config/logger";
+import { config } from "../../../config/vars";
 import { SEQUENCE_TIME_WINDOW_IN_SECONDS } from "../../../constants/constants";
 import Partner from "../../../models/partner.model";
 import QuoteTicket from "../../../models/quoteTicket.model";
@@ -168,6 +168,16 @@ export function normalizeAndValidateSigningAccounts(accounts: AccountMeta[]) {
 }
 
 export class RampService extends BaseRampService {
+  // Two backends share one database; each must only touch ramps/quotes for its own flow.
+  // We return 404 on mismatch so the wrong backend looks indistinguishable from "not found".
+  private static assertOwnedByThisFlow(entity: { flowVariant: string; id: string }, kind: "Ramp" | "Quote"): void {
+    if (entity.flowVariant !== config.flowVariant) {
+      throw new APIError({
+        message: `${kind} not found`,
+        status: httpStatus.NOT_FOUND
+      });
+    }
+  }
   /**
    * Register a new ramping process. This will create a new ramp state and create transactions that need to be signed
    * on the client side.
@@ -184,6 +194,8 @@ export class RampService extends BaseRampService {
           status: httpStatus.NOT_FOUND
         });
       }
+
+      RampService.assertOwnedByThisFlow(quote, "Quote");
 
       if (quote.status !== "pending") {
         throw new APIError({
@@ -230,6 +242,7 @@ export class RampService extends BaseRampService {
       const rampState = await this.createRampState(
         {
           currentPhase: "initial" as RampPhase,
+          flowVariant: quote.flowVariant,
           from: quote.from,
           paymentMethod: quote.paymentMethod,
           postCompleteState: {
@@ -296,6 +309,8 @@ export class RampService extends BaseRampService {
           status: httpStatus.NOT_FOUND
         });
       }
+
+      RampService.assertOwnedByThisFlow(rampState, "Ramp");
 
       const quote = await QuoteTicket.findByPk(rampState.quoteId, { transaction });
 
@@ -413,6 +428,8 @@ export class RampService extends BaseRampService {
         });
       }
 
+      RampService.assertOwnedByThisFlow(rampState, "Ramp");
+
       const quote = await QuoteTicket.findByPk(rampState.quoteId, { transaction });
 
       if (!quote) {
@@ -505,6 +522,10 @@ export class RampService extends BaseRampService {
     const rampState = await this.getRampState(id);
 
     if (!rampState) {
+      return null;
+    }
+
+    if (rampState.flowVariant !== config.flowVariant) {
       return null;
     }
 
@@ -619,6 +640,10 @@ export class RampService extends BaseRampService {
       return null;
     }
 
+    if (rampState.flowVariant !== config.flowVariant) {
+      return null;
+    }
+
     return rampState.errorLogs;
   }
 
@@ -635,7 +660,8 @@ export class RampService extends BaseRampService {
       [Op.or]: [{ "state.walletAddress": walletAddress }, { "state.destinationAddress": walletAddress }],
       currentPhase: {
         [Op.ne]: "initial"
-      }
+      },
+      flowVariant: config.flowVariant
     };
 
     let where: WhereOptions<RampStateAttributes>;
@@ -749,6 +775,8 @@ export class RampService extends BaseRampService {
         status: httpStatus.NOT_FOUND
       });
     }
+
+    RampService.assertOwnedByThisFlow(rampState, "Ramp");
 
     // Limit the number of error logs to 100
     const updatedErrorLogs = [...(rampState.errorLogs || []), errorLog].slice(-100);
@@ -1312,6 +1340,8 @@ export class RampService extends BaseRampService {
       throw new Error("Ramp not found.");
     }
 
+    RampService.assertOwnedByThisFlow(rampState, "Ramp");
+
     await this.updateRampState(id, {
       currentPhase: "timedOut"
     });
@@ -1336,6 +1366,8 @@ export class RampService extends BaseRampService {
     if (!rampState) {
       throw new Error(`RampState with id ${id} not found`);
     }
+
+    RampService.assertOwnedByThisFlow(rampState, "Ramp");
 
     const oldPhase = rampState.currentPhase;
 

--- a/apps/api/src/api/workers/cleanup.worker.ts
+++ b/apps/api/src/api/workers/cleanup.worker.ts
@@ -2,6 +2,7 @@ import { CronJob } from "cron";
 import { Op } from "sequelize";
 import logger from "../../config/logger";
 import { runWithRampContext } from "../../config/ramp-context";
+import { config } from "../../config/vars";
 import RampState from "../../models/rampState.model";
 import { postProcessHandlers } from "../services/phases/post-process";
 import { BaseRampService } from "../services/ramp/base.service";
@@ -152,6 +153,7 @@ class CleanupWorker {
         order: [["updatedAt", "DESC"]],
         where: {
           currentPhase: { [Op.in]: ["complete", "failed", "timedOut"] },
+          flowVariant: config.flowVariant,
           postCompleteState: {
             cleanup: {
               [Op.or]: [{ cleanupCompleted: false }, { cleanupCompleted: { [Op.is]: null } }]

--- a/apps/api/src/api/workers/ramp-recovery.worker.ts
+++ b/apps/api/src/api/workers/ramp-recovery.worker.ts
@@ -2,6 +2,7 @@ import { RampErrorLog } from "@vortexfi/shared";
 import { CronJob } from "cron";
 import { Op } from "sequelize";
 import logger from "../../config/logger";
+import { config } from "../../config/vars";
 import RampState from "../../models/rampState.model";
 import phaseProcessor from "../services/phases/phase-processor";
 import rampService from "../services/ramp/ramp.service";
@@ -58,6 +59,7 @@ class RampRecoveryWorker {
           currentPhase: {
             [Op.notIn]: ["complete", "failed", "initial"]
           },
+          flowVariant: config.flowVariant,
           presignedTxs: { [Op.not]: null },
           updatedAt: {
             [Op.lt]: new Date(Date.now() - TEN_MINUTES_IN_MS) // 10 minutes ago

--- a/apps/api/src/api/workers/unhandled-payment.worker.ts
+++ b/apps/api/src/api/workers/unhandled-payment.worker.ts
@@ -2,6 +2,7 @@ import { BrlaApiService, generateReferenceLabel, normalizeTaxId } from "@vortexf
 import { CronJob } from "cron";
 import { Op } from "sequelize";
 import logger from "../../config/logger";
+import { config } from "../../config/vars";
 import RampState from "../../models/rampState.model";
 import TaxId from "../../models/taxId.model";
 import { SlackNotifier } from "../services/slack.service";
@@ -79,6 +80,7 @@ class UnhandledPaymentWorker {
             [Op.gt]: threeDaysAgo
           },
           currentPhase: "initial",
+          flowVariant: config.flowVariant,
           id: {
             [Op.notIn]: Array.from(this.processedStateIds)
           }
@@ -105,6 +107,7 @@ class UnhandledPaymentWorker {
             [Op.gt]: threeDaysAgo
           },
           currentPhase: "failed",
+          flowVariant: config.flowVariant,
           id: {
             [Op.notIn]: Array.from(this.processedStateIds)
           }

--- a/apps/api/src/config/vars.ts
+++ b/apps/api/src/config/vars.ts
@@ -24,8 +24,14 @@ interface SpreadsheetConfig {
 
 type DeploymentEnv = "development" | "production" | "sandbox" | "staging" | "test";
 
+// Identifies which onramp flow this backend instance serves. Two backends
+// share one database; each ignores ramps/quotes belonging to the other flow.
+// "monerium" is the legacy grace-period backend; "mykobo" is the new replacement.
+export type FlowVariant = "monerium" | "mykobo";
+
 const nodeEnv = process.env.NODE_ENV || "production";
 const deploymentEnvValues: DeploymentEnv[] = ["development", "production", "sandbox", "staging", "test"];
+const flowVariantValues: FlowVariant[] = ["monerium", "mykobo"];
 
 function readDeploymentEnv(): DeploymentEnv {
   const rawDeploymentEnv = process.env.DEPLOYMENT_ENV || (nodeEnv === "production" ? "production" : nodeEnv);
@@ -37,9 +43,20 @@ function readDeploymentEnv(): DeploymentEnv {
   return rawDeploymentEnv as DeploymentEnv;
 }
 
+function readFlowVariant(): FlowVariant {
+  const rawFlowVariant = process.env.FLOW_VARIANT || "monerium";
+
+  if (!flowVariantValues.includes(rawFlowVariant as FlowVariant)) {
+    throw new Error(`FLOW_VARIANT must be one of: ${flowVariantValues.join(", ")} (got '${rawFlowVariant}')`);
+  }
+
+  return rawFlowVariant as FlowVariant;
+}
+
 interface Config {
   env: string;
   deploymentEnv: DeploymentEnv;
+  flowVariant: FlowVariant;
   port: string | number;
   amplitudeWss: string;
   pendulumWss: string;
@@ -132,6 +149,7 @@ export const config: Config = {
   },
   deploymentEnv: readDeploymentEnv(),
   env: nodeEnv,
+  flowVariant: readFlowVariant(),
 
   integrations: {
     alchemy: {
@@ -230,6 +248,7 @@ if (config.env === "production") {
   if (!config.supabase.serviceRoleKey) missing.push("SUPABASE_SERVICE_KEY");
   if (!config.secrets.webhookPrivateKey) missing.push("WEBHOOK_PRIVATE_KEY");
   if (!config.adminSecret) missing.push("ADMIN_SECRET");
+  if (!process.env.FLOW_VARIANT) missing.push("FLOW_VARIANT");
 
   if (missing.length > 0) {
     throw new Error(`Missing required environment variables in production: ${missing.join(", ")}`);

--- a/apps/api/src/database/migrations/028-add-flow-variant.ts
+++ b/apps/api/src/database/migrations/028-add-flow-variant.ts
@@ -1,0 +1,30 @@
+import { DataTypes, QueryInterface } from "sequelize";
+
+const TABLES = ["quote_tickets", "ramp_states"] as const;
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  for (const table of TABLES) {
+    await queryInterface.addColumn(table, "flow_variant", {
+      allowNull: true,
+      type: DataTypes.STRING(16)
+    });
+
+    await queryInterface.sequelize.query(`UPDATE "${table}" SET "flow_variant" = 'monerium' WHERE "flow_variant" IS NULL`);
+
+    await queryInterface.changeColumn(table, "flow_variant", {
+      allowNull: false,
+      type: DataTypes.STRING(16)
+    });
+
+    await queryInterface.addIndex(table, ["flow_variant"], {
+      name: `idx_${table}_flow_variant`
+    });
+  }
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  for (const table of TABLES) {
+    await queryInterface.removeIndex(table, `idx_${table}_flow_variant`);
+    await queryInterface.removeColumn(table, "flow_variant");
+  }
+}

--- a/apps/api/src/models/quoteTicket.model.ts
+++ b/apps/api/src/models/quoteTicket.model.ts
@@ -2,6 +2,7 @@ import { DestinationType, Networks, PaymentMethod, RampCurrency, RampDirection }
 import { DataTypes, Model, Optional } from "sequelize";
 import { QuoteTicketMetadata } from "../api/services/quote/core/types";
 import sequelize from "../config/database";
+import { FlowVariant } from "../config/vars";
 
 // Define the attributes of the QuoteTicket model
 export interface QuoteTicketAttributes {
@@ -22,6 +23,7 @@ export interface QuoteTicketAttributes {
   paymentMethod: PaymentMethod;
   countryCode: string | null;
   network: Networks;
+  flowVariant: FlowVariant;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -65,6 +67,8 @@ class QuoteTicket extends Model<QuoteTicketAttributes, QuoteTicketCreationAttrib
 
   declare network: Networks;
 
+  declare flowVariant: FlowVariant;
+
   declare createdAt: Date;
 
   declare updatedAt: Date;
@@ -94,6 +98,11 @@ QuoteTicket.init(
       defaultValue: () => new Date(Date.now() + 10 * 60 * 1000), // 10 minutes from now
       field: "expires_at",
       type: DataTypes.DATE
+    },
+    flowVariant: {
+      allowNull: false,
+      field: "flow_variant",
+      type: DataTypes.STRING(16)
     },
     from: {
       allowNull: false,
@@ -192,6 +201,10 @@ QuoteTicket.init(
       {
         fields: ["partner_id"],
         name: "idx_quote_tickets_partner"
+      },
+      {
+        fields: ["flow_variant"],
+        name: "idx_quote_tickets_flow_variant"
       }
     ],
     modelName: "QuoteTicket",

--- a/apps/api/src/models/rampState.model.ts
+++ b/apps/api/src/models/rampState.model.ts
@@ -11,6 +11,7 @@ import {
 import { DataTypes, Model, Optional } from "sequelize";
 import { StateMetadata } from "../api/services/phases/meta-state-types";
 import sequelize from "../config/database";
+import { FlowVariant } from "../config/vars";
 
 export interface PhaseHistoryEntry {
   phase: RampPhase;
@@ -53,6 +54,7 @@ export interface RampStateAttributes {
   errorLogs: RampErrorLog[]; // JSONB array
   processingLock: ProcessingLock;
   postCompleteState: PostCompleteState;
+  flowVariant: FlowVariant;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -92,6 +94,8 @@ class RampState extends Model<RampStateAttributes, RampStateCreationAttributes> 
 
   declare postCompleteState: PostCompleteState;
 
+  declare flowVariant: FlowVariant;
+
   declare createdAt: Date;
 
   declare updatedAt: Date;
@@ -117,6 +121,11 @@ RampState.init(
       defaultValue: [],
       field: "error_logs",
       type: DataTypes.JSONB
+    },
+    flowVariant: {
+      allowNull: false,
+      field: "flow_variant",
+      type: DataTypes.STRING(16)
     },
     from: {
       allowNull: false,
@@ -229,6 +238,10 @@ RampState.init(
         fields: ["quoteId"],
         name: "uq_ramp_states_quote_id",
         unique: true
+      },
+      {
+        fields: ["flow_variant"],
+        name: "idx_ramp_states_flow_variant"
       }
     ],
     modelName: "RampState",


### PR DESCRIPTION
Adds a new column to the ramp and quotes table that denotes the flow for which the quote/ramp was created. The flow_variant will be assigned by the respective backend, thus we need to set the env variables accordingly. In the future, all backends will use the Mykobo flow, but for now, it's still the Monerium variant. While this flow variant is only relevant for the respective onramps, we'll add it for all quotes/ramps for now and remove it later once the fallback is no longer needed. 