### PR TITLE
Allow negative targetDiscount as rate floor

### DIFF
--- a/apps/api/src/api/services/quote/engines/discount/helpers.test.ts
+++ b/apps/api/src/api/services/quote/engines/discount/helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import Big from "big.js";
+import { calculateSubsidyAmount } from "./helpers";
+
+describe("calculateSubsidyAmount", () => {
+  it("returns 0 when actual output meets expected output", () => {
+    const result = calculateSubsidyAmount(new Big(100), new Big(100), 0);
+    expect(result.toString()).toBe("0");
+  });
+
+  it("returns 0 when actual output exceeds expected output", () => {
+    const result = calculateSubsidyAmount(new Big(100), new Big(110), 0);
+    expect(result.toString()).toBe("0");
+  });
+
+  it("returns full shortfall when no maxSubsidy cap", () => {
+    const result = calculateSubsidyAmount(new Big(100), new Big(90), 0);
+    expect(result.toString()).toBe("10");
+  });
+
+  it("caps subsidy at maxSubsidy fraction of expected output", () => {
+    const result = calculateSubsidyAmount(new Big(100), new Big(80), 0.05);
+    // shortfall=20, maxAllowed=100*0.05=5
+    expect(result.toString()).toBe("5");
+  });
+
+  it("returns full shortfall when it is less than maxSubsidy cap", () => {
+    const result = calculateSubsidyAmount(new Big(100), new Big(95), 0.1);
+    // shortfall=5, maxAllowed=100*0.1=10
+    expect(result.toString()).toBe("5");
+  });
+
+  describe("negative targetDiscount scenarios (rate floor)", () => {
+    it("subsidizes when actual is below negative-target expected output", () => {
+      const result = calculateSubsidyAmount(new Big(99.9), new Big(99.5), 0);
+      expect(result.toString()).toBe("0.4");
+    });
+
+    it("returns 0 when actual already meets negative-target expected output", () => {
+      const result = calculateSubsidyAmount(new Big(99.9), new Big(99.9), 0);
+      expect(result.toString()).toBe("0");
+    });
+
+    it("returns 0 when actual exceeds negative-target expected output", () => {
+      const result = calculateSubsidyAmount(new Big(99.9), new Big(100.5), 0);
+      expect(result.toString()).toBe("0");
+    });
+
+    it("caps subsidy at maxSubsidy for negative target", () => {
+      const result = calculateSubsidyAmount(new Big(99.9), new Big(98.0), 0.01);
+      // shortfall=1.9, maxAllowed=99.9*0.01=0.999
+      expect(result.toString()).toBe("0.999");
+    });
+  });
+});

--- a/apps/api/src/api/services/quote/engines/discount/offramp-alfredpay.ts
+++ b/apps/api/src/api/services/quote/engines/discount/offramp-alfredpay.ts
@@ -68,7 +68,7 @@ export class OffRampAlfredpayDiscountEngine extends BaseDiscountEngine {
     const idealSubsidyDecimal = expectedOutputDecimal.gt(finalOutput) ? expectedOutputDecimal.minus(finalOutput) : new Big(0);
 
     const actualSubsidyDecimal =
-      targetDiscount > 0 ? calculateSubsidyAmount(expectedOutputDecimal, finalOutput, maxSubsidy) : new Big(0);
+      targetDiscount !== 0 ? calculateSubsidyAmount(expectedOutputDecimal, finalOutput, maxSubsidy) : new Big(0);
 
     const targetOutputDecimal = finalOutput.plus(actualSubsidyDecimal);
 

--- a/apps/api/src/api/services/quote/engines/discount/offramp.ts
+++ b/apps/api/src/api/services/quote/engines/discount/offramp.ts
@@ -74,7 +74,7 @@ export class OffRampDiscountEngine extends BaseDiscountEngine {
 
     // Calculate actual subsidy (capped by maxSubsidy)
     const actualSubsidyAmountDecimal =
-      targetDiscount > 0
+      targetDiscount !== 0
         ? calculateSubsidyAmount(adjustedExpectedOutputDecimal, actualOutputAmountDecimal, maxSubsidy)
         : Big(0);
     const actualSubsidyAmountRaw = multiplyByPowerOfTen(actualSubsidyAmountDecimal, nablaSwap.outputDecimals).toFixed(0, 0);

--- a/apps/api/src/api/services/quote/engines/discount/onramp-alfredpay.ts
+++ b/apps/api/src/api/services/quote/engines/discount/onramp-alfredpay.ts
@@ -51,7 +51,7 @@ export class OnRampAlfredpayDiscountEngine extends BaseDiscountEngine {
     const idealSubsidyDecimal = expectedOutputDecimal.gt(finalOutput) ? expectedOutputDecimal.minus(finalOutput) : new Big(0);
 
     const actualSubsidyDecimal =
-      targetDiscount > 0 ? calculateSubsidyAmount(expectedOutputDecimal, finalOutput, maxSubsidy) : new Big(0);
+      targetDiscount !== 0 ? calculateSubsidyAmount(expectedOutputDecimal, finalOutput, maxSubsidy) : new Big(0);
 
     const targetOutputDecimal = finalOutput.plus(actualSubsidyDecimal);
 

--- a/apps/api/src/api/services/quote/engines/discount/onramp.ts
+++ b/apps/api/src/api/services/quote/engines/discount/onramp.ts
@@ -218,7 +218,7 @@ export class OnRampDiscountEngine extends BaseDiscountEngine {
 
     // Calculate actual subsidy (capped by maxSubsidy)
     const actualSubsidyAmountDecimal =
-      targetDiscount > 0
+      targetDiscount !== 0
         ? calculateSubsidyAmount(adjustedExpectedOutputDecimal, actualOutputAmountDecimal, maxSubsidy)
         : Big(0);
     const actualSubsidyAmountRaw = multiplyByPowerOfTen(actualSubsidyAmountDecimal, nablaSwap.outputDecimals).toFixed(0, 0);


### PR DESCRIPTION
Change subsidy guard from targetDiscount > 0 to targetDiscount !== 0 in all four discount engines so that negative configured targets (e.g., -0.001 for reference rate minus 10 bps) correctly compute and apply subsidies when actual output falls below the floor.

- onramp.ts
- offramp.ts
- onramp-alfredpay.ts
- offramp-alfredpay.ts

Add unit tests for calculateSubsidyAmount covering:
- Positive/negative/zero targetDiscount scenarios
- Max subsidy cap behavior
- Actual output meeting or exceeding target