### PR TITLE
Mykobo base improvements - adjustments proposal

### DIFF
--- a/apps/api/src/api/services/phases/handlers/final-settlement-subsidy.ts
+++ b/apps/api/src/api/services/phases/handlers/final-settlement-subsidy.ts
@@ -28,12 +28,14 @@ import { MAX_FINAL_SETTLEMENT_SUBSIDY_USD } from "../../../../constants/constant
 import QuoteTicket from "../../../../models/quoteTicket.model";
 import RampState from "../../../../models/rampState.model";
 import { priceFeedService } from "../../priceFeed.service";
-import { isBrlToBrlaBaseDirect, isEurToEurcBaseDirect } from "../../quote/utils";
+import { isFiatToOwnStablecoinBaseDirect } from "../../quote/utils";
 import { BasePhaseHandler } from "../base-phase-handler";
 import { getEvmFundingAccount } from "../evm-funding";
 
 const BALANCE_POLLING_TIME_MS = 5000;
 const EVM_BALANCE_CHECK_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
+// Wait for >=90% of expected bridge delivery to absorb slippage while still waiting for actual bridge arrival.
+const MIN_BRIDGE_DELIVERY_RATIO = 0.9;
 
 const NATIVE_TOKENS: Record<EvmNetworks, { symbol: string; decimals: number }> = {
   [Networks.Ethereum]: { decimals: 18, symbol: "ETH" },
@@ -64,6 +66,8 @@ export class FinalSettlementSubsidyHandler extends BasePhaseHandler {
   protected async executePhase(state: RampState): Promise<RampState> {
     logger.debug(`FinalSettlementSubsidyHandler: Starting phase execution for ramp ${state.id}, type=${state.type}`);
 
+    // Two direct-transfer gates: the stateMeta flag is the cheap pre-quote early-out (set by the EUR/BRL
+    // Base routes); the quote-derived check below is the safety net for any direct route that didn't set it.
     if (state.state.isDirectTransfer === true) {
       logger.info(`FinalSettlementSubsidyHandler: Skipping subsidy for direct-transfer ramp ${state.id}`);
       return this.transitionToNextPhase(state, "destinationTransfer");
@@ -80,10 +84,7 @@ export class FinalSettlementSubsidyHandler extends BasePhaseHandler {
       `FinalSettlementSubsidyHandler: Quote found. inputCurrency=${quote.inputCurrency}, outputCurrency=${quote.outputCurrency}, network=${quote.network}`
     );
 
-    if (
-      isEurToEurcBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network) ||
-      isBrlToBrlaBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network)
-    ) {
+    if (isFiatToOwnStablecoinBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network)) {
       logger.info(`FinalSettlementSubsidyHandler: Skipping subsidy for Base direct-transfer route (ramp ${state.id})`);
       return this.transitionToNextPhase(state, "destinationTransfer");
     }
@@ -153,7 +154,7 @@ export class FinalSettlementSubsidyHandler extends BasePhaseHandler {
       `FinalSettlementSubsidyHandler: Polling ephemeral balance for ${ephemeralAddress} on ${destinationNetwork} (timeout=${EVM_BALANCE_CHECK_TIMEOUT_MS}ms, interval=${BALANCE_POLLING_TIME_MS}ms)`
     );
     const actualBalance = await checkEvmBalanceForToken({
-      amountDesiredRaw: expectedAmountRaw.mul(0.9).toFixed(0, 0), // Wait for >=90% of expected bridge delivery to absorb slippage while still waiting for actual bridge arrival.
+      amountDesiredRaw: expectedAmountRaw.mul(MIN_BRIDGE_DELIVERY_RATIO).toFixed(0, 0),
       chain: destinationNetwork,
       intervalMs: BALANCE_POLLING_TIME_MS,
       ownerAddress: ephemeralAddress,

--- a/apps/api/src/api/services/phases/handlers/final-settlement-subsidy.ts
+++ b/apps/api/src/api/services/phases/handlers/final-settlement-subsidy.ts
@@ -66,8 +66,6 @@ export class FinalSettlementSubsidyHandler extends BasePhaseHandler {
   protected async executePhase(state: RampState): Promise<RampState> {
     logger.debug(`FinalSettlementSubsidyHandler: Starting phase execution for ramp ${state.id}, type=${state.type}`);
 
-    // Two direct-transfer gates: the stateMeta flag is the cheap pre-quote early-out (set by the EUR/BRL
-    // Base routes); the quote-derived check below is the safety net for any direct route that didn't set it.
     if (state.state.isDirectTransfer === true) {
       logger.info(`FinalSettlementSubsidyHandler: Skipping subsidy for direct-transfer ramp ${state.id}`);
       return this.transitionToNextPhase(state, "destinationTransfer");

--- a/apps/api/src/api/services/phases/handlers/fund-ephemeral-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/fund-ephemeral-handler.ts
@@ -241,8 +241,6 @@ export class FundEphemeralPhaseHandler extends BasePhaseHandler {
   }
 
   protected nextPhaseSelector(state: RampState, quote: QuoteTicket): RampPhase {
-    // stateMeta flag is the cheap early-out (set by the EUR/BRL Base routes); the quote-derived check is
-    // the safety net for any direct onramp route that didn't set it.
     if (
       state.state.isDirectTransfer === true ||
       (isOnramp(state) && isFiatToOwnStablecoinBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network))

--- a/apps/api/src/api/services/phases/handlers/fund-ephemeral-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/fund-ephemeral-handler.ts
@@ -23,7 +23,7 @@ import RampState from "../../../../models/rampState.model";
 import { UnrecoverablePhaseError } from "../../../errors/phase-error";
 import { multiplyByPowerOfTen } from "../../pendulum/helpers";
 import { fundEphemeralAccount } from "../../pendulum/pendulum.service";
-import { isBrlToBrlaBaseDirect, isEurToEurcBaseDirect } from "../../quote/utils";
+import { isFiatToOwnStablecoinBaseDirect } from "../../quote/utils";
 import { BasePhaseHandler } from "../base-phase-handler";
 import { getEvmFundingAccount } from "../evm-funding";
 import { verifyUserSubmittedTxByHash } from "../helpers/user-tx-verifier";
@@ -241,11 +241,11 @@ export class FundEphemeralPhaseHandler extends BasePhaseHandler {
   }
 
   protected nextPhaseSelector(state: RampState, quote: QuoteTicket): RampPhase {
+    // stateMeta flag is the cheap early-out (set by the EUR/BRL Base routes); the quote-derived check is
+    // the safety net for any direct onramp route that didn't set it.
     if (
       state.state.isDirectTransfer === true ||
-      (isOnramp(state) &&
-        (isEurToEurcBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network) ||
-          isBrlToBrlaBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network)))
+      (isOnramp(state) && isFiatToOwnStablecoinBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network))
     ) {
       return "destinationTransfer";
     }

--- a/apps/api/src/api/services/phases/handlers/squid-router-phase-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/squid-router-phase-handler.ts
@@ -18,7 +18,7 @@ import { PublicClient } from "viem";
 import logger from "../../../../config/logger";
 import QuoteTicket from "../../../../models/quoteTicket.model";
 import RampState from "../../../../models/rampState.model";
-import { isBrlToBrlaBaseDirect, isEurToEurcBaseDirect } from "../../quote/utils";
+import { isFiatToOwnStablecoinBaseDirect } from "../../quote/utils";
 import { BasePhaseHandler } from "../base-phase-handler";
 
 /**
@@ -44,6 +44,8 @@ export class SquidRouterPhaseHandler extends BasePhaseHandler {
   protected async executePhase(state: RampState): Promise<RampState> {
     logger.info(`Executing squidRouter phase for ramp ${state.id}`);
 
+    // Two direct-transfer gates: the stateMeta flag is the cheap pre-quote early-out (set by the EUR/BRL
+    // Base routes); the quote-derived check below is the safety net for any direct route that didn't set it.
     if (state.state.isDirectTransfer === true) {
       logger.info(`SquidRouterPhaseHandler: Skipping squidRouter for direct-transfer ramp ${state.id}`);
       return this.transitionToNextPhase(state, "destinationTransfer");
@@ -54,10 +56,7 @@ export class SquidRouterPhaseHandler extends BasePhaseHandler {
       throw new Error("Quote not found for the given state");
     }
 
-    if (
-      isEurToEurcBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network) ||
-      isBrlToBrlaBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network)
-    ) {
+    if (isFiatToOwnStablecoinBaseDirect(quote.inputCurrency, quote.outputCurrency, quote.network)) {
       logger.info(`SquidRouterPhaseHandler: Skipping squidRouter for Base direct-transfer route (ramp ${state.id})`);
       return this.transitionToNextPhase(state, "destinationTransfer");
     }

--- a/apps/api/src/api/services/phases/handlers/squid-router-phase-handler.ts
+++ b/apps/api/src/api/services/phases/handlers/squid-router-phase-handler.ts
@@ -44,8 +44,6 @@ export class SquidRouterPhaseHandler extends BasePhaseHandler {
   protected async executePhase(state: RampState): Promise<RampState> {
     logger.info(`Executing squidRouter phase for ramp ${state.id}`);
 
-    // Two direct-transfer gates: the stateMeta flag is the cheap pre-quote early-out (set by the EUR/BRL
-    // Base routes); the quote-derived check below is the safety net for any direct route that didn't set it.
     if (state.state.isDirectTransfer === true) {
       logger.info(`SquidRouterPhaseHandler: Skipping squidRouter for direct-transfer ramp ${state.id}`);
       return this.transitionToNextPhase(state, "destinationTransfer");

--- a/apps/api/src/api/services/quote/utils.ts
+++ b/apps/api/src/api/services/quote/utils.ts
@@ -7,3 +7,12 @@ export function isEurToEurcBaseDirect(inputCurrency: string, outputCurrency: str
 export function isBrlToBrlaBaseDirect(inputCurrency: string, outputCurrency: string, toNetwork: string): boolean {
   return inputCurrency === FiatToken.BRL && outputCurrency === EvmToken.BRLA && toNetwork === Networks.Base;
 }
+
+// Fiat -> own-stablecoin passthrough on Base (EUR->EURC, BRL->BRLA): the anchor already minted the
+// requested stablecoin, so the swap/bridge/subsidy steps are skipped and funds transfer directly.
+export function isFiatToOwnStablecoinBaseDirect(inputCurrency: string, outputCurrency: string, toNetwork: string): boolean {
+  return (
+    isEurToEurcBaseDirect(inputCurrency, outputCurrency, toNetwork) ||
+    isBrlToBrlaBaseDirect(inputCurrency, outputCurrency, toNetwork)
+  );
+}

--- a/apps/frontend/src/components/widget-steps/SummaryStep/TransactionTokensDisplay.tsx
+++ b/apps/frontend/src/components/widget-steps/SummaryStep/TransactionTokensDisplay.tsx
@@ -1,5 +1,5 @@
 import { ArrowDownIcon } from "@heroicons/react/20/solid";
-import { useQuery } from "@tanstack/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 import {
   BaseFiatTokenDetails,
   FiatToken,
@@ -69,8 +69,7 @@ export const TransactionTokensDisplay: FC<TransactionTokensDisplayProps> = ({ ex
   const isEurOfframp = !isOnramp && executionInput.fiatToken === FiatToken.EURC;
 
   const { data: mykoboProfile } = useQuery({
-    enabled: isEurOfframp && !!userEmail,
-    queryFn: () => MykoboService.getProfile(userEmail as string),
+    queryFn: isEurOfframp && userEmail ? () => MykoboService.getProfile(userEmail) : skipToken,
     queryKey: ["mykoboProfile", userEmail]
   });
 


### PR DESCRIPTION


  ### Refactor / clarity (no behavior change)
  - Extracted the repeated `isEurToEurcBaseDirect || isBrlToBrlaBaseDirect` check into a
    single `isFiatToOwnStablecoinBaseDirect` helper, used across the three phase handlers —
    one source of truth instead of a disjunction duplicated per site.
  - Named the bridge-delivery threshold constant (`MIN_BRIDGE_DELIVERY_RATIO`) so the
    90% intent is readable without parsing a comment.
  - Documented why both direct-transfer gates (state flag + quote-derived check) exist.
  - Frontend: replaced a `userEmail as string` cast with TanStack Query `skipToken`, which
    narrows the type without an assertion and folds in the `enabled` gate.
