### PR TITLE
Stop retrying deterministic reverts, stagger squidrouter quotes

### DIFF
--- a/apps/rebalancer/src/index.ts
+++ b/apps/rebalancer/src/index.ts
@@ -281,6 +281,14 @@ function toUsdcRaw(amountUsdc: string): string {
   return multiplyByPowerOfTen(new Big(amountUsdc), 6).toFixed(0, 0);
 }
 
+// Squidrouter's per-address rate limit is tight enough that two route quotes fired back-to-back
+// (standard then profitable amount) can trigger "Too many quote requests for this address".
+const SQUIDROUTER_QUOTE_STAGGER_MS = 1500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 async function selectUsdcToBrlaPolicyAmount(coverageDeviationBps: number): Promise<{
   amountUsdcRaw: string;
   policyDecision: Awaited<ReturnType<typeof evaluateUsdcToBrlaPolicy>>;
@@ -309,6 +317,7 @@ async function selectUsdcToBrlaPolicyAmount(coverageDeviationBps: number): Promi
       `profitable ${config.rebalancingProfitableUsdToBrlAmount} USDC.`
   );
 
+  await sleep(SQUIDROUTER_QUOTE_STAGGER_MS);
   const profitablePolicyDecision = await evaluateUsdcToBrlaPolicy(profitableAmountRaw, coverageDeviationBps);
 
   const selectedAmount = selectEvaluatedUsdcToBrlaAmount(

--- a/packages/shared/src/services/evm/clientManager.ts
+++ b/packages/shared/src/services/evm/clientManager.ts
@@ -10,7 +10,9 @@ export interface EvmNetworkConfig {
 }
 
 const VIEM_DEFAULT_TRANSPORT_CACHE_KEY = "<default>";
-const NON_RETRYABLE_READ_CONTRACT_REVERTS = ["EXCEEDS_MAX_COVERAGE_RATIO"];
+// Any on-chain revert is deterministic for a given block state: retrying against a different RPC
+// node will not change the outcome, so retrying just wastes calls and delays failure reporting.
+const NON_RETRYABLE_READ_CONTRACT_ERROR_PATTERNS = [/execution reverted/i];
 
 export function redactRpcUrlForLogs(rpcUrl: string): string {
   if (!rpcUrl) {
@@ -53,7 +55,7 @@ function createRpcTransport(network: EvmNetworkConfig, rpcUrl?: string): Transpo
 }
 
 function isNonRetryableReadContractError(error: Error): boolean {
-  return NON_RETRYABLE_READ_CONTRACT_REVERTS.some(revertReason => error.message.includes(revertReason));
+  return NON_RETRYABLE_READ_CONTRACT_ERROR_PATTERNS.some(pattern => pattern.test(error.message));
 }
 
 function getEvmNetworks(apiKey?: string): EvmNetworkConfig[] {


### PR DESCRIPTION
Nabla quote reads only skipped retries for the single hardcoded EXCEEDS_MAX_COVERAGE_RATIO revert string; any other on-chain revert was retried 3x with backoff even though a revert is deterministic for a given block state and retrying against another RPC can't change it. Now any "execution reverted" error is treated as non-retryable.

Also add a 1.5s stagger between the standard and profitable-amount USDC->BRLA route comparisons, since each fires its own Squidrouter quote request and back-to-back calls were hitting Squidrouter's per-address rate limit ("Too many quote requests for this address").