### PR TITLE
Exclude .claude worktrees from biome's scanner

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
   "files": {
     "includes": [
       "**",
+      "!**/.claude/**",
       "!**/dist/**",
       "!**/build/**",
       "!**/node_modules/",


### PR DESCRIPTION
## Summary

Biome 2 hard-errors when its scanner finds a second "root" configuration nested inside the project. A git worktree created under `.claude/worktrees/` (e.g. by Claude Code's worktree feature) contains the repo's own `biome.json`, so while such a worktree exists, **every** biome invocation from the main checkout fails — including the lint-staged pre-commit hook, which blocks all commits:

```
× Found a nested root configuration, but there's already a root configuration.
i The other configuration was found in /Users/marcel/Documents/pendulum-pay.
```

`.claude` is already gitignored; this adds the matching `"!**/.claude/**"` negation to `files.includes` so biome skips it too.

## Test plan

- [x] Reproduced the failure from the main checkout with a worktree present (`bunx biome check package.json` → nested-root error)
- [x] With the exclusion: same command passes from both the main checkout and inside a worktree
- [x] Pre-commit hook (lint-staged → biome) runs green again