### PR TITLE
test(api): drop WASM keyring from BRL corridor tests to fix CI flake

### DIFF
--- a/apps/api/src/tests/corridors/brl-offramp-crosschain.scenario.test.ts
+++ b/apps/api/src/tests/corridors/brl-offramp-crosschain.scenario.test.ts
@@ -1,6 +1,4 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { Keyring } from "@polkadot/api";
-import { cryptoWaitReady, mnemonicGenerate } from "@polkadot/util-crypto";
 import {
   AveniaTicketStatus,
   EvmToken,
@@ -150,13 +148,12 @@ describe("BRL offramp cross-chain corridor (USDC on Polygon → Base → pix via
     return (await response.json()) as { id: string; outputAmount: string };
   }
 
-  // The EVM→BRL route still requires a Substrate ephemeral in signingAccounts
-  // (validateOfframpQuote legacy default) even though this path never uses it.
-  async function createSubstrateEphemeralAddress(): Promise<string> {
-    await cryptoWaitReady();
-    const keyring = new Keyring({ type: "sr25519" });
-    return keyring.addFromUri(mnemonicGenerate()).address;
-  }
+  // The EVM→BRL route still requires a Substrate entry in signingAccounts
+  // (validateOfframpQuote legacy default) even though this path never uses it to
+  // sign — all signing here is EVM. A static well-known SS58 address keeps the test
+  // off the @polkadot WASM keyring, whose CJS/ESM dual-load intermittently leaves an
+  // uninitialized bridge under Bun and crashed this suite in CI.
+  const SUBSTRATE_PLACEHOLDER_ADDRESS = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
   async function registerViaApi(
     quoteId: string,
@@ -175,7 +172,7 @@ describe("BRL offramp cross-chain corridor (USDC on Polygon → Base → pix via
         quoteId,
         signingAccounts: [
           { address: ephemeral.address, type: "EVM" },
-          { address: await createSubstrateEphemeralAddress(), type: "Substrate" }
+          { address: SUBSTRATE_PLACEHOLDER_ADDRESS, type: "Substrate" }
         ]
       }),
       headers: {

--- a/apps/api/src/tests/corridors/brl-offramp.scenario.test.ts
+++ b/apps/api/src/tests/corridors/brl-offramp.scenario.test.ts
@@ -1,6 +1,4 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { Keyring } from "@polkadot/api";
-import { cryptoWaitReady, mnemonicGenerate } from "@polkadot/util-crypto";
 import {
   AveniaTicketStatus,
   EvmToken,
@@ -142,13 +140,12 @@ describe("BRL offramp swap corridor (USDC on Base → pix via Avenia)", () => {
     return (await response.json()) as { id: string; outputAmount: string };
   }
 
-  // The EVM→BRL route still requires a Substrate ephemeral in signingAccounts
-  // (validateOfframpQuote legacy default) even though this path never uses it.
-  async function createSubstrateEphemeralAddress(): Promise<string> {
-    await cryptoWaitReady();
-    const keyring = new Keyring({ type: "sr25519" });
-    return keyring.addFromUri(mnemonicGenerate()).address;
-  }
+  // The EVM→BRL route still requires a Substrate entry in signingAccounts
+  // (validateOfframpQuote legacy default) even though this path never uses it to
+  // sign — all signing here is EVM. A static well-known SS58 address keeps the test
+  // off the @polkadot WASM keyring, whose CJS/ESM dual-load intermittently leaves an
+  // uninitialized bridge under Bun and crashed this suite in CI.
+  const SUBSTRATE_PLACEHOLDER_ADDRESS = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
   async function registerViaApi(
     quoteId: string,
@@ -167,7 +164,7 @@ describe("BRL offramp swap corridor (USDC on Base → pix via Avenia)", () => {
         quoteId,
         signingAccounts: [
           { address: ephemeral.address, type: "EVM" },
-          { address: await createSubstrateEphemeralAddress(), type: "Substrate" }
+          { address: SUBSTRATE_PLACEHOLDER_ADDRESS, type: "Substrate" }
         ]
       }),
       headers: {


### PR DESCRIPTION
## Summary

Fixes the intermittent `test` job failure seen on other PRs (e.g. #1251):

```
(fail) BRL offramp swap corridor … happy path …
RuntimeError: access to a null reference (evaluating 'wasm.ext_bip39_to_mini_secret(...)')
  at createSubstrateEphemeralAddress (brl-offramp.scenario.test.ts:150)
```

## Root cause

Under Bun, the entire `@polkadot/*` family loads as **both CJS and ESM** in the same test process (a dual-package hazard — the log warns `@polkadot/wasm-crypto has multiple versions … esm … cjs …`). The WASM bridge then exists twice: `cryptoWaitReady()` initializes one copy, but the keyring binds to the other, whose bridge is still null → the crash. It's intermittent because which copy each call site binds to depends on module load order in the full suite (so it passes locally in isolation and flakes in CI).

The two BRL corridor scenario tests only derived a Substrate address to satisfy `signingAccounts` validation — **the EVM→BRL route never signs with it** (all signing is EVM, via viem). So the WASM keyring call was pure, avoidable risk.

## Change

Replace the WASM-derived address with a static well-known SS58 placeholder in both `brl-offramp.scenario.test.ts` and `brl-offramp-crosschain.scenario.test.ts`, and drop the now-unused `@polkadot/api` / `@polkadot/util-crypto` imports. No keyring, no WASM, no flake.

## Why not a real dedupe?

A literal CJS/ESM dedupe isn't cleanly expressible under Bun (no per-package format alias / moduleNameMapper), and any dependency-resolution hack would be speculative and unverifiable (the flake won't reproduce locally). This targets the only site that actually crashed. The app runtime still loads `@polkadot/api` and the warnings remain, but no test now makes a WASM keyring call.

## Verification

- `bun test src/tests/corridors/brl-offramp.scenario.test.ts src/tests/corridors/brl-offramp-crosschain.scenario.test.ts` → **9 pass, 0 fail**
- `bun typecheck` clean (after `build:shared`); `bun lint` clean

Test-only change — no security-spec sync needed.