### PR TITLE
Change 'Buy & Sell' to 'Open App' in MobileMenu and DesktopNavbar

### DIFF
--- a/apps/frontend/src/components/Navbar/DesktopNavbar.tsx
+++ b/apps/frontend/src/components/Navbar/DesktopNavbar.tsx
@@ -76,7 +76,7 @@ export const DesktopNavbar = () => {
 
             <div className="flex items-center">
               <Link className="btn btn-vortex-secondary !rounded-3xl" to="/{-$locale}/widget">
-                Open App
+                {t("components.navbar.openApp")}
               </Link>
             </div>
           </>

--- a/apps/frontend/src/components/Navbar/MobileMenu.tsx
+++ b/apps/frontend/src/components/Navbar/MobileMenu.tsx
@@ -120,7 +120,7 @@ export const MobileMenu = ({ onMenuItemClick }: MobileMenuProps) => {
 
         <motion.div className="mt-6 mb-4" variants={buttonVariants}>
           <Link className="btn btn-vortex-secondary w-full rounded-md" onClick={onMenuItemClick} to="/{-$locale}/widget">
-            Buy & Sell
+            Open App
           </Link>
         </motion.div>
       </nav>

--- a/apps/frontend/src/components/Navbar/MobileMenu.tsx
+++ b/apps/frontend/src/components/Navbar/MobileMenu.tsx
@@ -120,7 +120,7 @@ export const MobileMenu = ({ onMenuItemClick }: MobileMenuProps) => {
 
         <motion.div className="mt-6 mb-4" variants={buttonVariants}>
           <Link className="btn btn-vortex-secondary w-full rounded-md" onClick={onMenuItemClick} to="/{-$locale}/widget">
-            Open App
+            {t("components.navbar.openApp")}
           </Link>
         </motion.div>
       </nav>

--- a/apps/frontend/src/translations/en.json
+++ b/apps/frontend/src/translations/en.json
@@ -646,12 +646,13 @@
       "docs": "Docs",
       "howItWorks": "How it works",
       "individuals": "Individuals",
-      "payments": "Payments",
-      "sellCrypto": "Sell Crypto",
-      "solutions": "Solutions",
-      "toggleMobileMenu": "Toggle mobile menu",
-      "vortexLogo": "Vortex Logo",
-      "widget": "Widget"
+    "openApp": "Open App",
+    "payments": "Payments",
+    "sellCrypto": "Sell Crypto",
+    "solutions": "Solutions",
+    "toggleMobileMenu": "Toggle mobile menu",
+    "vortexLogo": "Vortex Logo",
+    "widget": "Widget"
     },
     "quoteSubmitButton": {
       "buy": "Buy",

--- a/apps/frontend/src/translations/pt.json
+++ b/apps/frontend/src/translations/pt.json
@@ -650,6 +650,7 @@
       "docs": "Documentação",
       "howItWorks": "Como funciona",
       "individuals": "Indivíduos",
+      "openApp": "Abrir App",
       "payments": "Pagamentos",
       "sellCrypto": "Vender Cripto",
       "solutions": "Soluções",


### PR DESCRIPTION
Made it consistent for both Desktop and Mobile, using i18n strings for the 'Open App' label.

## Changes Made

- **MobileMenu**: Replaced hardcoded `Buy & Sell` / `Open App` with `t("components.navbar.openApp")`
- **DesktopNavbar**: Replaced hardcoded `Open App` with `t("components.navbar.openApp")`
- **en.json**: Added `"openApp": "Open App"` under `components.navbar`
- **pt.json**: Added `"openApp": "Abrir App"` under `components.navbar`