### PR TITLE
Repair postProcessCompletedStates JSONB query that never matched

### DIFF
--- a/apps/api/src/api/workers/cleanup.worker.ts
+++ b/apps/api/src/api/workers/cleanup.worker.ts
@@ -152,13 +152,15 @@ class CleanupWorker {
         limit: 5,
         order: [["updatedAt", "DESC"]],
         where: {
+          // Op.or nested inside the JSON path object is rejected by Sequelize's
+          // query builder ("Invalid value"); the dotted-path form is the
+          // documented way to query JSONB attributes.
+          [Op.or]: [
+            { "postCompleteState.cleanup.cleanupCompleted": false },
+            { "postCompleteState.cleanup.cleanupCompleted": { [Op.is]: null } }
+          ],
           currentPhase: { [Op.in]: ["complete", "failed", "timedOut"] },
-          flowVariant: config.flowVariant,
-          postCompleteState: {
-            cleanup: {
-              [Op.or]: [{ cleanupCompleted: false }, { cleanupCompleted: { [Op.is]: null } }]
-            }
-          }
+          flowVariant: config.flowVariant
         }
       });
 

--- a/apps/api/src/tests/cleanup-worker-postprocess.integration.test.ts
+++ b/apps/api/src/tests/cleanup-worker-postprocess.integration.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import type RampState from "../models/rampState.model";
+import CleanupWorker from "../api/workers/cleanup.worker";
+import { resetTestDatabase, setupTestDatabase } from "../test-utils/db";
+import { createTestRampState } from "../test-utils/factories";
+
+// CleanupWorker's CronJob is created with runOnInit=true, so merely
+// constructing the worker fires a real cleanup cycle in the background.
+// Neutralize the tick target for the duration of this file.
+const workerPrototype = CleanupWorker.prototype as unknown as { cleanup: () => Promise<void> };
+const realCleanupCycle = workerPrototype.cleanup;
+workerPrototype.cleanup = async () => {};
+
+afterAll(() => {
+  workerPrototype.cleanup = realCleanupCycle;
+});
+
+/**
+ * Regression test for the postProcessCompletedStates query: it used to nest
+ * Op.or inside the postCompleteState JSON path object, which Sequelize's
+ * query builder rejects with `Invalid value { cleanupCompleted: false }` —
+ * the error was caught and logged, so post-processing of completed ramps
+ * silently never ran.
+ */
+describe("CleanupWorker.postProcessCompletedStates", () => {
+  let worker: CleanupWorker;
+  let processedStateIds: string[];
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    processedStateIds = [];
+    worker = new CleanupWorker();
+    // Stub the per-state cleanup handlers; this test only covers the query.
+    // biome-ignore lint/suspicious/noExplicitAny: overriding a protected method for testing
+    (worker as any).processCleanup = async (state: RampState) => {
+      processedStateIds.push(state.id);
+    };
+  });
+
+  async function runPostProcess(): Promise<void> {
+    // biome-ignore lint/suspicious/noExplicitAny: calling the private method under test
+    await (worker as any).postProcessCompletedStates();
+  }
+
+  it("finds completed states whose cleanup is pending or missing", async () => {
+    const pendingCleanup = await createTestRampState({
+      currentPhase: "complete",
+      postCompleteState: { cleanup: { cleanupAt: null, cleanupCompleted: false, errors: null } }
+    });
+    const missingCleanupFlag = await createTestRampState({
+      currentPhase: "failed",
+      // biome-ignore lint/suspicious/noExplicitAny: simulating legacy rows without the cleanupCompleted flag
+      postCompleteState: { cleanup: {} } as any
+    });
+
+    await runPostProcess();
+
+    expect(processedStateIds.sort()).toEqual([pendingCleanup.id, missingCleanupFlag.id].sort());
+  });
+
+  it("skips states that are already cleaned up or not in a terminal phase", async () => {
+    await createTestRampState({
+      currentPhase: "complete",
+      postCompleteState: { cleanup: { cleanupAt: new Date(), cleanupCompleted: true, errors: null } }
+    });
+    await createTestRampState({
+      currentPhase: "initial",
+      postCompleteState: { cleanup: { cleanupAt: null, cleanupCompleted: false, errors: null } }
+    });
+
+    await runPostProcess();
+
+    expect(processedStateIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Production logs show this on every cleanup worker cycle (every 5 minutes):

```
error Error fetching states in postProcessCompletedStates: Invalid value { cleanupCompleted: false }
```

The `findAll` in `postProcessCompletedStates` nested `Op.or` inside the `postCompleteState` JSON path object. Sequelize's query builder rejects that shape (`Invalid value`), the error was caught and only logged — so post-processing of completed ramps has silently never run.

## Fix

Use the documented dotted-path JSONB syntax, with `Op.or` at the top level of the where clause:

```ts
[Op.or]: [
  { "postCompleteState.cleanup.cleanupCompleted": false },
  { "postCompleteState.cleanup.cleanupCompleted": { [Op.is]: null } }
]
```

## Testing

New DB-backed regression test `apps/api/src/tests/cleanup-worker-postprocess.integration.test.ts`:
- against the old query it fails with the exact production error;
- with the fix it verifies pending/missing-cleanup terminal states are picked up and cleaned-up / non-terminal states are skipped.

Existing `cleanup.worker.test.ts` unit tests, lint, and typecheck all pass.

## Note for deploy

Since this query never worked, the first cleanup cycle after deploy may find a backlog of completed ramps to post-process (it processes at most 5 per 5-minute cycle).