### PR TITLE
Add BlindPay shadow quote for USDC↔BRLA rebalances

### DIFF
--- a/apps/rebalancer/.env.example
+++ b/apps/rebalancer/.env.example
@@ -41,3 +41,14 @@ REBALANCING_DAILY_BRIDGE_LIMIT_USD=10000
 # Main Nabla instance on Base (BRL→USDC route). Leave empty to disable this route.
 MAIN_NABLA_ROUTER=0x...
 MAIN_NABLA_QUOTER=0x...
+
+# BlindPay (optional): logs an observational "shadow" quote (fiat BRL -> stablecoin) during
+# the usdc-brla-usdc-base route comparison, to evaluate BlindPay as a cheaper stablecoin
+# source over time. Never routed. When BLINDPAY_API_KEY/BLINDPAY_INSTANCE_ID are unset, the
+# shadow quote is skipped.
+# BLINDPAY_API_KEY=your_blindpay_api_key
+# BLINDPAY_INSTANCE_ID=in_000000000000
+# Optional, defaults to https://api.blindpay.com/v1
+# BLINDPAY_BASE_URL=https://api.blindpay.com/v1
+# Target stablecoin. Sandbox/dev instances only support "USDB"; production uses "USDC"/"USDT".
+# BLINDPAY_TOKEN=USDT

--- a/apps/rebalancer/src/index.ts
+++ b/apps/rebalancer/src/index.ts
@@ -204,6 +204,7 @@ async function evaluateUsdcToBrlaPolicy(
   profitable: boolean;
   routeQuotes?: {
     aveniaQuoteUsdc: string | null;
+    blindpayShadowQuoteUsdc: string | null;
     mainNablaQuoteUsdc: string | null;
     squidRouterQuoteUsdc: string | null;
   };
@@ -243,6 +244,7 @@ async function evaluateUsdcToBrlaPolicy(
     profitable: isProjectedProfit(Big(amountUsdcRaw), Big(projectedOutputRaw)),
     routeQuotes: {
       aveniaQuoteUsdc: comparison.aveniaQuoteUsdc,
+      blindpayShadowQuoteUsdc: comparison.blindpayShadowQuoteUsdc,
       mainNablaQuoteUsdc: comparison.mainNablaQuoteUsdc,
       squidRouterQuoteUsdc: comparison.squidRouterQuoteUsdc
     },

--- a/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/index.ts
+++ b/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/index.ts
@@ -144,12 +144,14 @@ export async function rebalanceUsdcBrlaUsdcBase(
       state.squidRouterQuoteUsdc = policy?.preflightQuotes?.squidRouterQuoteUsdc ?? null;
       state.aveniaQuoteUsdc = policy?.preflightQuotes?.aveniaQuoteUsdc ?? null;
       state.mainNablaQuoteUsdc = policy?.preflightQuotes?.mainNablaQuoteUsdc ?? null;
+      state.blindpayShadowQuoteUsdc = policy?.preflightQuotes?.blindpayShadowQuoteUsdc ?? null;
     } else {
       const comparison = await compareRoutesUpfront(state.usdcAmountRaw);
       state.winningRoute = comparison.winningRoute;
       state.squidRouterQuoteUsdc = comparison.squidRouterQuoteUsdc;
       state.aveniaQuoteUsdc = comparison.aveniaQuoteUsdc;
       state.mainNablaQuoteUsdc = comparison.mainNablaQuoteUsdc;
+      state.blindpayShadowQuoteUsdc = comparison.blindpayShadowQuoteUsdc;
     }
 
     console.log(`Route selected: ${state.winningRoute}`);
@@ -476,9 +478,19 @@ export async function rebalanceUsdcBrlaUsdcBase(
     startingTime: state.startingTime
   });
 
+  const winnerQuoteUsdcRaw =
+    state.winningRoute === "squidrouter"
+      ? state.squidRouterQuoteUsdc
+      : state.winningRoute === "avenia"
+        ? state.aveniaQuoteUsdc
+        : state.winningRoute === "nabla-main"
+          ? state.mainNablaQuoteUsdc
+          : null;
+
   const slackNotifier = new SlackNotifier(process.env.SLACK_WEB_HOOK_TOKEN);
   await slackNotifier.sendMessage({
     text: formatBaseRebalanceCompletionMessage({
+      blindpayShadowQuoteUsdcRaw: state.blindpayShadowQuoteUsdc,
       brlaReceived: Big(state.brlaAmountDecimal),
       cost,
       edgeCaseFlags,
@@ -486,7 +498,8 @@ export async function rebalanceUsdcBrlaUsdcBase(
       initialUsdcBalance: initialUsdcDecimal,
       policy: policy ?? { config: getConfig().rebalancingCostPolicy },
       requestedUsdc: usdcRebalanced,
-      route: state.winningRoute
+      route: state.winningRoute,
+      winnerQuoteUsdcRaw
     })
   });
 }

--- a/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/notifications.ts
+++ b/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/notifications.ts
@@ -17,6 +17,7 @@ export interface RebalancePolicySummary {
   opportunistic?: boolean;
   preflightQuotes?: {
     aveniaQuoteUsdc: string | null;
+    blindpayShadowQuoteUsdc: string | null;
     mainNablaQuoteUsdc: string | null;
     squidRouterQuoteUsdc: string | null;
   };
@@ -32,6 +33,9 @@ interface BaseRebalanceCompletionMessageParams {
   policy?: RebalancePolicySummary;
   requestedUsdc: Big;
   route: WinningRoute;
+  // Observational-only BlindPay shadow quote and the executed route's USDC, both raw (6 decimals).
+  blindpayShadowQuoteUsdcRaw?: string | null;
+  winnerQuoteUsdcRaw?: string | null;
 }
 
 export function formatBaseRebalanceCompletionMessage(params: BaseRebalanceCompletionMessageParams): string {
@@ -54,8 +58,29 @@ export function formatBaseRebalanceCompletionMessage(params: BaseRebalanceComple
         ]
       ]
     ),
+    formatBlindpayShadowLine(params.blindpayShadowQuoteUsdcRaw, params.winnerQuoteUsdcRaw, params.route),
     formatPolicySummary(params.policy, params.edgeCaseFlags)
-  ].join("\n");
+  ]
+    .filter(section => section !== null)
+    .join("\n");
+}
+
+// Observational only: shows what BlindPay would have quoted for the same BRLA amount, alongside
+// the executed route, to evaluate BlindPay as a cheaper stablecoin source. Never routed.
+function formatBlindpayShadowLine(
+  blindpayShadowUsdcRaw: string | null | undefined,
+  winnerQuoteUsdcRaw: string | null | undefined,
+  route: WinningRoute
+): string | null {
+  if (!blindpayShadowUsdcRaw) return null;
+
+  const blindpayUsdc = Big(blindpayShadowUsdcRaw).div(1e6);
+  let comparison = "";
+  if (winnerQuoteUsdcRaw) {
+    const delta = blindpayUsdc.minus(Big(winnerQuoteUsdcRaw).div(1e6));
+    comparison = ` | vs ${formatRoute(route)} ${Big(winnerQuoteUsdcRaw).div(1e6).toFixed(6)}: ${delta.gte(0) ? "+" : ""}${delta.toFixed(6)}`;
+  }
+  return `*BlindPay shadow* (not routed): ${blindpayUsdc.toFixed(6)} USDC-eq${comparison}`;
 }
 
 export function formatPolicySummary(policy: RebalancePolicySummary | undefined, edgeCaseFlags: string[] = []): string {

--- a/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/steps.ts
+++ b/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/steps.ts
@@ -1011,6 +1011,7 @@ export async function compareRoutesUpfront(usdcAmountRaw: string): Promise<{
   squidRouterQuoteUsdc: string | null;
   aveniaQuoteUsdc: string | null;
   mainNablaQuoteUsdc: string | null;
+  blindpayShadowQuoteUsdc: string | null;
 }> {
   console.log("Quoting first Nabla (USDC→BRLA) to estimate BRLA output for route comparison...");
 
@@ -1121,6 +1122,7 @@ export async function compareRoutesUpfront(usdcAmountRaw: string): Promise<{
 
   return {
     aveniaQuoteUsdc,
+    blindpayShadowQuoteUsdc,
     estimatedBrlaRaw: estimatedBrlaRaw.toString(),
     mainNablaQuoteUsdc,
     squidRouterQuoteUsdc,

--- a/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/steps.ts
+++ b/apps/rebalancer/src/rebalance/usdc-brla-usdc-base/steps.ts
@@ -19,6 +19,8 @@ import Big from "big.js";
 import { encodeFunctionData, erc20Abi, type PublicClient } from "viem";
 import { base, polygon } from "viem/chains";
 import { brlaMoonbeamTokenDetails } from "../../constants.ts";
+import { BlindpayApiService } from "../../services/blindpay/blindpayApiService.ts";
+import type { BlindpayStablecoin } from "../../services/blindpay/types.ts";
 import { UsdcBaseRebalanceState, UsdcBaseStateManager, type WinningRoute } from "../../services/stateManager.ts";
 import { getBaseEvmClients, getConfig, getPolygonEvmClients } from "../../utils/config.ts";
 import { NonceManager } from "../../utils/nonce.ts";
@@ -533,6 +535,45 @@ export async function fetchAveniaQuote(brlaAmountDecimal: Big): Promise<string> 
   return outputUsdcRaw;
 }
 
+// BlindPay rejects payin quotes below this amount (in cents of the sender currency).
+const BLINDPAY_MIN_REQUEST_AMOUNT_CENTS = 500;
+
+/**
+ * Observational-only quote: what BlindPay would give for converting the same BRLA amount
+ * into stablecoin (payin BRL -> USDT/USDB). Returned as a USDC-equivalent raw amount
+ * (6 decimals) so it is directly comparable to the executed-route quotes. Never routed.
+ * Returns null when BlindPay is unconfigured or the amount is below its minimum.
+ */
+export async function fetchBlindpayShadowQuoteUsdc(brlaAmountDecimal: Big): Promise<string | null> {
+  if (!BlindpayApiService.isConfigured()) {
+    console.log("BlindPay shadow quote skipped: not configured (set BLINDPAY_API_KEY and BLINDPAY_INSTANCE_ID).");
+    return null;
+  }
+
+  const requestAmountCents = brlaAmountDecimal.mul(100).round(0, 0).toNumber();
+  if (requestAmountCents < BLINDPAY_MIN_REQUEST_AMOUNT_CENTS) {
+    const minBrl = Big(BLINDPAY_MIN_REQUEST_AMOUNT_CENTS).div(100).toString();
+    console.log(
+      `BlindPay shadow quote skipped: ${brlaAmountDecimal.toFixed(4)} BRL is below BlindPay's minimum of ${minBrl} BRL.`
+    );
+    return null;
+  }
+
+  const { blindpayToken } = getConfig();
+  const quote = await BlindpayApiService.getInstance().getPayinFxRate({
+    currency_type: "sender",
+    from: "BRL",
+    request_amount: requestAmountCents,
+    to: blindpayToken as BlindpayStablecoin
+  });
+
+  // `result_amount` is in cents of the target stablecoin (USD-pegged). Convert to a
+  // USDC-equivalent raw amount (6 decimals) for an apples-to-apples comparison.
+  const outputUsdcRaw = multiplyByPowerOfTen(Big(quote.result_amount).div(100), 6).toFixed(0, 0);
+  console.log(`BlindPay shadow quote: ${outputUsdcRaw} ${blindpayToken} (raw, 6 decimals)`);
+  return outputUsdcRaw;
+}
+
 export async function compareRates(brlaAmountDecimal: Big): Promise<{
   winningRoute: "squidrouter" | "avenia";
   squidRouterQuoteUsdc: string | null;
@@ -1007,10 +1048,15 @@ export async function compareRoutesUpfront(usdcAmountRaw: string): Promise<{
   const config = getConfig();
   const mainNablaAvailable = !!(config.mainNablaRouter && config.mainNablaQuoter);
 
+  // BlindPay is an observational shadow quote only: fetched alongside the real routes for
+  // comparison, but never added to `candidates` (never actually routed through).
+  let blindpayShadowQuoteUsdc: string | null = null;
+
   const results = await Promise.allSettled([
     fetchSquidRouterQuote(estimatedBrlaDecimal),
     fetchAveniaQuote(estimatedBrlaDecimal),
-    mainNablaAvailable ? fetchMainNablaQuote(estimatedBrlaRaw.toString()) : Promise.reject("not configured")
+    mainNablaAvailable ? fetchMainNablaQuote(estimatedBrlaRaw.toString()) : Promise.reject("not configured"),
+    fetchBlindpayShadowQuoteUsdc(estimatedBrlaDecimal)
   ]);
 
   if (results[0].status === "fulfilled") {
@@ -1029,6 +1075,12 @@ export async function compareRoutesUpfront(usdcAmountRaw: string): Promise<{
     mainNablaQuoteUsdc = results[2].value;
   } else if (mainNablaAvailable) {
     console.warn("Main Nabla quote failed:", results[2].reason);
+  }
+
+  if (results[3].status === "fulfilled") {
+    blindpayShadowQuoteUsdc = results[3].value;
+  } else {
+    console.warn("BlindPay shadow quote failed:", results[3].reason);
   }
 
   // Normalize all quotes to decimal USDC for comparison
@@ -1054,6 +1106,17 @@ export async function compareRoutesUpfront(usdcAmountRaw: string): Promise<{
   console.log("Route comparison results:");
   for (const c of candidates) {
     console.log(`  ${c.route}: ${c.usdcDecimal.toFixed(6)} USDC ${c.route === winner.route ? "(WINNER)" : ""}`);
+  }
+
+  // Observational only: log what BlindPay would have quoted for the same BRLA amount,
+  // alongside the executed routes, to evaluate it as a cheaper stablecoin source over time.
+  if (blindpayShadowQuoteUsdc) {
+    const blindpayUsdcDecimal = multiplyByPowerOfTen(Big(blindpayShadowQuoteUsdc), -6);
+    const deltaVsWinner = blindpayUsdcDecimal.minus(winner.usdcDecimal);
+    console.log(
+      `  blindpay (shadow, not routed): ${blindpayUsdcDecimal.toFixed(6)} USDC-eq ` +
+        `| vs ${winner.route} (winner): ${deltaVsWinner.gte(0) ? "+" : ""}${deltaVsWinner.toFixed(6)} USDC`
+    );
   }
 
   return {

--- a/apps/rebalancer/src/services/blindpay/blindpayApiService.ts
+++ b/apps/rebalancer/src/services/blindpay/blindpayApiService.ts
@@ -1,0 +1,53 @@
+import { getConfig } from "../../utils/config.ts";
+import type { PayinFxRateInput, PayinFxRateResponse } from "./types.ts";
+
+/// Minimal client for the BlindPay API. Uses a static Bearer API key (no login flow).
+/// We only need the payin FX-rate endpoint to obtain an indicative fiat -> stablecoin
+/// price, used purely as an observational comparison against the executed routes.
+export class BlindpayApiService {
+  private static instance: BlindpayApiService;
+
+  private constructor() {}
+
+  public static getInstance(): BlindpayApiService {
+    if (!BlindpayApiService.instance) {
+      BlindpayApiService.instance = new BlindpayApiService();
+    }
+    return BlindpayApiService.instance;
+  }
+
+  /// Whether BlindPay is configured. When false, callers should skip gracefully.
+  public static isConfigured(): boolean {
+    const { blindpayApiKey, blindpayInstanceId } = getConfig();
+    return Boolean(blindpayApiKey && blindpayInstanceId);
+  }
+
+  /// Returns an indicative payin quote (fiat -> stablecoin) without creating a receiver
+  /// or blockchain wallet. See POST /instances/{instanceId}/payin-quotes/fx.
+  public async getPayinFxRate(input: PayinFxRateInput): Promise<PayinFxRateResponse> {
+    const { blindpayApiKey, blindpayBaseUrl, blindpayInstanceId } = getConfig();
+    if (!blindpayApiKey || !blindpayInstanceId) {
+      throw new Error("BlindPay is not configured (BLINDPAY_API_KEY / BLINDPAY_INSTANCE_ID missing).");
+    }
+
+    const url = `${blindpayBaseUrl}/instances/${blindpayInstanceId}/payin-quotes/fx`;
+
+    console.log(`BlindPay API Request: POST ${url}`, input);
+
+    const response = await fetch(url, {
+      body: JSON.stringify(input),
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${blindpayApiKey}`,
+        "Content-Type": "application/json"
+      },
+      method: "POST"
+    });
+
+    if (!response.ok) {
+      throw new Error(`BlindPay request failed with status '${response.status}'. Error: ${await response.text()}`);
+    }
+
+    return (await response.json()) as PayinFxRateResponse;
+  }
+}

--- a/apps/rebalancer/src/services/blindpay/types.ts
+++ b/apps/rebalancer/src/services/blindpay/types.ts
@@ -1,0 +1,33 @@
+// Types for the BlindPay API (https://api.blindpay.com/reference).
+// We only use the lightweight payin FX-rate endpoint to obtain an indicative
+// price for converting fiat (BRL) into a stablecoin, for rate-tracking purposes.
+
+// Fiat currency the sender pays in.
+export type BlindpayFiatCurrency = "BRL" | "USD" | "MXN" | "COP" | "ARS";
+
+// Stablecoin the receiver would get out. "USDB" is only available on sandbox/dev instances.
+export type BlindpayStablecoin = "USDC" | "USDT" | "USDB";
+
+// Which side of the conversion `request_amount` is denominated in.
+// "sender" => request_amount is in the fiat currency (what we want here).
+export type BlindpayCurrencyType = "sender" | "receiver";
+
+// POST /instances/{instanceId}/payin-quotes/fx
+export interface PayinFxRateInput {
+  currency_type: BlindpayCurrencyType;
+  from: BlindpayFiatCurrency;
+  to: BlindpayStablecoin;
+  // Integer amount in cents of the `currency_type` currency. No float values allowed.
+  request_amount: number;
+}
+
+export interface PayinFxRateResponse {
+  // Market/reference quotation.
+  commercial_quotation: number;
+  // The quotation BlindPay actually applies (includes their spread).
+  blindpay_quotation: number;
+  // Resulting amount on the other side of the conversion, in cents.
+  result_amount: number;
+  instance_flat_fee: number;
+  instance_percentage_fee: number;
+}

--- a/apps/rebalancer/src/services/stateManager.ts
+++ b/apps/rebalancer/src/services/stateManager.ts
@@ -203,6 +203,8 @@ export interface UsdcBaseRebalanceState {
   squidRouterQuoteUsdc: string | null;
   aveniaQuoteUsdc: string | null;
   mainNablaQuoteUsdc: string | null;
+  // Observational-only BlindPay shadow quote (USDC-equivalent raw, 6 decimals); never routed.
+  blindpayShadowQuoteUsdc: string | null;
   mainNablaApproveHash: string | null;
   mainNablaSwapHash: string | null;
   mainNablaUsdcBalanceBeforeRaw: string | null;
@@ -251,6 +253,7 @@ export function createUsdcBaseRebalanceState(
     aveniaTicketId: null,
     baseUsdcBalanceBeforeAveniaSwapRaw: null,
     baseUsdcBalanceBeforeSquidSwapRaw: null,
+    blindpayShadowQuoteUsdc: null,
     brlaAmountDecimal: null,
     brlaAmountRaw: null,
     brlaBalanceBeforeNablaRaw: null,

--- a/apps/rebalancer/src/utils/config.ts
+++ b/apps/rebalancer/src/utils/config.ts
@@ -83,6 +83,16 @@ export function getConfig() {
 
   return {
     alchemyApiKey: process.env.ALCHEMY_API_KEY,
+
+    // BlindPay is used purely to log an observational comparison price (fiat BRL -> stablecoin)
+    // against the executed routes. Optional: when apiKey/instanceId are missing, the comparison
+    // is skipped and the rebalancer keeps working as before.
+    blindpayApiKey: process.env.BLINDPAY_API_KEY,
+    blindpayBaseUrl: process.env.BLINDPAY_BASE_URL || "https://api.blindpay.com/v1",
+    blindpayInstanceId: process.env.BLINDPAY_INSTANCE_ID,
+    // Sandbox/dev instances only support the "USDB" token; production uses "USDC"/"USDT".
+    blindpayToken: process.env.BLINDPAY_TOKEN || "USDT",
+
     brlaBaseUrl: BRLA_BASE_URL,
 
     brlaBusinessAccountAddress: process.env.BRLA_BUSINESS_ACCOUNT_ADDRESS || "0xDF5Fb34B90e5FDF612372dA0c774A516bF5F08b2",


### PR DESCRIPTION
## What

Adds an **observational** BlindPay price comparison to the \`usdc-brla-usdc-base\` rebalancing route, to evaluate whether BlindPay is a cheaper source of stablecoin (USDT to feed into Nabla) than the routes we already use.

On each route comparison, \`compareRoutesUpfront\` now fetches a **BlindPay shadow quote** (payin BRL → USDT/USDB) in parallel with the SquidRouter / Avenia / Nabla quotes. It's:
- **Logged in the console comparison**, alongside the executed routes.
- **Surfaced in the Slack completion notification**, e.g.:
  \`\`\`
  *BlindPay shadow* (not routed): 95.220000 USDC-eq | vs SquidRouter 95.400000: -0.180000
  \`\`\`

## Not routed

The shadow quote is **never added to \`candidates\`**, so BlindPay is never actually selected/executed — this is a data-gathering feature only. It never throws, and skips cleanly when BlindPay is unconfigured or the amount is below BlindPay's 5 BRL minimum.

## Implementation

- New \`apps/rebalancer/src/services/blindpay/\` — a minimal client for BlindPay's lightweight payin FX-rate endpoint (\`POST /instances/{id}/payin-quotes/fx\`), which needs only an API key + instance ID (no receiver/KYC/blockchain-wallet setup).
- \`fetchBlindpayShadowQuoteUsdc\` returns a USDC-equivalent (6dp) quote for apples-to-apples comparison.
- Threaded through preflight quotes → rebalance state → Slack completion message.
- Optional \`BLINDPAY_*\` config (documented in \`.env.example\`).

## Config

\`\`\`
BLINDPAY_API_KEY=...
BLINDPAY_INSTANCE_ID=in_...
BLINDPAY_BASE_URL=https://api.blindpay.com/v1   # optional
BLINDPAY_TOKEN=USDT                              # sandbox/dev instances only support USDB
\`\`\`

When \`BLINDPAY_API_KEY\`/\`BLINDPAY_INSTANCE_ID\` are unset, the shadow quote is skipped and the rebalancer behaves exactly as before.

## Testing

- \`tsc\` clean, all 56 rebalancer tests pass.
- Verified live against the BlindPay sandbox: 500 BRL → 95.22 USDC-eq (~0.190 USD/BRL, tracks real BRL/USD); below-minimum amounts return null; Slack line renders with the delta vs the executed route and is absent when unconfigured.

## Notes for reviewers / before prod

- Sandbox returns realistic BRL/USD FX and exposes BlindPay's spread (~0.1%) + flat fee (~\$0.10 on the test instance). Re-confirm fees on the production instance.
- For production, set \`BLINDPAY_TOKEN=USDC\` or \`USDT\` — \`USDB\` is sandbox-only.