### PR TITLE
fix(shared): make ApiManager refresh paths actually replace the stale api

### DIFF
--- a/packages/shared/src/services/pendulum/apiManager.test.ts
+++ b/packages/shared/src/services/pendulum/apiManager.test.ts
@@ -91,14 +91,15 @@ describe("ApiManager api refresh", () => {
 
     // Mimics the real connectApi: returns a fresh instance reading the current on-chain
     // spec version and records that version as the previous one.
-    manager.connectApi = mock((networkName: SubstrateApiNetwork) => {
+    const connectApiMock = mock((networkName: SubstrateApiNetwork) => {
       const fake = createFakeApi(() => onChainSpecVersion);
       fakes.push(fake);
       manager.previousSpecVersions.set(networkName, onChainSpecVersion);
       return Promise.resolve(fake.instance);
     });
+    manager.connectApi = connectApiMock;
 
-    return { fakes, manager, setSpecVersion: (version: number) => (onChainSpecVersion = version) };
+    return { connectApiMock, fakes, manager, setSpecVersion: (version: number) => (onChainSpecVersion = version) };
   }
 
   it("populateApi is idempotent and reuses the cached instance", async () => {
@@ -126,6 +127,20 @@ describe("ApiManager api refresh", () => {
     expect(manager.connectApi).toHaveBeenCalledTimes(2);
     expect(fakes[0].disconnect).toHaveBeenCalledTimes(1);
     expect(manager.apiInstances.get("pendulum-0")).toBe(refreshed);
+  });
+
+  it("keeps the cached instance when the refresh reconnect fails", async () => {
+    const { connectApiMock, fakes, manager, setSpecVersion } = setupManager();
+
+    const initial = await manager.populateApi("pendulum");
+
+    setSpecVersion(2);
+    connectApiMock.mockImplementationOnce(() => Promise.reject(new Error("reconnect failed")));
+
+    await expect(manager.getApi("pendulum")).rejects.toThrow("reconnect failed");
+
+    expect(manager.apiInstances.get("pendulum-0")).toBe(initial);
+    expect(fakes[0].disconnect).not.toHaveBeenCalled();
   });
 
   it("getApi with forceRefresh replaces and disconnects the cached instance", async () => {

--- a/packages/shared/src/services/pendulum/apiManager.test.ts
+++ b/packages/shared/src/services/pendulum/apiManager.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import type { NetworkConfig } from "./apiManager";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { ApiPromise } from "@polkadot/api";
+import { type API, ApiManager, type NetworkConfig, type SubstrateApiNetwork } from "./apiManager";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -51,5 +52,90 @@ describe("ApiManager network configuration", () => {
       "wss://moonbeam-one.example",
       "wss://moonbeam-two.example"
     ]);
+  });
+});
+
+// Exposes the private members needed to drive the manager without real WS connections.
+type TestableApiManager = {
+  apiInstances: Map<string, API>;
+  previousSpecVersions: Map<string, number>;
+  connectApi: (networkName: SubstrateApiNetwork, wsUrlIndex?: number) => Promise<API>;
+  populateApi: ApiManager["populateApi"];
+  getApi: ApiManager["getApi"];
+};
+
+function createManager(): TestableApiManager {
+  return new (ApiManager as unknown as new () => TestableApiManager)();
+}
+
+function createFakeApi(getSpecVersion: () => number): { instance: API; disconnect: ReturnType<typeof mock> } {
+  const disconnect = mock(() => Promise.resolve());
+  const api = {
+    call: {
+      core: {
+        version: () => Promise.resolve({ toHuman: () => ({ specVersion: getSpecVersion() }) })
+      }
+    },
+    disconnect,
+    isConnected: true,
+    isReady: Promise.resolve()
+  };
+  return { disconnect, instance: { api: api as unknown as ApiPromise, decimals: 12, ss58Format: 42 } };
+}
+
+describe("ApiManager api refresh", () => {
+  function setupManager() {
+    const manager = createManager();
+    let onChainSpecVersion = 1;
+    const fakes: ReturnType<typeof createFakeApi>[] = [];
+
+    // Mimics the real connectApi: returns a fresh instance reading the current on-chain
+    // spec version and records that version as the previous one.
+    manager.connectApi = mock((networkName: SubstrateApiNetwork) => {
+      const fake = createFakeApi(() => onChainSpecVersion);
+      fakes.push(fake);
+      manager.previousSpecVersions.set(networkName, onChainSpecVersion);
+      return Promise.resolve(fake.instance);
+    });
+
+    return { fakes, manager, setSpecVersion: (version: number) => (onChainSpecVersion = version) };
+  }
+
+  it("populateApi is idempotent and reuses the cached instance", async () => {
+    const { fakes, manager } = setupManager();
+
+    const first = await manager.populateApi("pendulum");
+    const second = await manager.populateApi("pendulum");
+
+    expect(second).toBe(first);
+    expect(manager.connectApi).toHaveBeenCalledTimes(1);
+    expect(fakes[0].disconnect).not.toHaveBeenCalled();
+  });
+
+  it("getApi replaces and disconnects the cached instance when the spec version changes", async () => {
+    const { fakes, manager, setSpecVersion } = setupManager();
+
+    const initial = await manager.populateApi("pendulum");
+
+    // Simulate a runtime upgrade on chain
+    setSpecVersion(2);
+
+    const refreshed = await manager.getApi("pendulum");
+
+    expect(refreshed).not.toBe(initial);
+    expect(manager.connectApi).toHaveBeenCalledTimes(2);
+    expect(fakes[0].disconnect).toHaveBeenCalledTimes(1);
+    expect(manager.apiInstances.get("pendulum-0")).toBe(refreshed);
+  });
+
+  it("getApi with forceRefresh replaces and disconnects the cached instance", async () => {
+    const { fakes, manager } = setupManager();
+
+    const initial = await manager.populateApi("pendulum");
+    const refreshed = await manager.getApi("pendulum", true);
+
+    expect(refreshed).not.toBe(initial);
+    expect(fakes[0].disconnect).toHaveBeenCalledTimes(1);
+    expect(manager.apiInstances.get("pendulum-0")).toBe(refreshed);
   });
 });

--- a/packages/shared/src/services/pendulum/apiManager.ts
+++ b/packages/shared/src/services/pendulum/apiManager.ts
@@ -118,7 +118,10 @@ export class ApiManager {
     const index = wsUrlIndex ?? 0;
     const instanceKey = this.generateInstanceKey(networkName, index);
     const staleInstance = this.apiInstances.get(instanceKey);
-    this.apiInstances.delete(instanceKey);
+
+    // Create the replacement before dropping the stale instance so a failed reconnect
+    // doesn't leave the network without a cached api.
+    const newApi = await this.createAndCacheApi(networkName, index);
 
     if (staleInstance) {
       try {
@@ -128,16 +131,17 @@ export class ApiManager {
       }
     }
 
-    return await this.createAndCacheApi(networkName, index);
+    return newApi;
   }
 
   private async createAndCacheApi(networkName: SubstrateApiNetwork, index: number): Promise<API> {
-    const instanceKey = this.generateInstanceKey(networkName, index);
     const newApi = await this.connectApi(networkName, index);
-    this.apiInstances.set(instanceKey, newApi);
 
     if (!newApi.api.isConnected) await newApi.api.connect();
     await newApi.api.isReady;
+
+    // Cache only once the api is ready so concurrent readers never observe a connecting instance.
+    this.apiInstances.set(this.generateInstanceKey(networkName, index), newApi);
 
     return newApi;
   }

--- a/packages/shared/src/services/pendulum/apiManager.ts
+++ b/packages/shared/src/services/pendulum/apiManager.ts
@@ -107,6 +107,32 @@ export class ApiManager {
     if (existingInstance) {
       return existingInstance;
     }
+    return await this.createAndCacheApi(networkName, index);
+  }
+
+  /**
+   * Discards the cached API instance (disconnecting it) and creates a fresh one.
+   * Unlike populateApi, this always replaces the cached instance.
+   */
+  public async refreshApi(networkName: SubstrateApiNetwork, wsUrlIndex?: number): Promise<API> {
+    const index = wsUrlIndex ?? 0;
+    const instanceKey = this.generateInstanceKey(networkName, index);
+    const staleInstance = this.apiInstances.get(instanceKey);
+    this.apiInstances.delete(instanceKey);
+
+    if (staleInstance) {
+      try {
+        await staleInstance.api.disconnect();
+      } catch (error) {
+        logger.current.warn(`Failed to disconnect stale API instance for ${instanceKey}: ${error}`);
+      }
+    }
+
+    return await this.createAndCacheApi(networkName, index);
+  }
+
+  private async createAndCacheApi(networkName: SubstrateApiNetwork, index: number): Promise<API> {
+    const instanceKey = this.generateInstanceKey(networkName, index);
     const newApi = await this.connectApi(networkName, index);
     this.apiInstances.set(instanceKey, newApi);
 
@@ -127,8 +153,12 @@ export class ApiManager {
     const instanceKey = this.generateInstanceKey(networkName, 0);
     const apiInstance = this.apiInstances.get(instanceKey);
 
-    if (!apiInstance || forceRefresh) {
+    if (!apiInstance) {
       return await this.populateApi(networkName);
+    }
+
+    if (forceRefresh) {
+      return await this.refreshApi(networkName);
     }
 
     const currentSpecVersion = await this.getSpecVersion(apiInstance.api);
@@ -136,7 +166,7 @@ export class ApiManager {
 
     if (currentSpecVersion !== previousSpecVersion) {
       logger.current.info(`Spec version changed for ${networkName}, refreshing the api...`);
-      return await this.populateApi(networkName);
+      return await this.refreshApi(networkName);
     }
 
     return apiInstance;
@@ -235,10 +265,12 @@ export class ApiManager {
         );
 
         try {
-          await this.populateApi(networkName);
+          const refreshedApiInstance = await this.refreshApi(networkName);
+          // Rebuild the extrinsic against the refreshed api; the original call is bound to the stale registry.
+          const retryCall = createCall(refreshedApiInstance.api);
           const nonce = await this.getNonce(senderKeypair, networkName);
           return new Promise((resolve, reject) => {
-            call.signAndSend(senderKeypair, { nonce }, (submissionResult: ISubmittableResult) => {
+            retryCall.signAndSend(senderKeypair, { nonce }, (submissionResult: ISubmittableResult) => {
               const { status, dispatchError } = submissionResult;
 
               if (dispatchError) {


### PR DESCRIPTION
## Summary

`populateApi()` in `packages/shared/src/services/pendulum/apiManager.ts` returns the cached instance when one exists, but it was also used as the "refresh" mechanism in two places:

- `getApi()` when a spec version change is detected (logs "refreshing the api...")
- `executeApiCall()` on the "Transaction has a bad signature" retry

In both cases the cached instance was returned unchanged, so the refresh was a no-op — the stale `ApiPromise` kept being used.

## Changes

- Add `refreshApi()`, which removes the cached instance from `apiInstances`, disconnects the old `ApiPromise` (best-effort with a warning log), and creates a fresh connection. The connect-and-cache logic is shared with `populateApi` via a private `createAndCacheApi` helper, so `populateApi`/`populateAllApis` remain idempotent for normal startup.
- `getApi()` uses `refreshApi()` on the spec-version-change path, and also for `forceRefresh: true`, which had the same no-op bug (no current callers pass it).
- The bad-signature retry in `executeApiCall()` uses `refreshApi()` and rebuilds the extrinsic via `createCall(refreshedApi.api)` — the original call object is bound to the stale api's registry, so re-signing it would defeat the refresh even with a new connection.

## Tests

New `ApiManager api refresh` block in `apiManager.test.ts` stubs the private `connectApi` with fake instances whose reported spec version is controllable:

- `populateApi` idempotency (cached instance reused, no reconnect, no disconnect)
- spec-version-change path: a simulated runtime upgrade must yield a new instance, disconnect the old one, and update `apiInstances`
- `forceRefresh` path: same replacement + disconnect semantics

Both refresh tests were verified to fail against the previous implementation (`getApi` returned the identical stale instance).

Verified with `bun test` in `packages/shared` (19 pass), `bun typecheck`, and `bun lint`.