### PR TITLE
style(frontend): fix en.json formatting breaking bun verify on staging

### DIFF
--- a/apps/frontend/src/translations/en.json
+++ b/apps/frontend/src/translations/en.json
@@ -646,13 +646,13 @@
       "docs": "Docs",
       "howItWorks": "How it works",
       "individuals": "Individuals",
-    "openApp": "Open App",
-    "payments": "Payments",
-    "sellCrypto": "Sell Crypto",
-    "solutions": "Solutions",
-    "toggleMobileMenu": "Toggle mobile menu",
-    "vortexLogo": "Vortex Logo",
-    "widget": "Widget"
+      "openApp": "Open App",
+      "payments": "Payments",
+      "sellCrypto": "Sell Crypto",
+      "solutions": "Solutions",
+      "toggleMobileMenu": "Toggle mobile menu",
+      "vortexLogo": "Vortex Logo",
+      "widget": "Widget"
     },
     "quoteSubmitButton": {
       "buy": "Buy",


### PR DESCRIPTION
The i18n commit merged in #1255 left `apps/frontend/src/translations/en.json` mis-formatted, so `bun verify` fails on staging itself and on the merge ref of every open PR (first seen on #1257's CI).

One-line-class fix: `biome check --write` on the translations folder. No content changes, formatting only.