### PR TITLE
fix(sdk): map current BRL missing-parameter error messages

### DIFF
--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -111,7 +111,7 @@ export class BrlOnrampError extends RegisterRampError {
 
 export class MissingBrlParametersError extends BrlOnrampError {
   constructor() {
-    super("Parameters destinationAddress and taxId are required for onramp", 400);
+    super("Parameter destinationAddress is required for onramp", 400);
     this.name = "MissingBrlParametersError";
   }
 }
@@ -161,7 +161,7 @@ export class BrlOfframpError extends RegisterRampError {
 
 export class MissingBrlOfframpParametersError extends BrlOfframpError {
   constructor() {
-    super("receiverTaxId, pixDestination and taxId parameters must be provided for offramp to BRL", 400);
+    super("pixDestination is required for offramp to BRL", 400);
     this.name = "MissingBrlOfframpParametersError";
   }
 }
@@ -473,7 +473,7 @@ export function parseAPIError(response: unknown, fallbackStatus?: number): Vorte
       if (missingEphemeralMatch) {
         return new EphemeralNotFreshError(errorMessage, missingEphemeralMatch[1] as EphemeralChain, "");
       }
-      if (errorMessage === "Parameters destinationAddress and taxId are required for onramp") {
+      if (errorMessage === "Parameter destinationAddress is required for onramp") {
         return new MissingBrlParametersError();
       }
       if (errorMessage === "Moonbeam ephemeral not found") {
@@ -491,7 +491,7 @@ export function parseAPIError(response: unknown, fallbackStatus?: number): Vorte
       if (errorMessage === "Amount exceeds KYC limits" || errorMessage === "Amount exceeds limit") {
         return new AmountExceedsLimitError();
       }
-      if (errorMessage === "receiverTaxId, pixDestination and taxId parameters must be provided for offramp to BRL") {
+      if (errorMessage === "pixDestination is required for offramp to BRL") {
         return new MissingBrlOfframpParametersError();
       }
       if (errorMessage === "Invalid pixKey or receiverTaxId") {
@@ -511,6 +511,8 @@ export function parseAPIError(response: unknown, fallbackStatus?: number): Vorte
       if (errorMessage === "fiatAccountId is required for Alfredpay offramp") {
         return new MissingAlfredpayOfframpParametersError(errorMessage);
       }
+      // Shared across BRL, Alfredpay and Mykobo offramp routes (missing walletAddress);
+      // the message carries no corridor, so it cannot be mapped to a corridor-specific class.
       if (errorMessage === "User address must be provided for offramping.") {
         return new MissingAlfredpayOfframpParametersError(errorMessage);
       }

--- a/packages/sdk/test/errors.test.ts
+++ b/packages/sdk/test/errors.test.ts
@@ -1,5 +1,12 @@
 import {describe, expect, test} from "bun:test";
-import {AlfredpayOnrampKycRequiredError, parseAPIError, VortexSdkError} from "../src/errors";
+import {
+  AlfredpayOnrampKycRequiredError,
+  MissingAlfredpayOfframpParametersError,
+  MissingBrlOfframpParametersError,
+  MissingBrlParametersError,
+  parseAPIError,
+  VortexSdkError
+} from "../src/errors";
 
 describe("parseAPIError", () => {
   test("uses API error code when status is omitted", () => {
@@ -26,5 +33,46 @@ describe("parseAPIError", () => {
 
     expect(error).toBeInstanceOf(AlfredpayOnrampKycRequiredError);
     expect(error.status).toBe(401);
+  });
+
+  // Regression: the backend dropped taxId from these messages once taxId became
+  // server-derived. The parser must match the current strings, not the legacy ones.
+  test("maps the current BRL onramp missing-parameter message", () => {
+    const error = parseAPIError({ code: 400, message: "Parameter destinationAddress is required for onramp" });
+
+    expect(error).toBeInstanceOf(MissingBrlParametersError);
+    expect(error.status).toBe(400);
+  });
+
+  test("maps the current BRL offramp missing-parameter message", () => {
+    const error = parseAPIError({ code: 400, message: "pixDestination is required for offramp to BRL" });
+
+    expect(error).toBeInstanceOf(MissingBrlOfframpParametersError);
+    expect(error.status).toBe(400);
+  });
+
+  test("does not map the retired legacy BRL messages to the named errors", () => {
+    const onramp = parseAPIError({ code: 400, message: "Parameters destinationAddress and taxId are required for onramp" });
+    const offramp = parseAPIError({
+      code: 400,
+      message: "receiverTaxId, pixDestination and taxId parameters must be provided for offramp to BRL"
+    });
+
+    expect(onramp).not.toBeInstanceOf(MissingBrlParametersError);
+    expect(offramp).not.toBeInstanceOf(MissingBrlOfframpParametersError);
+  });
+
+  // The missing-walletAddress message is shared across BRL/Alfredpay/Mykobo offramps
+  // and carries no corridor, so it maps to the Alfredpay class regardless of corridor.
+  test("maps the shared missing-walletAddress offramp message", () => {
+    const error = parseAPIError({ code: 400, message: "User address must be provided for offramping." });
+
+    expect(error).toBeInstanceOf(MissingAlfredpayOfframpParametersError);
+    expect(error.status).toBe(400);
+  });
+
+  test("named BRL parameter errors default to the current backend messages", () => {
+    expect(new MissingBrlParametersError().message).toBe("Parameter destinationAddress is required for onramp");
+    expect(new MissingBrlOfframpParametersError().message).toBe("pixDestination is required for offramp to BRL");
   });
 });


### PR DESCRIPTION
## Summary

`parseAPIError` in `packages/sdk/src/errors.ts` matched the **pre-`taxId`-derivation** backend messages, so `MissingBrlParametersError` and `MissingBrlOfframpParametersError` stopped firing once the backend dropped `taxId` from those strings. A caller who omits `destinationAddress` (onramp) or `pixDestination` (offramp) was getting a generic `VortexSdkError` instead of the named class.

Surfaced during the Copilot review of #1266.

## Changes

- Match the current backend messages, verified in `apps/api/src/api/services/ramp/ramp.service.ts`:
  - onramp missing `destinationAddress` → `"Parameter destinationAddress is required for onramp"` (`ramp.service.ts:1115`)
  - offramp missing `pixDestination` → `"pixDestination is required for offramp to BRL"` (`ramp.service.ts:1043`)
- Update the two error classes' default messages to the same strings.
- **Dropped** the legacy strings rather than keeping them: they no longer exist on either `staging` or `main` (checked both).
- The shared `"User address must be provided for offramping."` message (missing `walletAddress`) is thrown by BRL, Alfredpay **and** Mykobo routes and carries no corridor, so it cannot be mapped to a corridor-specific class. Left it on the existing `MissingAlfredpayOfframpParametersError` mapping and added a comment explaining why, to prevent a future "fix" that would break the other corridors.

## Tests

Added `parseAPIError` regression tests in `packages/sdk/test/errors.test.ts` covering:
- the current onramp/offramp messages → named BRL errors
- the retired legacy strings → **not** mapped (the regression guard)
- the shared walletAddress message → Alfredpay class
- the updated class default messages

## Verification

- `bun test` in `packages/sdk`: 41 pass, 0 fail
- `bun run typecheck`: clean
- `bun run build` + `require('./dist/index.js')` smoke test: classes carry the new messages, parser maps the current message correctly
- `bun lint`: clean