### PR TITLE
chore: large-codebase playbook — codebase map, layered CLAUDE.md, permission denies

### DIFF
--- a/.agents/skills/sentry-vortex/SKILL.md
+++ b/.agents/skills/sentry-vortex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-vortex
-description: Audit code against Vortex's Sentry conventions and guide correct error instrumentation. Triggers on: sentry, captureException, error reporting, error monitoring, beforeSend, ignoreErrors, adding an API service method, new error class, new XState machine error handling, ErrorBoundary, "is this reported to Sentry".
+description: "Scoped to apps/frontend (the React web app). Audit code against Vortex's Sentry conventions and guide correct error instrumentation. Triggers when working under apps/frontend on: sentry, captureException, error reporting, error monitoring, beforeSend, ignoreErrors, adding an API service method, new error class, new XState machine error handling, ErrorBoundary, \"is this reported to Sentry\"."
 user-invocable: true
 argument-hint: "[files or 'current changes' — defaults to the working-tree diff]"
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "Team-shared, version-controlled Claude Code settings. Personal overrides go in the git-ignored settings.local.json. deny takes precedence over any allow.",
+  "permissions": {
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push -f *)",
+      "Bash(git push origin --force*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(./.api-key.json)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,8 @@
       "Read(./.env.*)",
       "Read(**/.env)",
       "Read(**/.env.*)",
-      "Read(./.api-key.json)"
+      "Read(./.api-key.json)",
+      "Read(**/.api-key.json)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,9 @@ storybook-static
 
 
 CLAUDE.local.md
-.claude
+# Ignore everything under .claude except the team-shared settings.json
+.claude/*
+!.claude/settings.json
 /.roo/*
 
 # hardhat generated files in workspace contract projects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ Full wayfinding is in [`MAP.md`](MAP.md). This is a **Bun monorepo** using works
 ## Monorepo Commands
 
 > Always use `bun` — never `npm`, `yarn`, or `pnpm`. Run `bun lint:fix` after any code
-> change. Per-app test/dev/migrate commands live in each subdirectory's `CLAUDE.md`.
+> change — **except in `packages/sdk`, which is linted by ESLint** (`bun lint` inside that
+> package); Biome does not govern it. Per-app test/dev/migrate commands live in each
+> subdirectory's `CLAUDE.md`.
 
 ```bash
 bun install          # install all dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,179 +1,110 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository. This root file
+holds **cross-cutting** context only. Each app/package has its own `CLAUDE.md` with
+scoped architecture and commands — `cd` into the relevant one before working there, and
+read it first.
 
 ## Project Overview
 
-Vortex is a cross-border payments gateway built on the Pendulum blockchain. It enables on-ramping and off-ramping of fiat currencies through stablecoins using cross-chain swaps via XCM (Cross-Consensus Messaging).
+Vortex is a cross-border payments gateway built on the Pendulum blockchain. It enables
+on-ramping and off-ramping of fiat currencies through stablecoins using cross-chain swaps
+via XCM (Cross-Consensus Messaging).
 
-## Monorepo Structure
+## Repository Map
 
-This is a **Bun monorepo** using workspaces:
+Full wayfinding is in [`MAP.md`](MAP.md). This is a **Bun monorepo** using workspaces:
 
-- **apps/frontend** - React 19 + Vite web application
-- **apps/api** - Express backend service (PostgreSQL + Sequelize)
-- **apps/rebalancer** - Liquidity rebalancing service
-- **packages/shared** - Shared utilities, types, token configs, and helpers
-- **packages/sdk** - Public SDK for Vortex API integration
+- **apps/frontend** — React 19 + Vite web app → [`apps/frontend/CLAUDE.md`](apps/frontend/CLAUDE.md)
+- **apps/api** — Express backend (PostgreSQL + Sequelize) → [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md)
+- **apps/rebalancer** — liquidity rebalancing service → [`apps/rebalancer/CLAUDE.md`](apps/rebalancer/CLAUDE.md)
+- **packages/shared** — `@vortexfi/shared` utilities/configs → [`packages/shared/CLAUDE.md`](packages/shared/CLAUDE.md)
+- **packages/sdk** — `@vortexfi/sdk` public SDK → [`packages/sdk/CLAUDE.md`](packages/sdk/CLAUDE.md)
 
-## Essential Commands
+## Monorepo Commands
 
-> Always use `bun`- never `npm`, `yarn`, or `pnpm`. Run `bun lint:fix` after any code change.
+> Always use `bun` — never `npm`, `yarn`, or `pnpm`. Run `bun lint:fix` after any code
+> change. Per-app test/dev/migrate commands live in each subdirectory's `CLAUDE.md`.
 
 ```bash
-# Install all dependencies
-bun install
-
-# Development (runs frontend, backend, and shared concurrently)
-bun dev
-
-# Individual app development
-bun dev:frontend    # Frontend at http://127.0.0.1:5173
-bun dev:backend     # Backend at http://localhost:3000
+bun install          # install all dependencies
+bun dev              # frontend + backend + shared concurrently
+bun dev:frontend     # http://127.0.0.1:5173
+bun dev:backend      # http://localhost:3000
 bun dev:rebalancer
 
-# Build
-bun build           # Build all (shared -> sdk -> frontend -> backend)
-bun build:shared    # Must build shared first when making changes
-bun build:frontend
-bun build:backend
+bun build            # build all (shared -> sdk -> frontend -> backend)
+bun build:shared     # rebuild shared (see below)
 
-# Linting and formatting (uses Biome)
-bun lint            # Run linter
-bun lint:fix        # Auto-fix lint issues
-bun format          # Format all files
-bun verify          # Check without fixing
-
-# Type checking
-bun typecheck
-
-# Database (from apps/api)
-cd apps/api
-bun migrate                  # Run migrations
-bun migrate:revert           # Revert all migrations
-bun migrate:revert-last      # Revert last migration
-bun seed:phase-metadata      # Seed phase configuration
-
-# Testing
-cd apps/frontend && bun test    # Frontend tests (Vitest)
-cd apps/api && bun test         # Backend tests
+bun lint             # Biome lint          bun lint:fix   # auto-fix
+bun format           # format all           bun verify     # check without fixing
+bun typecheck        # type check
 ```
 
-## Architecture
+### Always rebuild shared after changing it
 
-### State Machine Pattern
-
-The ramping process uses a state machine with defined phases:
-- **Offramp**: prepareTransactions → squidRouter → pendulumFundEphemeral → subsidizePreSwap → nablaApprove → nablaSwap → subsidizePostSwap → performBrlaPayout → pendulumCleanup
-- **Onramp**: brlaTeleport → createMoonbeamEphemeral → executeMoonbeamToPendulumXCM → subsidizePreSwap → nablaApprove → nablaSwap → executePendulumToAssetHubXCM → pendulumCleanup
-
-Phase metadata and valid transitions are stored in PostgreSQL and seeded via `seed:phase-metadata`.
-
-### Frontend Architecture
-
-- **State**: Zustand stores (`stores/`) + React Context (`contexts/`)
-- **Forms**: React Hook Form with Zod validation (not Yup)
-- **Data Fetching**: TanStack Query
-- **Routing**: TanStack Router (route tree auto-generated in `routeTree.gen.ts`)
-- **State Machines**: XState machines in `machines/` for complex flows (KYC, ramp process)
-- **Wallet Integration**: Wagmi/AppKit (EVM) + Talisman (Polkadot)
-
-### Backend Architecture
-
-- **API Layer**: Express routes in `api/routes/`, controllers in `api/controllers/`
-- **Services**: Business logic in `api/services/`
-- **Models**: Sequelize models in `models/` (RampState, QuoteTicket, Partner, etc.)
-- **Workers**: Background jobs in `api/workers/`
-- **Cross-chain**: XCM handlers, Nabla AMM integration, Stellar/BRLA APIs
-
-### Shared Package (`@vortexfi/shared`)
-
-Contains cross-package utilities:
-- Token configurations and network definitions
-- Endpoint helpers for API calls
-- Contract ABIs and addresses
-- Decimal/BigNumber helpers
-- Logger configuration
-
-**Important**: Always rebuild shared when making changes: `bun build:shared`
-
-After ANY change to `packages/shared`, run `bun build:shared` before running frontend/api.
-
-## Code Style Guidelines
-
-From `.clinerules/`:
-
-### General
-- Prefer composition over inheritance
-- Create ADRs in `/docs/adr` for major architectural changes
-
-### Frontend-Specific
-- Avoid `useState` unless absolutely needed; prefer derived data and `useRef`
-- Avoid `useEffect` except for external system synchronization
-- Avoid `setTimeout` (always comment why if used)
-- Extract complex conditional rendering into new components
-- Skip useless comments; only comment race conditions, TODOs, or genuinely confusing code
-
-### XState v5
-- Use `setup({ ... }).createMachine(...)` API- not `createMachine` directly
-- Actor refs from `useActor` / `useSelector` from `@xstate/react`
-- Machine files live in `apps/frontend/src/machines/`
-
-### Biome Configuration
-- Line width: 128
-- Indent: 2 spaces
-- Semicolons: always
-- Trailing commas: none
-- Quote style: double
-- Sorted Tailwind classes enforced via `useSortedClasses` rule
+`packages/shared` is consumed as built output. **After ANY change to `packages/shared`,
+run `bun build:shared` before running frontend/api** — otherwise they use stale code.
 
 ## Token Exhaustiveness
 
 `FiatToken` currently has 6 values: `EURC`, `ARS`, `BRL`, `USD`, `MXN`, `COP`.
 
 Any `Record<FiatToken, X>` must include ALL six. Missing entries cause TypeScript errors
-when shared is rebuilt. Check: tokenAvailability, mapFiatToDestination, success page
-ARRIVAL_TEXT_BY_TOKEN, sep10 tokenMapping.
+when shared is rebuilt. Check: `tokenAvailability`, `mapFiatToDestination`, success page
+`ARRIVAL_TEXT_BY_TOKEN`, sep10 `tokenMapping`.
+
+## Code Style
+
+Biome config: line width 128, 2-space indent, semicolons always, no trailing commas,
+double quotes, sorted Tailwind classes (`useSortedClasses`). General: prefer composition
+over inheritance; create ADRs in `/docs/adr` for major architectural changes.
+Frontend-specific and XState conventions live in
+[`apps/frontend/CLAUDE.md`](apps/frontend/CLAUDE.md).
 
 ## No Over-Engineering
 
-- Don't add features, refactors, or "improvements" beyond what was asked
-- Don't add docstrings/comments to code you didn't touch
-- Don't create helpers/utilities for one-time operations
-- Don't validate inputs that can't be invalid (internal calls, typed params)
-- Three similar lines is better than a premature abstraction
+- Don't add features, refactors, or "improvements" beyond what was asked.
+- Don't add docstrings/comments to code you didn't touch.
+- Don't create helpers/utilities for one-time operations.
+- Don't validate inputs that can't be invalid (internal calls, typed params).
+- Three similar lines is better than a premature abstraction.
 
 ## Testing
 
-### Test Coverage Requirements
-
 These apply to every agent working in this repo:
 
-- **Bug fixes and regressions**: if a bug or regression slipped past the existing tests, add a test that reproduces it (and fails without the fix) before/with the fix — so it can't silently come back. Write the test at the level that actually covers the gap (unit or integration). Only skip when a test genuinely can't capture it (e.g. purely cosmetic, environment/config, or third-party behavior) — and say why you skipped.
-- **New features**: always ship the appropriate tests alongside the feature. Cover the core behavior and the edge cases that matter, not just the happy path.
+- **Bug fixes and regressions**: if a bug slipped past existing tests, add a test that
+  reproduces it (and fails without the fix) before/with the fix, so it can't silently
+  come back. Write it at the level that covers the gap (unit or integration). Only skip
+  when a test genuinely can't capture it (purely cosmetic, environment/config, or
+  third-party behavior) — and say why you skipped.
+- **New features**: always ship the appropriate tests alongside the feature. Cover the
+  core behavior and the edge cases that matter, not just the happy path.
 
-### Backend Integration Tests
-```bash
-cd apps/api
-bun test phase-processor.integration.test.ts --timeout X
-```
-State is stored in `lastRampState.json`. For recovery testing, copy failed state to `failedRampStateRecovery.json` and run the recovery test.
-
-### Frontend Tests
-```bash
-cd apps/frontend
-bun test
-```
+Per-app test commands and integration-test state handling live in each subdirectory's
+`CLAUDE.md`.
 
 ## Security Spec Sync
 
-`docs/security-spec/` is the audit-facing source of truth for security-sensitive behavior, and it must not go stale. Any change to an API feature or its business logic — auth, admin routes, quote/ramp state, signing, fees, partner pricing, integrations, migrations/schema that affect invariants, or cross-chain fund flow — must be cross-checked against the matching spec file and updated in the same change whenever the behavior it documents changed. This applies to every agent working in this repo, not just the one that first touched the code.
+`docs/security-spec/` is the audit-facing source of truth for security-sensitive
+behavior, and it must not go stale. Any change to an API feature or its business logic —
+auth, admin routes, quote/ramp state, signing, fees, partner pricing, integrations,
+migrations/schema that affect invariants, or cross-chain fund flow — must be cross-checked
+against the matching spec file and updated in the same change whenever the behavior it
+documents changed. This applies to every agent working in this repo.
 
-Keep this lightweight: grep/read only the relevant spec path from `docs/security-spec/README.md`; skip this for cosmetic refactors, test-only changes, or implementation changes that do not alter security-relevant behavior. If a change alters documented behavior but you are unsure which spec file owns it, say so rather than leaving the spec silently stale.
+Keep this lightweight: grep/read only the relevant spec path from
+`docs/security-spec/README.md`; skip it for cosmetic refactors, test-only changes, or
+implementation changes that do not alter security-relevant behavior. If a change alters
+documented behavior but you are unsure which spec file owns it, say so rather than leaving
+the spec silently stale.
 
 ## Type Issues
 
-If IDE doesn't detect `@pendulum-chain/types` properly, ensure all `@polkadot/*` packages match versions in the types package. The root `package.json` uses `catalog:` for version management.
+If the IDE doesn't detect `@pendulum-chain/types` properly, ensure all `@polkadot/*`
+packages match versions in the types package. The root `package.json` uses `catalog:` for
+version management.
 
 ---
 
@@ -233,4 +164,5 @@ For multi-step tasks, state a brief plan:
 3. [Step] → verify: [check]
 ```
 
-Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+Strong success criteria let you loop independently. Weak criteria ("make it work")
+require constant clarification.

--- a/MAP.md
+++ b/MAP.md
@@ -1,0 +1,47 @@
+# Repository Map
+
+Wayfinding for the Vortex monorepo: what kind of code lives where. Each app/package
+has its own `CLAUDE.md` with scoped commands and conventions — `cd` into the relevant
+one before working there.
+
+## Apps
+
+| Path | What lives here |
+|------|-----------------|
+| `apps/frontend` | React 19 + Vite web app — the user-facing ramp UI. Zustand, TanStack Query/Router, XState, Wagmi/Talisman wallets. → [`CLAUDE.md`](apps/frontend/CLAUDE.md) |
+| `apps/api` | Express backend (PostgreSQL + Sequelize). Ramp state machine, quotes, partners, webhooks, XCM/Nabla/Stellar/BRLA integrations. → [`CLAUDE.md`](apps/api/CLAUDE.md) |
+| `apps/rebalancer` | Standalone liquidity rebalancing service. → [`CLAUDE.md`](apps/rebalancer/CLAUDE.md) |
+
+## Packages
+
+| Path | What lives here |
+|------|-----------------|
+| `packages/shared` | `@vortexfi/shared` — token/network configs, contract ABIs & addresses, decimal/BigNumber helpers, endpoint helpers, logger. Consumed by every app. → [`CLAUDE.md`](packages/shared/CLAUDE.md) |
+| `packages/sdk` | `@vortexfi/sdk` — the public integration SDK shipped to partners. → [`CLAUDE.md`](packages/sdk/CLAUDE.md) |
+
+## Contracts
+
+| Path | What lives here |
+|------|-----------------|
+| `contracts` | Solidity contracts: `cctp-settlement` and `relayer`. |
+| `relayer-contract` | Relayer contract security-audit material. |
+
+## Docs & specs
+
+| Path | What lives here |
+|------|-----------------|
+| `docs/security-spec` | Audit-facing source of truth for security-sensitive behavior. Keep in sync with code changes (see root `CLAUDE.md` → Security Spec Sync). |
+| `docs/api` | Public API docs — OpenAPI spec (`openapi/`) and prose pages (`pages/`). Whitelabeled. |
+| `docs/architecture`, `docs/features`, `docs/qa`, `docs/refactoring` | Architecture notes, feature write-ups, QA and refactoring records. |
+| `docs/testing-strategy.md`, `docs/test-audit-findings.md` | Testing approach and audit findings. |
+| `memory-bank` | Long-form project context: product/tech context, decision log, phases, progress. |
+
+## Tooling & config
+
+| Path | What lives here |
+|------|-----------------|
+| `scripts` | Repo tooling — `check-coverage.ts`, `coverage-report.ts` (LCOV-based coverage gate). |
+| `supabase` | Supabase config, DB migrations, snippets, email templates. |
+| `.agents/skills` | Repo-scoped agent skills: `vortex-integration` (partner integration recipes), `sentry-vortex` (frontend error-instrumentation audit). |
+| `.clinerules` | Cline coding rules (general, useful prompts, frontend). |
+| `.claude` | Claude Code config — shared `settings.json` (deny rules), personal `settings.local.json` (ignored), worktrees. |

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,50 @@
+# apps/api — Vortex backend
+
+Express + PostgreSQL/Sequelize service. Root `CLAUDE.md` holds cross-cutting rules
+(over-engineering, security-spec sync, testing policy); this file holds API-scoped
+architecture and commands. Run commands from `apps/api/` unless noted.
+
+## Architecture
+
+- **API layer**: routes in `src/api/routes/`, controllers in `src/api/controllers/`.
+- **Services**: business logic in `src/api/services/`.
+- **Models**: Sequelize models in `src/models/` (RampState, QuoteTicket, Partner, …).
+- **Workers**: background jobs in `src/api/workers/`.
+- **Cross-chain**: XCM handlers, Nabla AMM integration, Stellar/BRLA APIs.
+- **Middlewares / observability / errors / helpers**: under `src/api/`.
+
+### Ramp state machine
+
+The ramping process runs through defined phases; metadata and valid transitions live in
+PostgreSQL, seeded via `bun seed:phase-metadata`.
+
+- **Offramp**: prepareTransactions → squidRouter → pendulumFundEphemeral → subsidizePreSwap → nablaApprove → nablaSwap → subsidizePostSwap → performBrlaPayout → pendulumCleanup
+- **Onramp**: brlaTeleport → createMoonbeamEphemeral → executeMoonbeamToPendulumXCM → subsidizePreSwap → nablaApprove → nablaSwap → executePendulumToAssetHubXCM → pendulumCleanup
+
+## Commands (from `apps/api/`)
+
+```bash
+bun test                         # full backend suite
+bun test <file>                  # single file, e.g. bun test ramp.service.test.ts
+bun test phase-processor.integration.test.ts --timeout X   # integration test
+
+bun migrate                      # run migrations
+bun migrate:revert              # revert ALL migrations (destructive — dev only)
+bun migrate:revert-last          # revert last migration
+bun seed:phase-metadata          # seed phase configuration
+```
+
+Lint with the repo Biome config: from repo root `bun lint:fix`, or target a path with
+`bunx @biomejs/biome check apps/api/src`. Dev server: `bun dev:backend` from root
+(backend at http://localhost:3000).
+
+## Integration test state
+
+Integration tests store state in `lastRampState.json`. For recovery testing, copy a
+failed state into `failedRampStateRecovery.json` and run the recovery test.
+
+## Security spec
+
+Changes to auth, admin routes, quote/ramp state, signing, fees, partner pricing,
+integrations, or migrations that affect invariants must be cross-checked against
+`docs/security-spec/` in the same change. See root `CLAUDE.md` → Security Spec Sync.

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -1,0 +1,51 @@
+# apps/frontend — Vortex web app
+
+React 19 + Vite. Root `CLAUDE.md` holds cross-cutting rules; this file holds
+frontend-scoped architecture, conventions, and commands. Run commands from
+`apps/frontend/` unless noted.
+
+## Architecture
+
+- **State**: Zustand stores (`src/stores/`) + React Context (`src/contexts/`).
+- **Forms**: React Hook Form with Zod validation (not Yup).
+- **Data fetching**: TanStack Query.
+- **Routing**: TanStack Router — route tree auto-generated in `src/routeTree.gen.ts` (do not hand-edit).
+- **State machines**: XState machines in `src/machines/` for complex flows (KYC, ramp process).
+- **Wallets**: Wagmi/AppKit (EVM) + Talisman (Polkadot).
+
+## Conventions
+
+- Avoid `useState` unless truly needed; prefer derived data and `useRef`.
+- Avoid `useEffect` except for external-system synchronization.
+- Avoid `setTimeout` (always comment why if used).
+- Extract complex conditional rendering into new components.
+- Skip useless comments; only comment race conditions, TODOs, or genuinely confusing code.
+
+### XState v5
+
+- Use `setup({ ... }).createMachine(...)` — not `createMachine` directly.
+- Get actor refs via `useActor` / `useSelector` from `@xstate/react`.
+
+## Commands (from `apps/frontend/`)
+
+```bash
+bun test              # Vitest suite
+bun test <pattern>    # single file / pattern
+```
+
+Dev server: `bun dev:frontend` from root (http://127.0.0.1:5173). Lint from root with
+`bun lint:fix`, or `bunx @biomejs/biome check apps/frontend/src`.
+
+## Error instrumentation
+
+Sentry conventions here are strict (single-source filtering, no capture in components,
+no PII). Before adding error handling, API service methods, or machine error states,
+follow the **`sentry-vortex`** skill (`.agents/skills/sentry-vortex/SKILL.md`) — it is
+the authority for correct instrumentation in this app.
+
+## Token exhaustiveness
+
+`FiatToken` has 6 values (`EURC`, `ARS`, `BRL`, `USD`, `MXN`, `COP`). Any
+`Record<FiatToken, X>` must include all six or the build fails. Common spots:
+`tokenAvailability`, `mapFiatToDestination`, success-page `ARRIVAL_TEXT_BY_TOKEN`,
+sep10 `tokenMapping`.

--- a/apps/rebalancer/CLAUDE.md
+++ b/apps/rebalancer/CLAUDE.md
@@ -1,0 +1,16 @@
+# apps/rebalancer — liquidity rebalancing service
+
+Standalone service that rebalances liquidity across chains. Root `CLAUDE.md` holds
+cross-cutting rules. Run commands from `apps/rebalancer/`.
+
+## Commands
+
+```bash
+bun run src/index.ts   # run the service (also: bun dev:rebalancer from root)
+bun test               # test suite
+```
+
+Lint from root with `bun lint:fix`, or `bunx @biomejs/biome check apps/rebalancer/src`.
+
+Depends on `@vortexfi/shared` — after changing `packages/shared`, run `bun build:shared`
+(from root) before running this service.

--- a/packages/sdk/CLAUDE.md
+++ b/packages/sdk/CLAUDE.md
@@ -1,0 +1,30 @@
+# packages/sdk — @vortexfi/sdk
+
+The **public** integration SDK shipped to partners. It is consumed outside this repo, so
+treat its API surface as a stable contract — breaking changes ripple to integrators.
+
+## SDK-specific gotchas
+
+- **Lint uses ESLint, not Biome**: `bun lint` runs `eslint . --ext .ts`. The repo-wide
+  `bun lint:fix` (Biome) does not govern this package's lint.
+- **`test` also builds and smoke-loads the dist**: `bun test` runs the suite, then
+  `bun run build`, then `node -e "require('./dist/index.js')"`. A green `bun test` means
+  the built bundle imports cleanly too.
+- **Dual build**: see `ARCHITECTURE.md`, `DUAL_BUILD_GUIDE.md`, and
+  `CHANGELOG_DUAL_BUILD.md` before touching the build config.
+
+## Commands (from `packages/sdk/`)
+
+```bash
+bun test          # suite + build + dist smoke-load
+bun run build     # tsc types + bundle to dist/
+bun typecheck     # bun x --bun tsc
+bun lint          # eslint
+```
+
+## Integration recipes
+
+Partner-facing usage patterns (quotes, on/off-ramp flows, webhooks, auth, error
+recovery) are documented in the **`vortex-integration`** skill
+(`.agents/skills/vortex-integration/SKILL.md`). Keep that skill in sync when the SDK's
+public surface changes.

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,0 +1,27 @@
+# packages/shared — @vortexfi/shared
+
+Cross-package utilities consumed by every app: token/network configs, contract ABIs &
+addresses, decimal/BigNumber helpers, endpoint helpers, logger.
+
+## Rebuild after every change
+
+`@vortexfi/shared` is built to `dist/` (dual node + browser targets). Consumers read the
+built output, not `src/`. **After ANY change here, run `bun build:shared` (from root)**
+before running or testing frontend/api — otherwise they use stale code.
+
+```bash
+bun test              # from packages/shared/
+bun build:shared      # from root — rebuild node + browser bundles
+```
+
+## Token exhaustiveness
+
+`FiatToken` has 6 values (`EURC`, `ARS`, `BRL`, `USD`, `MXN`, `COP`). Any
+`Record<FiatToken, X>` defined here must include all six, or dependents fail to typecheck
+when shared is rebuilt.
+
+## Type resolution
+
+If `@pendulum-chain/types` isn't detected properly, ensure all `@polkadot/*` packages
+match the versions in the types package. The root `package.json` manages versions via
+`catalog:`.


### PR DESCRIPTION
## What & why

Applies several best practices from the [large-codebase playbook](https://claudefa.st/blog/guide/development/large-codebase-playbook) to make this monorepo easier and safer for AI agents (and humans) to navigate. All changes are documentation/config — **no application code is touched**.

The core idea: agents (and new contributors) waste context and make cross-module mistakes when all guidance lives in one giant root file and there's no map. This PR makes guidance **layered and local**, adds a **wayfinding map**, and **version-controls a few safety rails**.

## Changes

**1. Root codebase map — `MAP.md`**
A one-screen "what kind of code lives where" for every top-level dir (apps, packages, contracts, docs, tooling), each linking to its scoped `CLAUDE.md`.

**2. Layered, per-workspace `CLAUDE.md` + slimmed root**
New scoped files for `apps/api`, `apps/frontend`, `apps/rebalancer`, `packages/shared`, `packages/sdk`. App-specific architecture, commands, and conventions were **relocated** out of the root into the workspace they belong to (e.g. the ramp state machine + migrations → api; XState/`useEffect` rules + Vitest → frontend; the ESLint-not-Biome and test-builds-dist quirks → sdk; the rebuild-shared rule → shared). The root `CLAUDE.md` drops from 236 → ~168 lines and now holds only cross-cutting context with links down. Agents started in a subdirectory load only the rules that apply there.

**3. Version-controlled permission denies — `.claude/settings.json`**
Team-shared deny rules for force-push and reads of secret files (`.env*`, `.api-key.json`). Because `.claude` was fully git-ignored, `.gitignore` is changed from `.claude` to `.claude/*` + `!.claude/settings.json`, so the shared denies are tracked while personal `settings.local.json` and `worktrees/` stay ignored. (Verified: only `settings.json` becomes tracked.)

**4. Path-scoped skill**
`sentry-vortex`'s description is sharpened to name its `apps/frontend` scope so it surfaces in the React app and not elsewhere; the frontend/sdk `CLAUDE.md` files reference their governing skills, which is the practical form of "path-scoped skills" for Claude Code (skills are selected by description, not globs).

## Not included (evaluated, deliberately left out)

- **LSP-via-MCP** (symbol-level search): prototyped on a separate `chore/lsp-mcp-spike` branch and **evaluated, not adopted**. Out of the box it didn't beat grep on this repo — cross-package navigation is blocked because apps import `@vortexfi/shared` as its built `dist` declarations, so tsserver can't trace symbols back to source. Findings and fix options are documented on that branch; kept out of this PR intentionally.

## Notes for reviewers

- **Stacked on #1266** (`docs/api-seo-and-all-corridor-updates`), so this PR's base is that branch and the diff shows only the playbook changes. It should merge after #1266 (GitHub will retarget to `staging` automatically once #1266 lands).
- Pure docs/config — no runtime impact, nothing to test beyond a read-through. Worth confirming the relocated per-workspace commands match how you actually run each app.
