### PR TITLE
Fix Alfredpay configs endpoint rename + harden limits indexer against junk rows

### DIFF
--- a/apps/api/src/api/services/alfredpay/alfredpay-limits.service.test.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-limits.service.test.ts
@@ -40,7 +40,9 @@ const configsResponse: GetAllConfigsResponse = {
     pair({ decimals: null, id: "junk-individual", typeCustomer: AlfredpayCustomerType.INDIVIDUAL }),
     pair({ decimals: null, id: "junk-wildcard" }),
     pair({ decimals: "", id: "junk-empty-decimals" }),
-    pair({ decimals: null, fromCurrency: null, id: "junk-null-currency" })
+    pair({ decimals: null, fromCurrency: null, id: "junk-null-currency" }),
+    // Oversized decimals would make Big(10).pow throw and abort the whole refresh.
+    pair({ decimals: "999999999999999999999999", id: "junk-huge-decimals", typeCustomer: AlfredpayCustomerType.INDIVIDUAL })
   ]
 };
 

--- a/apps/api/src/api/services/alfredpay/alfredpay-limits.service.test.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-limits.service.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  AlfredpayApiService,
+  type AlfredpayConfigPair,
+  AlfredpayCustomerType,
+  FiatToken,
+  type GetAllConfigsResponse,
+  RampDirection
+} from "@vortexfi/shared";
+import { AlfredpayLimitsService } from "./alfredpay-limits.service";
+
+/**
+ * The live /allConfigs listing contains junk rows: `decimals` null or "", even a null
+ * `fromCurrency` (observed 2026-07-14). Regression test: such rows must be skipped, not
+ * indexed — Number(null) is 0, and a customer-specific null-decimals row would otherwise
+ * override the valid wildcard row and shrink the raw limits by 10^decimals.
+ */
+
+function pair(overrides: Partial<AlfredpayConfigPair>): AlfredpayConfigPair {
+  return {
+    businessId: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    decimals: "2",
+    fromCurrency: "MXN",
+    id: "pair",
+    maxQuantity: "170799.99",
+    minQuantity: "50.00",
+    toCurrency: "USDC",
+    typeCustomer: null,
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides
+  };
+}
+
+const configsResponse: GetAllConfigsResponse = {
+  supportedPairs: [
+    // The only trustworthy row: wildcard MXN -> USDC with explicit decimals.
+    pair({ id: "valid-wildcard" }),
+    // Junk rows as served live; the INDIVIDUAL one would take precedence if indexed.
+    pair({ decimals: null, id: "junk-individual", typeCustomer: AlfredpayCustomerType.INDIVIDUAL }),
+    pair({ decimals: null, id: "junk-wildcard" }),
+    pair({ decimals: "", id: "junk-empty-decimals" }),
+    pair({ decimals: null, fromCurrency: null, id: "junk-null-currency" })
+  ]
+};
+
+const originalGetInstance = AlfredpayApiService.getInstance;
+afterAll(() => {
+  AlfredpayApiService.getInstance = originalGetInstance;
+});
+
+describe("AlfredpayLimitsService.refresh", () => {
+  test("indexes only rows with digit-string decimals; junk rows never shadow valid ones", async () => {
+    AlfredpayApiService.getInstance = () =>
+      ({ getAllConfigs: async () => configsResponse }) as unknown as AlfredpayApiService;
+
+    const service = new (AlfredpayLimitsService as unknown as { new (): AlfredpayLimitsService })();
+    await (service as unknown as { refresh(): Promise<void> }).refresh();
+
+    // From the valid wildcard row: 50.00 / 170799.99 scaled by 10^2 — not 10^0.
+    const limits = service.getLimits(FiatToken.MXN, "USDC", AlfredpayCustomerType.INDIVIDUAL, RampDirection.BUY);
+    expect(limits).toEqual({ maxRaw: "17079999", minRaw: "5000" });
+  });
+});

--- a/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
@@ -120,8 +120,10 @@ export class AlfredpayLimitsService {
   private indexPair(target: Map<string, RawAmountLimits>, pair: AlfredpayConfigPair): void {
     // The /allConfigs listing contains junk rows: decimals null/"" and even null
     // currencies. Only digit-string decimals are trustworthy — Number(null) is 0 and
-    // would silently shrink the raw limits by 10^decimals.
-    if (typeof pair.decimals !== "string" || !/^\d+$/.test(pair.decimals)) return;
+    // would silently shrink the raw limits by 10^decimals. Capped at two digits (sane
+    // currency precision): an oversized exponent would make Big(10).pow throw and
+    // abort the whole refresh on one bad row.
+    if (typeof pair.decimals !== "string" || !/^\d{1,2}$/.test(pair.decimals)) return;
     const decimals = Number(pair.decimals);
 
     const axes = this.deriveAxes(pair);

--- a/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-limits.service.ts
@@ -118,8 +118,11 @@ export class AlfredpayLimitsService {
   }
 
   private indexPair(target: Map<string, RawAmountLimits>, pair: AlfredpayConfigPair): void {
+    // The /allConfigs listing contains junk rows: decimals null/"" and even null
+    // currencies. Only digit-string decimals are trustworthy — Number(null) is 0 and
+    // would silently shrink the raw limits by 10^decimals.
+    if (typeof pair.decimals !== "string" || !/^\d+$/.test(pair.decimals)) return;
     const decimals = Number(pair.decimals);
-    if (!Number.isFinite(decimals)) return;
 
     const axes = this.deriveAxes(pair);
     if (!axes) return;
@@ -142,6 +145,7 @@ export class AlfredpayLimitsService {
   }
 
   private deriveAxes(pair: AlfredpayConfigPair): DerivedAxes | null {
+    if (!pair.fromCurrency) return null;
     const fromFiat = ALFREDPAY_FIATS[pair.fromCurrency];
     const toFiat = ALFREDPAY_FIATS[pair.toCurrency];
 

--- a/packages/shared/src/services/alfredpay/alfredpayApiService.ts
+++ b/packages/shared/src/services/alfredpay/alfredpayApiService.ts
@@ -184,9 +184,11 @@ export class AlfredpayApiService {
   /**
    * Fetch all supported trading pairs and their per-pair / per-customer-type quantity limits.
    * Docs: https://alfredpay.readme.io/v2.0/reference/configurationscontroller_getallconfigs-3
+   * Alfredpay renamed the route: the former /configurations path now returns
+   * 400 errorCode 111301 (caught by the nightly contract suite, 2026-07-14).
    */
   public async getAllConfigs(): Promise<GetAllConfigsResponse> {
-    const path = "/api/v1/third-party-service/penny/configurations";
+    const path = "/api/v1/third-party-service/penny/allConfigs";
     return (await this.executeRequest<GetAllConfigsResponse>(path, "GET")) ?? { supportedPairs: [] };
   }
 

--- a/packages/shared/src/services/alfredpay/schemas.test.ts
+++ b/packages/shared/src/services/alfredpay/schemas.test.ts
@@ -47,6 +47,17 @@ describe("alfredpayConfigsResponseSchema", () => {
     expect(() => alfredpayConfigsResponseSchema.parse(body)).not.toThrow();
   });
 
+  test("accepts the junk rows the live listing contains (null/empty decimals, null fromCurrency)", () => {
+    const body = {
+      supportedPairs: [
+        { decimals: null, fromCurrency: "MXN", maxQuantity: "170799.99", minQuantity: "50.00", toCurrency: "USDC", typeCustomer: "INDIVIDUAL" },
+        { decimals: "", fromCurrency: "PEN", maxQuantity: "295349602.00", minQuantity: "1.00", toCurrency: "USDC", typeCustomer: null },
+        { decimals: null, fromCurrency: null, maxQuantity: "295349602.00", minQuantity: "1.00", toCurrency: "USDT", typeCustomer: null }
+      ]
+    };
+    expect(() => alfredpayConfigsResponseSchema.parse(body)).not.toThrow();
+  });
+
   test("rejects a pair with a missing consumed field (minQuantity)", () => {
     const body = {
       supportedPairs: [{ decimals: "2", fromCurrency: "MXN", maxQuantity: "100000", toCurrency: "USDC", typeCustomer: null }]

--- a/packages/shared/src/services/alfredpay/schemas.ts
+++ b/packages/shared/src/services/alfredpay/schemas.ts
@@ -49,22 +49,27 @@ type ConsumedKycStatus = Pick<GetKycStatusResponse, "status"> & {
 };
 
 const DECIMAL_STRING = /^\d+(\.\d+)?$/;
-const DIGITS = /^\d+$/;
+const DIGITS_OR_EMPTY = /^\d*$/;
 const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
 // expiration is consumed via `new Date(...)` — the property that matters is parseability.
 const parseableTimestamp = z.string().refine(value => !Number.isNaN(Date.parse(value)), "not a parseable timestamp");
 
-/** One entry of the GET …/configurations `supportedPairs` array. */
+/**
+ * One entry of the GET …/allConfigs `supportedPairs` array. The listing contains junk
+ * rows (observed live, 2026-07-14): `decimals` may be null or "", `fromCurrency` may be
+ * null. The limits indexer skips rows without a digit-string `decimals`, so the per-row
+ * contract is correspondingly loose.
+ */
 export const alfredpayConfigPairSchema = z.looseObject({
-  decimals: z.string().regex(DIGITS),
-  fromCurrency: z.string().min(1),
+  decimals: z.string().regex(DIGITS_OR_EMPTY).nullable(),
+  fromCurrency: z.string().min(1).nullable(),
   maxQuantity: z.string().regex(DECIMAL_STRING),
   minQuantity: z.string().regex(DECIMAL_STRING),
   toCurrency: z.string().min(1),
   typeCustomer: z.enum(AlfredpayCustomerType).nullable()
 }) satisfies z.ZodType<ConsumedConfigPair>;
 
-/** The body of a GET …/configurations response. */
+/** The body of a GET …/allConfigs response. */
 export const alfredpayConfigsResponseSchema = z.looseObject({
   supportedPairs: z.array(alfredpayConfigPairSchema)
 }) satisfies z.ZodType<{ supportedPairs: ConsumedConfigPair[] }>;

--- a/packages/shared/src/services/alfredpay/types.ts
+++ b/packages/shared/src/services/alfredpay/types.ts
@@ -363,15 +363,20 @@ const ALFREDPAY_FIAT_TOKEN_SET: ReadonlySet<RampCurrency> = new Set([
 
 export const isAlfredpayToken = (token: RampCurrency): token is FiatToken => ALFREDPAY_FIAT_TOKEN_SET.has(token);
 
-/** Raw shape returned by `GET …/configurations`. `typeCustomer: null` means the pair applies to both customer types. */
+/**
+ * Raw shape returned by `GET …/allConfigs`. `typeCustomer: null` means the pair applies
+ * to both customer types. The listing contains junk rows (observed live, 2026-07-14):
+ * `decimals` may be null or "", and `fromCurrency` may be null — consumers must skip
+ * rows without a digit-string `decimals` (the limits indexer does).
+ */
 export interface AlfredpayConfigPair {
   id: string;
-  fromCurrency: string;
+  fromCurrency: string | null;
   toCurrency: string;
   businessId: string | null;
   maxQuantity: string;
   minQuantity: string;
-  decimals: string;
+  decimals: string | null;
   typeCustomer: AlfredpayCustomerType | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

The nightly external-API contract run kept reporting `getAllConfigs` as inconclusive (`400 {"errorCode":111301}`). Investigation showed this is **our bug, with real production impact**, plus a second latent bug the fix would have triggered:

1. **Alfredpay renamed the route.** The old `…/penny/configurations` 400s on both hosts; their docs and the live API serve `…/penny/allConfigs` (200, same `supportedPairs` shape). Since the rename, `AlfredpayLimitsService.refresh()` has failed on every cycle — production has been silently running on the **hardcoded fallback limits** (warn log per refresh, no alert).
2. **The renamed endpoint's payload contains junk rows** — `decimals: null`, `decimals: ""`, even `fromCurrency: null` — including the customer-specific rows for pairs we consume. The indexer's guard was `Number.isFinite(Number(pair.decimals))`, and `Number(null) === 0`, so fixing only the path would have indexed those rows at 0 decimals and **shrunk the enforced raw limits by 10^decimals** (customer-specific rows take precedence over the valid wildcard rows). The failing refresh was accidentally protecting us.

## Changes

- `getAllConfigs` calls `/allConfigs` (comment records the rename and the 400 signature of the old path).
- `indexPair` only trusts rows with digit-string `decimals`; `deriveAxes` skips null `fromCurrency`. Junk rows fall through to the valid wildcard row, or the hardcoded fallback per lookup — unchanged behavior otherwise.
- `AlfredpayConfigPair.decimals` / `.fromCurrency` are nullable per the observed wire; the contract schema accepts the junk rows (with the skip-contract documented on the schema).
- Regression test: a refresh fed the observed junk-row mix must serve limits from the valid wildcard row (`minRaw "5000"`, not the decimals-0 `"50"`).

## Verification

- Live against the Alfredpay sandbox: the configs contract test now validates a real 200 response — 12/12 Alfredpay contract tests pass, no inconclusive skips.
- Full api suite 459 pass / 0 fail; `bun typecheck` and Biome clean.

Found by the external-API contract layer added in #1254 — this is the drift-detector working as designed: a partner-side rename that production only signaled via warn logs became a red nightly with an exact field-level diagnosis.