### PR TITLE
feat(dashboard): disable EU onboarding (KYC and KYB) in the UI

### DIFF
--- a/apps/dashboard/e2e/onboarding-monerium-eu.spec.ts
+++ b/apps/dashboard/e2e/onboarding-monerium-eu.spec.ts
@@ -2,7 +2,13 @@ import { expect, test } from "@playwright/test";
 import { mockBackend } from "./support/mockBackend";
 import { E2E_USER_EMAIL, E2E_USER_ID, SESSION_KEYS, seedSession } from "./support/session";
 
-test("Monerium EU OAuth returns securely and refreshes approval", async ({ page }) => {
+// EU onboarding (KYC and KYB) is temporarily disabled: the corridor card must not offer any
+// actionable button and the wizard must refuse the corridor even via the ?onboarding=EU deep
+// link, so no user can reach the Monerium flow. When EU is re-enabled, restore the OAuth
+// round-trip coverage this file carried before (git history: "Monerium EU OAuth returns
+// securely and refreshes approval").
+
+test("EU onboarding is disabled: card action and wizard deep link are both blocked", async ({ page }) => {
   const backend = await mockBackend(page, { moneriumKyc: true });
   await seedSession(page);
   await page.goto("/overview");
@@ -14,53 +20,19 @@ test("Monerium EU OAuth returns securely and refreshes approval", async ({ page 
   await page.getByRole("option", { name: /Europe/ }).click();
   await addDialog.getByRole("button", { name: "Add card" }).click();
 
-  await page.getByRole("button", { name: "Start KYC" }).click();
+  await expect(page.getByRole("button", { name: "KYC is currently disabled in Europe" })).toBeDisabled();
+
+  await page.goto("/overview?onboarding=EU");
   const wizard = page.getByRole("dialog");
-  await expect(wizard.getByText("Verify with Monerium")).toBeVisible({ timeout: 20_000 });
-  let continueNavigation: () => void;
-  const navigationGate = new Promise<void>(resolve => {
-    continueNavigation = resolve;
-  });
-  await page.route(`${new URL(page.url()).origin}/monerium/callback?**`, async route => {
-    await navigationGate;
-    await route.continue();
-  });
-  const connectingShown = page.evaluate(
-    () =>
-      new Promise<boolean>(resolve => {
-        const observer = new MutationObserver(() => {
-          if (document.body.textContent?.includes("Connecting to Monerium")) {
-            observer.disconnect();
-            resolve(true);
-          }
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-      })
-  );
-  const navigation = wizard.getByRole("button", { name: "Continue to Monerium" }).click();
-  try {
-    await expect(connectingShown).resolves.toBe(true);
-  } finally {
-    continueNavigation();
-  }
-  await navigation;
+  await expect(wizard.getByText("KYC is currently disabled in Europe.")).toBeVisible({ timeout: 20_000 });
+  await wizard.getByRole("button", { exact: true, name: "Close" }).first().click();
 
-  await expect(page).toHaveURL(/\/overview\?onboarding=EU$/, { timeout: 20_000 });
-  await expect(page.getByRole("dialog").getByText("Verification in review")).toBeVisible();
-  await expect(page.getByRole("button", { name: "Continue in background" })).toBeVisible();
-  expect(backend.monerium.startRequests).toEqual([{ customerType: "individual" }]);
-
-  await page.getByRole("button", { name: "Continue in background" }).click();
-  await expect.poll(() => new URL(page.url()).search).toBe("");
-  await expect(page.getByRole("button", { name: "Awaiting provider review" })).toBeVisible({ timeout: 20_000 });
-
-  backend.monerium.approved = true;
-  await expect(page.getByRole("button", { name: "Verification complete" })).toBeVisible({ timeout: 25_000 });
+  expect(backend.monerium.startRequests).toEqual([]);
   expect(backend.unmatchedRequests).toEqual([]);
   expect(backend.unexpectedExternalRequests).toEqual([]);
 });
 
-test("Monerium callback refreshes an expired dashboard session before exchange", async ({ page }) => {
+test("Monerium callback refreshes an expired dashboard session, then lands on the disabled notice", async ({ page }) => {
   const backend = await mockBackend(page, { moneriumKyc: true, moneriumRequireRefresh: true });
   await page.addInitScript(
     ({ email, keys, userId }) => {
@@ -75,22 +47,17 @@ test("Monerium callback refreshes an expired dashboard session before exchange",
   await page.goto("/monerium/callback?code=e2e-code&state=e2e-state");
 
   await expect(page).toHaveURL(/\/overview\?onboarding=EU$/, { timeout: 20_000 });
-  await expect(page.getByRole("dialog").getByText("Verification in review")).toBeVisible();
+  await expect(page.getByRole("dialog").getByText("KYC is currently disabled in Europe.")).toBeVisible();
   expect(backend.auth.refreshes).toBe(1);
 });
 
-test("in-review Monerium onboarding offers reauthentication when the status response requires it", async ({ page }) => {
+test("in-review Monerium onboarding requiring reauthentication is disabled instead of actionable", async ({ page }) => {
   const backend = await mockBackend(page, { moneriumKyc: true });
   backend.monerium.completed = true;
   await seedSession(page);
   await page.goto("/overview");
 
-  const reauthenticateButton = page.getByRole("button", { name: "Re-authenticate with Monerium" });
-  await expect(reauthenticateButton).toBeVisible({ timeout: 20_000 });
-  await reauthenticateButton.click();
-
-  const wizard = page.getByRole("dialog");
-  await expect(wizard.getByText("Verify with Monerium")).toBeVisible();
-  await expect(wizard.getByRole("button", { name: "Continue to Monerium" })).toBeVisible();
+  const disabledButton = page.getByRole("button", { name: "KYC is currently disabled in Europe" });
+  await expect(disabledButton).toBeDisabled({ timeout: 20_000 });
   expect(backend.unmatchedRequests).toEqual([]);
 });

--- a/apps/dashboard/src/components/onboarding/CorridorCard.tsx
+++ b/apps/dashboard/src/components/onboarding/CorridorCard.tsx
@@ -2,7 +2,13 @@ import { ArrowRight, ExternalLink, FileText, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { isOnboardingAvailable, onboardingKindFor, PROVIDER_LABEL, routeFor } from "@/domain/corridors";
+import {
+  isCorridorOnboardingDisabled,
+  isOnboardingAvailable,
+  onboardingKindFor,
+  PROVIDER_LABEL,
+  routeFor
+} from "@/domain/corridors";
 import { STATUS_META } from "@/domain/status";
 import type { Corridor, OnboardingRoute, OnboardingStatus, SenderAccount } from "@/domain/types";
 import { StatusBadge } from "./StatusBadge";
@@ -33,6 +39,16 @@ export function CorridorCard({ account, corridor, onStart }: CorridorCardProps) 
   const kind = onboardingKindFor(corridor, account.type);
   const available = isOnboardingAvailable(corridor, kind);
   const onboarding = account.onboardings[corridor.id];
+  // Suppress every actionable state (start, continue, retry, re-authenticate) while the
+  // corridor is disabled; purely informational buttons (awaiting review, complete) stay.
+  const actionable =
+    !onboarding ||
+    onboarding.status === "not_started" ||
+    onboarding.status === "pending" ||
+    onboarding.status === "started" ||
+    onboarding.status === "rejected" ||
+    (onboarding.status === "in_review" && onboarding.reauthenticationRequired === true);
+  const disabled = isCorridorOnboardingDisabled(corridor) && actionable;
   const meta = onboarding ? STATUS_META[onboarding.status] : null;
   const hint = ROUTE_HINT[routeFor(corridor.id, kind)];
 
@@ -76,7 +92,11 @@ export function CorridorCard({ account, corridor, onStart }: CorridorCardProps) 
       </CardContent>
 
       <CardFooter>
-        {!available && (!onboarding || onboarding.status === "not_started" || onboarding.status === "rejected") ? (
+        {disabled ? (
+          <Button className="w-full" disabled variant="outline">
+            {kind.toUpperCase()} is currently disabled in {corridor.name}
+          </Button>
+        ) : !available && (!onboarding || onboarding.status === "not_started" || onboarding.status === "rejected") ? (
           <Button className="w-full" disabled variant="outline">
             {kind.toUpperCase()} not yet available
           </Button>

--- a/apps/dashboard/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/dashboard/src/components/onboarding/OnboardingWizard.tsx
@@ -2,7 +2,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { isCorridorAvailableForAccountType, onboardingKindFor, PROVIDER_LABEL, routeFor } from "@/domain/corridors";
+import {
+  isCorridorAvailableForAccountType,
+  isCorridorOnboardingDisabled,
+  onboardingKindFor,
+  PROVIDER_LABEL,
+  routeFor
+} from "@/domain/corridors";
 import type { Corridor, OnboardingKind, OnboardingStatus, SenderAccount } from "@/domain/types";
 import { ONBOARDING_STATUS_QUERY_KEY } from "@/hooks/useApprovedCorridors";
 import { notifyOnboardingStatus } from "@/lib/notify";
@@ -62,7 +68,9 @@ export function OnboardingWizard({ account, corridor, onClose }: OnboardingWizar
           </DialogDescription>
         </DialogHeader>
 
-        {isRealAlfredpayKyc ? (
+        {isCorridorOnboardingDisabled(corridor) ? (
+          <UnavailableNotice corridor={corridor} kind={kind} onClose={onClose} />
+        ) : isRealAlfredpayKyc ? (
           <AlfredpayKycFlow
             business={kind === "kyb"}
             corridor={corridor}
@@ -99,8 +107,9 @@ function UnavailableNotice({ corridor, kind, onClose }: { corridor: Corridor; ki
     <>
       <div className="flex min-h-[120px] items-center justify-center py-6 text-center">
         <p className="max-w-sm text-muted-foreground text-sm">
-          {corridor.name} {kind.toUpperCase()} verification is not available yet. Please contact support if you need this
-          corridor.
+          {isCorridorOnboardingDisabled(corridor)
+            ? `${kind.toUpperCase()} is currently disabled in ${corridor.name}. Please contact support if you need this corridor.`
+            : `${corridor.name} ${kind.toUpperCase()} verification is not available yet. Please contact support if you need this corridor.`}
         </p>
       </div>
       <DialogFooter>

--- a/apps/dashboard/src/domain/corridors.test.ts
+++ b/apps/dashboard/src/domain/corridors.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { isCorridorAvailableForAccountType } from "./corridors";
+import { CORRIDORS, isCorridorAvailableForAccountType, isCorridorOnboardingDisabled } from "./corridors";
 
 describe("isCorridorAvailableForAccountType", () => {
   it("disallows Argentina for company accounts", () => {
@@ -12,5 +12,14 @@ describe("isCorridorAvailableForAccountType", () => {
     assert.equal(isCorridorAvailableForAccountType("MX", "company"), true);
     assert.equal(isCorridorAvailableForAccountType("CO", "company"), true);
     assert.equal(isCorridorAvailableForAccountType("US", "company"), true);
+  });
+});
+
+describe("isCorridorOnboardingDisabled", () => {
+  it("disables EU onboarding only, leaving every other corridor untouched", () => {
+    assert.equal(isCorridorOnboardingDisabled(CORRIDORS.EU), true);
+    for (const corridor of [CORRIDORS.AR, CORRIDORS.BR, CORRIDORS.CO, CORRIDORS.MX, CORRIDORS.US]) {
+      assert.equal(isCorridorOnboardingDisabled(corridor), false);
+    }
   });
 });

--- a/apps/dashboard/src/domain/corridors.ts
+++ b/apps/dashboard/src/domain/corridors.ts
@@ -106,3 +106,13 @@ export function isOnboardingAvailable(corridor: Corridor, kind: OnboardingKind):
   }
   return isCorridorAvailableForAccountType(corridor.id, kind === "kyb" ? "company" : "individual");
 }
+
+/**
+ * EU onboarding (KYC and KYB) is temporarily switched off: the corridor card replaces every
+ * actionable button (start, continue, retry, re-authenticate) with a disabled, explanatory
+ * one, and the wizard refuses the corridor even when opened via the `?onboarding=EU` deep
+ * link so mid-flow users cannot reach the Monerium flow either.
+ */
+export function isCorridorOnboardingDisabled(corridor: Corridor): boolean {
+  return corridor.id === "EU";
+}


### PR DESCRIPTION
## Summary

EU onboarding via Monerium is temporarily switched off in the dashboard. Only the EU corridor is affected — all other corridors (BR, MX, CO, US, AR) behave exactly as before.

- **Corridor card**: every actionable button for EU — "Start", "Continue", "Retry", and "Re-authenticate with Monerium" — is replaced by a disabled button reading "KYC is currently disabled in Europe" ("KYB …" for company accounts). Purely informational states ("Awaiting provider review", "Verification complete") are unchanged.
- **Onboarding wizard**: the `?onboarding=EU` deep link (including the landing after the Monerium OAuth callback) no longer reaches the Monerium flow; it shows a "currently disabled" notice instead, so mid-flow users cannot access disabled content.
- Introduced `isCorridorOnboardingDisabled(corridor)` in `domain/corridors.ts` as the single switch — re-enabling EU later is a one-line revert of that function.

## Not covered (intentionally)

- The Monerium callback route still completes the OAuth token exchange server-side before landing on the disabled notice; blocking the API endpoints themselves would be a backend change.
- Already-approved EU users still see "Verification complete" and can transfer.

## Testing

- Unit tests for the new domain helper (EU disabled, all other corridors untouched).
- `e2e/onboarding-monerium-eu.spec.ts` rewritten to assert the disabled behavior: card buttons disabled, deep link blocked with zero Monerium start requests, callback session refresh still working, in-review/re-auth state disabled. The original OAuth round-trip test can be restored from git history when EU is re-enabled (noted in the spec header).
- Full dashboard e2e suite passes (22 passed, 2 pre-existing skips); `tsc --noEmit`, Biome, and unit tests clean.