### PR TITLE
Use Alchemy for Polygon Amoy RPC

### DIFF
--- a/packages/shared/src/helpers/signUnsigned.test.ts
+++ b/packages/shared/src/helpers/signUnsigned.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import type { WalletClient } from "viem";
+import { polygonAmoy } from "viem/chains";
+
+// Importing ./signUnsigned pulls in the package barrel, which freezes src/constants.ts from
+// process.env for the whole test run. Provide the env defaults other test files rely on before
+// that happens (same pattern as alfredpayApiService.test.ts), hence the dynamic import.
+process.env.ALFREDPAY_API_KEY ||= "test-key";
+process.env.ALFREDPAY_API_SECRET ||= "test-secret";
+
+const { Networks } = await import("./networks");
+const { createEvmClient } = await import("./signUnsigned");
+
+const EPHEMERAL = {
+  address: "0x0000000000000000000000000000000000000000",
+  secret: "0x0000000000000000000000000000000000000000000000000000000000000001"
+};
+
+function transportUrls(client: WalletClient): (string | undefined)[] {
+  const transport = client.transport as unknown as { transports: { value?: { url?: string } }[] };
+  return transport.transports.map(t => t.value?.url);
+}
+
+describe("createEvmClient Polygon Amoy transports", () => {
+  it("prefers Alchemy for signing and keeps viem's default transport as the fallback", () => {
+    const client = createEvmClient(Networks.PolygonAmoy, EPHEMERAL, "test-api-key");
+
+    expect(transportUrls(client)).toEqual([
+      "https://polygon-amoy.g.alchemy.com/v2/test-api-key",
+      polygonAmoy.rpcUrls.default.http[0]
+    ]);
+  });
+
+  it("uses only viem's default transport without an Alchemy API key", () => {
+    const client = createEvmClient(Networks.PolygonAmoy, EPHEMERAL);
+
+    expect(transportUrls(client)).toEqual([polygonAmoy.rpcUrls.default.http[0]]);
+  });
+});

--- a/packages/shared/src/helpers/signUnsigned.ts
+++ b/packages/shared/src/helpers/signUnsigned.ts
@@ -77,7 +77,7 @@ async function signMultipleSubstrateTransactions(
  * @param apiKey - Optional Alchemy API key
  * @returns WalletClient for the specified network
  */
-function createEvmClient(
+export function createEvmClient(
   network: string, // Accept string to match UnsignedTx.network type usually being string/enum
   evmEphemeral: EphemeralAccount,
   apiKey?: string

--- a/packages/shared/src/helpers/signUnsigned.ts
+++ b/packages/shared/src/helpers/signUnsigned.ts
@@ -95,7 +95,7 @@ function createEvmClient(
       break;
     case Networks.PolygonAmoy:
       chain = polygonAmoy;
-      rpcUrls = ["https://polygon-amoy.api.onfinality.io/public"];
+      rpcUrls = apiKey ? [`https://polygon-amoy.g.alchemy.com/v2/${apiKey}`] : [];
       break;
     case Networks.Moonbeam:
       chain = moonbeam;

--- a/packages/shared/src/services/evm/clientManager.test.ts
+++ b/packages/shared/src/services/evm/clientManager.test.ts
@@ -1,12 +1,15 @@
 import {describe, expect, it, mock} from "bun:test";
 import {Networks} from "../../helpers";
 import logger from "../../logger";
-import {EvmClientManager, redactRpcUrlForLogs, sanitizeRpcErrorMessage} from "./clientManager";
+import {EvmClientManager, getEvmNetworks, redactRpcUrlForLogs, sanitizeRpcErrorMessage} from "./clientManager";
 
 describe("redactRpcUrlForLogs", () => {
   it("redacts provider API keys from RPC URLs", () => {
     expect(redactRpcUrlForLogs("https://polygon-mainnet.g.alchemy.com/v2/test-api-key")).toBe(
       "https://polygon-mainnet.g.alchemy.com/v2/[redacted]"
+    );
+    expect(redactRpcUrlForLogs("https://polygon-amoy.g.alchemy.com/v2/test-api-key")).toBe(
+      "https://polygon-amoy.g.alchemy.com/v2/[redacted]"
     );
   });
 
@@ -21,11 +24,25 @@ describe("redactRpcUrlForLogs", () => {
   });
 });
 
+describe("EvmClientManager RPC configuration", () => {
+  it("prefers Alchemy for Polygon Amoy and keeps viem's default transport as the fallback", () => {
+    const polygonAmoyConfig = getEvmNetworks("test-api-key").find(network => network.name === Networks.PolygonAmoy);
+
+    expect(polygonAmoyConfig?.rpcUrls).toEqual(["https://polygon-amoy.g.alchemy.com/v2/test-api-key", ""]);
+  });
+
+  it("uses only viem's default Polygon Amoy transport without an Alchemy API key", () => {
+    const polygonAmoyConfig = getEvmNetworks().find(network => network.name === Networks.PolygonAmoy);
+
+    expect(polygonAmoyConfig?.rpcUrls).toEqual([""]);
+  });
+});
+
 describe("EvmClientManager RPC cache keys", () => {
   it("keeps viem's default transport distinct from explicit RPC URLs", () => {
     const manager = EvmClientManager.getInstance();
-    const explicitRpcClient = manager.getClient(Networks.PolygonAmoy, "https://polygon-amoy.api.onfinality.io/public");
-    const defaultRpcClient = manager.getClient(Networks.PolygonAmoy, "");
+    const explicitRpcClient = manager.getClient(Networks.Moonbeam, "https://rpc.api.moonbeam.network");
+    const defaultRpcClient = manager.getClient(Networks.Moonbeam, "");
 
     expect(defaultRpcClient).not.toBe(explicitRpcClient);
   });

--- a/packages/shared/src/services/evm/clientManager.ts
+++ b/packages/shared/src/services/evm/clientManager.ts
@@ -58,7 +58,7 @@ function isNonRetryableReadContractError(error: Error): boolean {
   return NON_RETRYABLE_READ_CONTRACT_ERROR_PATTERNS.some(pattern => pattern.test(error.message));
 }
 
-function getEvmNetworks(apiKey?: string): EvmNetworkConfig[] {
+export function getEvmNetworks(apiKey?: string): EvmNetworkConfig[] {
   // Note on defining RPC URLs: '' is equal to viem's default RPC for that chain: http().
   return [
     {
@@ -69,7 +69,7 @@ function getEvmNetworks(apiKey?: string): EvmNetworkConfig[] {
     {
       chain: polygonAmoy,
       name: Networks.PolygonAmoy,
-      rpcUrls: ["https://polygon-amoy.api.onfinality.io/public", ""]
+      rpcUrls: apiKey ? [`https://polygon-amoy.g.alchemy.com/v2/${apiKey}`, ""] : [""]
     },
     {
       chain: moonbeam,


### PR DESCRIPTION
## Summary
- Route Polygon Amoy RPC calls through Alchemy when `ALCHEMY_API_KEY` is configured, replacing the rate-limited public OnFinality endpoint, with viem's default transport as the fallback — in both `EvmClientManager` and the `signUnsignedTransactions` helper.
- This stops backend ephemeral freshness checks from hitting the OnFinality rate limit during `registerRamp`.

Replaces #1301, recreated on current staging: that branch is based ~960 commits behind and would revert the recent "treat execution reverts as non-retryable" fix (5ca4d3e7e) and re-touch transaction grouping that staging has since changed. This PR contains only the RPC routing change.

## Changes
- `clientManager.ts`: Polygon Amoy now uses `apiKey ? [Alchemy, ""] : [""]`, the same pattern as every other Alchemy-backed network. `getEvmNetworks` is exported for deterministic tests (same precedent as the redaction helpers).
- `signUnsigned.ts`: the Polygon Amoy case in `createEvmClient` follows the identical `apiKey ? [...] : []` pattern of its six sibling networks; the viem default transport was already appended unconditionally.
- Tests assert the exact ordered RPC list with and without an API key (the regression coverage review flagged as missing on #1301), plus redaction coverage for the new Amoy Alchemy URL. The cache-key test moved to Moonbeam since it referenced the removed OnFinality URL.

## Test
- `bun test` in `packages/shared` (89 pass)
- `bun lint`, `tsc --noEmit`, `bun build:shared`