### PR TITLE
Sign destination-phase EVM transactions exactly once

### DIFF
--- a/packages/shared/src/helpers/signUnsigned.test.ts
+++ b/packages/shared/src/helpers/signUnsigned.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import type { UnsignedTx } from "../endpoints/ramp.endpoints";
+import type { Networks } from "./networks";
+
+// Importing ./signUnsigned pulls in the package barrel, which freezes src/constants.ts from
+// process.env for the whole test run. Provide the env defaults other test files rely on before
+// that happens (same pattern as alfredpayApiService.test.ts), hence the dynamic import.
+process.env.ALFREDPAY_API_KEY ||= "test-key";
+process.env.ALFREDPAY_API_SECRET ||= "test-secret";
+
+const { Networks: NetworksEnum } = await import("./networks");
+const { groupUnsignedTxsForSigning } = await import("./signUnsigned");
+
+function makeTx(network: Networks, phase: UnsignedTx["phase"]): UnsignedTx {
+  return {
+    meta: {},
+    network,
+    nonce: 0,
+    phase,
+    signer: "0x0000000000000000000000000000000000000000",
+    txData: {
+      data: "0x",
+      gas: "21000",
+      maxFeePerGas: "1",
+      maxPriorityFeePerGas: "1",
+      to: "0x0000000000000000000000000000000000000000",
+      value: "0"
+    }
+  };
+}
+
+describe("groupUnsignedTxsForSigning", () => {
+  it("assigns destination-phase transactions on directly signed EVM networks to the EVM group only", () => {
+    const tx = makeTx(NetworksEnum.Arbitrum, "destinationTransfer");
+
+    const groups = groupUnsignedTxsForSigning([tx]);
+
+    expect(groups.evmTxs).toEqual([tx]);
+    expect(groups.destinationNetworkTxs).toEqual([]);
+  });
+
+  it("keeps destination-phase transactions on other networks in the destination group", () => {
+    const tx = makeTx(NetworksEnum.BaseSepolia, "destinationTransfer");
+
+    const groups = groupUnsignedTxsForSigning([tx]);
+
+    expect(groups.destinationNetworkTxs).toEqual([tx]);
+    expect(groups.evmTxs).toEqual([]);
+  });
+
+  it("never assigns a transaction to both the EVM and destination groups", () => {
+    const destinationPhases: UnsignedTx["phase"][] = [
+      "destinationTransfer",
+      "backupSquidRouterApprove",
+      "backupSquidRouterSwap",
+      "backupApprove"
+    ];
+    const txs = Object.values(NetworksEnum).flatMap(network => destinationPhases.map(phase => makeTx(network, phase)));
+
+    const groups = groupUnsignedTxsForSigning(txs);
+
+    for (const tx of txs) {
+      expect(groups.evmTxs.includes(tx) && groups.destinationNetworkTxs.includes(tx)).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/helpers/signUnsigned.ts
+++ b/packages/shared/src/helpers/signUnsigned.ts
@@ -18,6 +18,47 @@ import {
 } from "../index";
 import logger from "../logger";
 
+// Networks whose transactions are signed directly with the EVM ephemeral, regardless of phase.
+const EVM_EPHEMERAL_SIGNING_NETWORKS: Networks[] = [
+  Networks.Polygon,
+  Networks.PolygonAmoy,
+  Networks.Base,
+  Networks.Arbitrum,
+  Networks.Avalanche,
+  Networks.BSC,
+  Networks.Ethereum
+];
+
+const DESTINATION_NETWORK_PHASES = [
+  "destinationTransfer",
+  "backupSquidRouterApprove",
+  "backupSquidRouterSwap",
+  "backupApprove"
+];
+
+/**
+ * Groups transactions by the signing flow that handles them. The destination group must
+ * exclude every network the EVM group selects, or the same transaction would be signed
+ * (and returned) twice.
+ */
+export function groupUnsignedTxsForSigning(unsignedTxs: UnsignedTx[]): {
+  destinationNetworkTxs: UnsignedTx[];
+  evmTxs: UnsignedTx[];
+  hydrationTxs: UnsignedTx[];
+  moonbeamTxs: UnsignedTx[];
+  pendulumTxs: UnsignedTx[];
+} {
+  return {
+    destinationNetworkTxs: unsignedTxs.filter(
+      tx => DESTINATION_NETWORK_PHASES.includes(tx.phase) && !EVM_EPHEMERAL_SIGNING_NETWORKS.includes(tx.network)
+    ),
+    evmTxs: unsignedTxs.filter(tx => EVM_EPHEMERAL_SIGNING_NETWORKS.includes(tx.network)),
+    hydrationTxs: unsignedTxs.filter(tx => tx.network === Networks.Hydration),
+    moonbeamTxs: unsignedTxs.filter(tx => tx.network === Networks.Moonbeam),
+    pendulumTxs: unsignedTxs.filter(tx => tx.network === Networks.Pendulum)
+  };
+}
+
 export function addAdditionalTransactionsToMeta(primaryTx: PresignedTx, multiSignedTxs: PresignedTx[]): PresignedTx {
   if (multiSignedTxs.length <= 1) {
     return primaryTx;
@@ -206,32 +247,9 @@ export async function signUnsignedTransactions(
   const signedTxs: PresignedTx[] = [];
 
   // Group transactions
-  const moonbeamTxs = unsignedTxs.filter(tx => tx.network === Networks.Moonbeam);
-  const evmTxs = unsignedTxs.filter(
-    tx =>
-      tx.network === Networks.Polygon ||
-      tx.network === Networks.PolygonAmoy ||
-      tx.network === Networks.Base ||
-      tx.network === Networks.Arbitrum ||
-      tx.network === Networks.Avalanche ||
-      tx.network === Networks.BSC ||
-      tx.network === Networks.Ethereum
-  );
-  const hydrationTxs = unsignedTxs.filter(tx => tx.network === Networks.Hydration);
-  const destinationNetworkTxs = unsignedTxs.filter(
-    tx =>
-      (tx.phase === "destinationTransfer" ||
-        tx.phase === "backupSquidRouterApprove" ||
-        tx.phase === "backupSquidRouterSwap" ||
-        tx.phase === "backupApprove") &&
-      tx.network !== Networks.Polygon &&
-      tx.network !== Networks.PolygonAmoy &&
-      tx.network !== Networks.Base
-  );
+  const { destinationNetworkTxs, evmTxs, hydrationTxs, moonbeamTxs, pendulumTxs } = groupUnsignedTxsForSigning(unsignedTxs);
 
   try {
-    const pendulumTxs = unsignedTxs.filter(tx => tx.network === "pendulum");
-
     for (const tx of hydrationTxs) {
       if (!ephemerals.substrateEphemeral) {
         throw new Error("Missing Substrate ephemeral account");
@@ -330,10 +348,6 @@ export async function signUnsignedTransactions(
       if (!ephemerals.evmEphemeral) {
         throw new Error("Missing EVM ephemeral account");
       }
-
-      // Check if already signed to avoid duplication
-      const alreadySigned = signedTxs.some(st => st === tx || (st.txData === tx.txData && st.nonce === tx.nonce));
-      if (alreadySigned) continue;
 
       const client = createEvmClient(tx.network, ephemerals.evmEphemeral, alchemyApiKey);
       const multiSignedTxs = await signMultipleEvmTransactions(tx, client, tx.nonce);


### PR DESCRIPTION
> [!NOTE]
> This branch now includes #1302 (both PRs add `signUnsigned.test.ts`, so they are stacked to avoid an add/add conflict). Merge #1302 first — this diff then collapses to just the grouping change.

## Summary
Since 5515a7a17 ("adjust morpho flow from non-base networks") expanded the direct EVM signing group to Arbitrum, Avalanche, BSC, and Ethereum, destination-phase transactions (`destinationTransfer`, `backupSquidRouterApprove`, `backupSquidRouterSwap`, `backupApprove`) on those networks matched **both** signing groups in `signUnsignedTransactions` and were signed and returned twice. The `alreadySigned` guard could never catch this: it compares the unsigned `txData` object against the already-replaced signed hex string, so it never matches anything.

Impact: duplicate identical presigned entries in ramp state for onramps to those networks (API validation tolerates them — subset matching, no exact counts), violating the one-signature-per-transaction model. No fund-loss path identified.

## Changes
- The seven directly-signed EVM networks live in one list; grouping moved to an exported pure `groupUnsignedTxsForSigning`, whose destination group excludes exactly that list — the groups are disjoint by construction and can't drift apart again.
- Removed the dead `alreadySigned` guard.
- Regression tests: an Arbitrum `destinationTransfer` lands only in the EVM group; non-listed networks stay in the destination group; a property test sweeps every network × destination phase asserting no tx lands in both groups. Verified 2/3 fail against the old filter. Tested via the pure grouping function because viem's `signTransaction` always fetches `eth_chainId`, so the real signing path would hit live RPCs.

Known pre-existing quirk, deliberately untouched: a destination-phase tx on Moonbeam would still match both the Moonbeam group and the destination group — that overlap predates 5515a7a17; whether Moonbeam can be a ramp destination for these phases needs a product-level answer before changing it.

Spec check: `docs/security-spec/03-ramp-engine/transaction-validation.md` documents presigned verification, not client-side grouping; this restores documented behavior, so no spec change.

## Test
- `bun test` in `packages/shared` (89 pass)
- `bun lint`, `tsc --noEmit`, `bun build:shared`
