### PR TITLE
fix(api): route sell quotes to settlement chains

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,6 +65,15 @@ jobs:
           path: apps/dashboard/playwright-report/
           retention-days: 7
 
+      # Browser journeys mock the API and cannot detect deployment or upstream routing failures.
+      # Probe both live environments through a cross-chain corridor so BUY and SELL exercise Squid.
+      - name: 🩺 Live BUY/SELL quote smoke tests
+        if: always()
+        working-directory: apps/api
+        env:
+          VORTEX_QUOTE_SMOKE_URLS: https://api-staging.vortexfinance.co,https://api.vortexfinance.co
+        run: bun test src/tests/deployed-quotes.e2e.test.ts
+
       # Non-blocking runs are only useful if somebody hears about failures.
       # Uses the same webhook token the backend's Slack notifier uses
       # (repo secret SLACK_WEB_HOOK_TOKEN); skips silently when unset.

--- a/apps/api/src/api/services/phases/blocks/__tests__/onramp-discount.test.ts
+++ b/apps/api/src/api/services/phases/blocks/__tests__/onramp-discount.test.ts
@@ -17,7 +17,6 @@ const bridgeQuoteRequests: Array<{
   fromNetwork: Networks;
   inputCurrency: EvmToken;
   outputCurrency: EvmToken;
-  rampType: RampDirection;
   toNetwork: Networks;
 }> = [];
 
@@ -147,7 +146,6 @@ describe("onramp discount semantics", () => {
         fromNetwork: Networks.Base,
         inputCurrency: EvmToken.USDC,
         outputCurrency: EvmToken.USDC,
-        rampType: RampDirection.BUY,
         toNetwork: Networks.Arbitrum
       }
     ]);

--- a/apps/api/src/api/services/phases/blocks/__tests__/squidrouter-quote-route.test.ts
+++ b/apps/api/src/api/services/phases/blocks/__tests__/squidrouter-quote-route.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import {
+  EvmToken,
+  evmTokenConfig,
+  getNetworkId,
+  Networks,
+} from "@vortexfi/shared";
+import {
+  prepareSquidrouterRouteParams,
+  type SquidrouterQuoteRouteParams,
+} from "../core/squidrouter-route";
+
+const SELL_ROUTE_CASES: Array<{
+  label: string;
+  params: SquidrouterQuoteRouteParams;
+}> = [
+  {
+    label: "Base settlement used by BRL and EUR offramps",
+    params: {
+      amountRaw: "100000000",
+      fromNetwork: Networks.Base,
+      fromToken:
+        evmTokenConfig[Networks.Base][EvmToken.EURC]!.erc20AddressSourceChain,
+      toToken:
+        evmTokenConfig[Networks.Base][EvmToken.USDC]!.erc20AddressSourceChain,
+      toNetwork: Networks.Base,
+    },
+  },
+  {
+    label: "Polygon settlement used by Alfredpay offramps",
+    params: {
+      amountRaw: "100000000",
+      fromNetwork: Networks.Base,
+      fromToken:
+        evmTokenConfig[Networks.Base][EvmToken.USDC]!.erc20AddressSourceChain,
+      toToken:
+        evmTokenConfig[Networks.Polygon][EvmToken.USDT]!
+          .erc20AddressSourceChain,
+      toNetwork: Networks.Polygon,
+    },
+  },
+];
+
+describe("SquidRouter SELL quote routes", () => {
+  it.each(SELL_ROUTE_CASES)("routes to the requested $label", ({ params }) => {
+    const route = prepareSquidrouterRouteParams(params);
+
+    expect(route.fromChain).toBe(getNetworkId(params.fromNetwork).toString());
+    expect(route.fromToken.toLowerCase()).toBe(params.fromToken.toLowerCase());
+    expect(route.toChain).toBe(getNetworkId(params.toNetwork).toString());
+    expect(route.toToken.toLowerCase()).toBe(params.toToken.toLowerCase());
+    expect(route.toChain).not.toBe(getNetworkId(Networks.Moonbeam).toString());
+    expect(route.postHook).toBeUndefined();
+  });
+});

--- a/apps/api/src/api/services/phases/blocks/core/squidrouter-route.ts
+++ b/apps/api/src/api/services/phases/blocks/core/squidrouter-route.ts
@@ -1,0 +1,29 @@
+import { createGenericRouteParams, type Networks, type RouteParams } from "@vortexfi/shared";
+import { generatePrivateKey, privateKeyToAddress } from "viem/accounts";
+
+export interface SquidrouterQuoteRouteParams {
+  amountRaw: string;
+  fromToken: `0x${string}`;
+  toToken: `0x${string}`;
+  fromNetwork: Networks;
+  toNetwork: Networks;
+}
+
+/** Build a non-executable route request for quote simulation. */
+export function prepareSquidrouterRouteParams(params: SquidrouterQuoteRouteParams): RouteParams {
+  const { amountRaw, fromToken, toToken, fromNetwork, toNetwork } = params;
+  const placeholderAddress = privateKeyToAddress(generatePrivateKey());
+
+  // Quote the same destination that transaction preparation will execute.
+  // Ramp direction does not determine bridge topology: current EVM offramps
+  // settle on Base or Polygon rather than routing through legacy Moonbeam hooks.
+  return createGenericRouteParams({
+    amount: amountRaw,
+    destinationAddress: placeholderAddress,
+    fromAddress: placeholderAddress,
+    fromNetwork,
+    fromToken,
+    toNetwork,
+    toToken
+  });
+}

--- a/apps/api/src/api/services/phases/blocks/core/squidrouter.ts
+++ b/apps/api/src/api/services/phases/blocks/core/squidrouter.ts
@@ -10,7 +10,6 @@ import {
   OnChainToken,
   parseContractBalanceResponse,
   QuoteError,
-  RampDirection,
   RouteParams,
   SquidrouterCachedRoute,
   SquidrouterCachedRouteResult,
@@ -34,11 +33,9 @@ export interface EvmBridgeRequest {
   fromNetwork: Networks;
   toNetwork: Networks;
   originalInputAmountForRateCalc: string; // The inputAmountForSwap that went into Nabla, for final rate calculation
-  rampType: RampDirection; // Whether this is an onramp or offramp
 }
 
 export interface EvmBridgeQuoteRequest {
-  rampType: RampDirection; // Whether this is an onramp or offramp
   amountDecimal: string; // Raw amount
   inputCurrency: OnChainToken;
   outputCurrency: OnChainToken;

--- a/apps/api/src/api/services/phases/blocks/core/squidrouter.ts
+++ b/apps/api/src/api/services/phases/blocks/core/squidrouter.ts
@@ -1,6 +1,4 @@
 import {
-  createGenericRouteParams,
-  createRouteParamsWithMoonbeamPostHook,
   DestinationType,
   EvmToken,
   EvmTokenDetails,
@@ -22,12 +20,12 @@ import {
 } from "@vortexfi/shared";
 import { Big } from "big.js";
 import httpStatus from "http-status";
-import { generatePrivateKey, privateKeyToAddress } from "viem/accounts";
 import logger from "../../../../../config/logger";
 import { APIError } from "../../../../errors/api-error";
 import { multiplyByPowerOfTen } from "../../../pendulum/helpers";
 import { priceFeedService } from "../../../priceFeed.service";
 import { createLowLiquidityQuoteError, isLowLiquidityQuoteError } from "../../../quote/core/errors";
+import { prepareSquidrouterRouteParams } from "./squidrouter-route";
 
 export interface EvmBridgeRequest {
   amountRaw: string; // Raw amount to bridge/swap via Squidrouter
@@ -89,42 +87,6 @@ export function getTokenDetailsForEvmDestination(
  */
 export function getBridgeTargetTokenDetails(outputCurrency: OnChainToken, toNetwork: Networks): EvmTokenDetails {
   return getTokenDetailsForEvmDestination(outputCurrency, toNetwork);
-}
-
-/**
- * Helper to prepare route parameters for Squidrouter
- */
-function prepareSquidrouterRouteParams(params: {
-  rampType: RampDirection;
-  amountRaw: string;
-  fromToken: `0x${string}`;
-  toToken: `0x${string}`;
-  fromNetwork: Networks;
-  toNetwork: Networks;
-}): RouteParams {
-  const { rampType, amountRaw, fromToken, toToken, fromNetwork, toNetwork } = params;
-
-  const placeholderAddress = privateKeyToAddress(generatePrivateKey());
-  const placeholderHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
-  return rampType === RampDirection.BUY
-    ? createGenericRouteParams({
-        amount: amountRaw,
-        destinationAddress: placeholderAddress,
-        fromAddress: placeholderAddress,
-        fromNetwork,
-        fromToken,
-        toNetwork,
-        toToken
-      })
-    : createRouteParamsWithMoonbeamPostHook({
-        amount: amountRaw,
-        fromAddress: placeholderAddress,
-        fromNetwork,
-        fromToken,
-        receivingContractAddress: placeholderAddress,
-        squidRouterReceiverHash: placeholderHash
-      });
 }
 
 // Squid swap gas is paid in the source chain's native token. The CoinGecko ID
@@ -202,7 +164,6 @@ function buildRouteRequest(request: EvmBridgeQuoteRequest) {
     amountRaw,
     fromNetwork: request.fromNetwork,
     fromToken: inputTokenDetails.erc20AddressSourceChain,
-    rampType: request.rampType,
     toNetwork: request.toNetwork,
     toToken: outputTokenDetails.erc20AddressSourceChain
   });
@@ -249,7 +210,7 @@ async function getSquidrouterRouteData(routeParams: RouteParams, fromNetwork: Ne
  * Handles EVM bridging/swapping via Squidrouter and calculates its specific network fee
  */
 export async function calculateEvmBridgeAndNetworkFee(request: EvmBridgeRequest): Promise<EvmBridgeResult> {
-  const { amountRaw, fromNetwork, toNetwork, fromToken, toToken, originalInputAmountForRateCalc, rampType } = request;
+  const { amountRaw, fromNetwork, toNetwork, fromToken, toToken, originalInputAmountForRateCalc } = request;
 
   try {
     // Prepare route parameters for Squidrouter
@@ -257,7 +218,6 @@ export async function calculateEvmBridgeAndNetworkFee(request: EvmBridgeRequest)
       amountRaw: amountRaw,
       fromNetwork,
       fromToken,
-      rampType,
       toNetwork,
       toToken
     });

--- a/apps/api/src/api/services/phases/blocks/phases/alfredpay-offramp/simulation.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/alfredpay-offramp/simulation.ts
@@ -69,7 +69,6 @@ export function simulateAlfredpayOfframp<FromToken extends EvmToken, FromNetwork
       fromNetwork,
       inputCurrency: fromToken as OnChainToken,
       outputCurrency: ALFREDPAY_EVM_TOKEN,
-      rampType: RampDirection.SELL,
       toNetwork: Networks.Polygon
     });
     const { preNablaDeductibleFeeAmount, feeCurrency } = await calculatePreNablaDeductibleFees(

--- a/apps/api/src/api/services/phases/blocks/phases/alfredpay-offramp/simulation.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/alfredpay-offramp/simulation.ts
@@ -1,5 +1,6 @@
 import {
   ALFREDPAY_ERC20_DECIMALS,
+  ALFREDPAY_ERC20_TOKEN,
   ALFREDPAY_EVM_TOKEN,
   ALFREDPAY_ONCHAIN_CURRENCY,
   AlfredpayApiService,
@@ -56,6 +57,19 @@ export interface AlfredpayOfframpMetadata {
 
 export const AlfredpayOfframpContext = defineContext<AlfredpayOfframpMetadata>()("alfredpayOfframp");
 
+function directAlfredpaySettlementQuote(amountDecimal: string) {
+  const outputAmountDecimal = new Big(amountDecimal);
+  const amountRaw = multiplyByPowerOfTen(outputAmountDecimal, ALFREDPAY_ERC20_DECIMALS).toFixed(0, Big.roundDown);
+
+  return {
+    fromToken: ALFREDPAY_ERC20_TOKEN,
+    inputAmountRaw: amountRaw,
+    outputAmountDecimal,
+    outputAmountRaw: amountRaw,
+    toToken: ALFREDPAY_ERC20_TOKEN
+  };
+}
+
 export function simulateAlfredpayOfframp<FromToken extends EvmToken, FromNetwork extends EvmNetworks>(
   fromToken: FromToken,
   fromNetwork: FromNetwork
@@ -64,13 +78,16 @@ export function simulateAlfredpayOfframp<FromToken extends EvmToken, FromNetwork
     input: PhaseIO<FromToken, FromNetwork>,
     ctx: PhaseCtx
   ): Promise<PhaseResult<PhaseIO<FiatToken, "fiat">, AlfredpayOfframpMetadata>> => {
-    const bridge = await getEvmBridgeQuote({
-      amountDecimal: ctx.request.inputAmount,
-      fromNetwork,
-      inputCurrency: fromToken as OnChainToken,
-      outputCurrency: ALFREDPAY_EVM_TOKEN,
-      toNetwork: Networks.Polygon
-    });
+    const bridge =
+      fromNetwork === Networks.Polygon && fromToken === ALFREDPAY_EVM_TOKEN
+        ? directAlfredpaySettlementQuote(ctx.request.inputAmount)
+        : await getEvmBridgeQuote({
+            amountDecimal: ctx.request.inputAmount,
+            fromNetwork,
+            inputCurrency: fromToken as OnChainToken,
+            outputCurrency: ALFREDPAY_EVM_TOKEN,
+            toNetwork: Networks.Polygon
+          });
     const { preNablaDeductibleFeeAmount, feeCurrency } = await calculatePreNablaDeductibleFees(
       ctx.request.inputAmount,
       ctx.request.inputCurrency,

--- a/apps/api/src/api/services/phases/blocks/phases/avenia-mint/index.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/avenia-mint/index.ts
@@ -37,7 +37,6 @@ export const AveniaMint: Phase<
               fromNetwork: Networks.Base,
               inputCurrency: EvmToken.USDC,
               outputCurrency: ctx.request.outputCurrency as OnChainToken,
-              rampType: ctx.request.rampType,
               toNetwork
             })
           ).networkFeeUSD;

--- a/apps/api/src/api/services/phases/blocks/phases/evm-offramp-source/simulation.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/evm-offramp-source/simulation.ts
@@ -5,8 +5,7 @@ import {
   getOnChainTokenDetails,
   isEvmTokenDetails,
   Networks,
-  OnChainToken,
-  RampDirection
+  OnChainToken
 } from "@vortexfi/shared";
 import Big from "big.js";
 import { priceFeedService } from "../../../../priceFeed.service";
@@ -100,7 +99,6 @@ export async function simulateEvmOfframpSource<FromToken extends OnChainToken, F
     fromNetwork: input.chain,
     inputCurrency: input.token,
     outputCurrency: EvmToken.USDC,
-    rampType: RampDirection.SELL,
     toNetwork: Networks.Base
   });
   if (!ctx.fees?.usd || !ctx.fees.displayFiat) {

--- a/apps/api/src/api/services/phases/blocks/phases/mykobo-mint/simulation.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/mykobo-mint/simulation.ts
@@ -62,7 +62,6 @@ export async function simulateMykoboMint(
           fromNetwork: Networks.Base as EvmNetworks,
           fromToken: (eurcBaseDetails as EvmTokenDetails).erc20AddressSourceChain,
           originalInputAmountForRateCalc: ctx.request.inputAmount,
-          rampType: ctx.request.rampType,
           toNetwork,
           toToken: toToken.erc20AddressSourceChain
         })

--- a/apps/api/src/api/services/phases/blocks/phases/squid-router-swap/simulation.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/squid-router-swap/simulation.ts
@@ -70,7 +70,6 @@ export async function simulateSquidRouterSwap<
     fromNetwork: fromChain as Networks,
     fromToken: bridgeSourceToken,
     originalInputAmountForRateCalc: input.amountRaw,
-    rampType: ctx.request.rampType,
     toNetwork: toChain as Networks,
     toToken: bridgeTargetToken
   });

--- a/apps/api/src/api/services/phases/blocks/phases/subsidize-post/simulation.ts
+++ b/apps/api/src/api/services/phases/blocks/phases/subsidize-post/simulation.ts
@@ -54,7 +54,6 @@ export async function simulateSubsidizePost<Token extends TokenBrand, Chain exte
         fromNetwork: Networks.Base,
         inputCurrency: EvmToken.USDC,
         outputCurrency: ctx.request.outputCurrency as OnChainToken,
-        rampType: ctx.request.rampType,
         toNetwork
       });
       if (expectedOutput.gt(0) && bridge.outputAmountDecimal.gt(0)) {

--- a/apps/api/src/tests/corridors/mxn-offramp.scenario.test.ts
+++ b/apps/api/src/tests/corridors/mxn-offramp.scenario.test.ts
@@ -109,6 +109,7 @@ describe("MXN offramp direct corridor (USDT on Polygon → spei, no-permit)", ()
   });
 
   async function createQuoteViaApi(): Promise<{ id: string; inputAmount: string; outputAmount: string }> {
+    const squidRouteCount = world.squidRouter.requestedRoutes.length;
     const response = await app.request("/v1/quotes", {
       body: JSON.stringify({
         from: Networks.Polygon,
@@ -123,6 +124,7 @@ describe("MXN offramp direct corridor (USDT on Polygon → spei, no-permit)", ()
       method: "POST"
     });
     expect(response.status).toBe(201);
+    expect(world.squidRouter.requestedRoutes).toHaveLength(squidRouteCount);
     return (await response.json()) as { id: string; inputAmount: string; outputAmount: string };
   }
 
@@ -280,6 +282,25 @@ describe("MXN offramp direct corridor (USDT on Polygon → spei, no-permit)", ()
   function submissionsOf(signedTransfer: `0x${string}`): number {
     return world.evm.sentTransactions.filter(tx => tx.serialized === signedTransfer).length;
   }
+
+  it("quotes direct Polygon USDT 1:1 without requesting a Squid route", async () => {
+    const quote = await createQuoteViaApi();
+    const persistedQuote = await QuoteTicket.findByPk(quote.id);
+    const metadata = persistedQuote?.metadata as unknown as
+      | {
+          blocks: {
+            alfredpayOfframp?: {
+              bridgeInputAmountRaw?: string;
+              bridgeOutputAmountRaw?: string;
+            };
+          };
+        }
+      | undefined;
+    const expectedRaw = parseUnits(quote.inputAmount, ALFREDPAY_ERC20_DECIMALS).toString();
+
+    expect(metadata?.blocks.alfredpayOfframp?.bridgeInputAmountRaw).toBe(expectedRaw);
+    expect(metadata?.blocks.alfredpayOfframp?.bridgeOutputAmountRaw).toBe(expectedRaw);
+  });
 
   it(
     "happy path: processes the full Alfredpay offramp phase sequence to complete",

--- a/apps/api/src/tests/deployed-quotes.e2e.test.ts
+++ b/apps/api/src/tests/deployed-quotes.e2e.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+const apiBaseUrls = (process.env.VORTEX_QUOTE_SMOKE_URLS ?? "")
+  .split(",")
+  .map((value) => value.trim().replace(/\/$/, ""))
+  .filter(Boolean);
+
+const quoteCases = [
+  {
+    direction: "BUY",
+    request: {
+      from: "pix",
+      inputAmount: "100",
+      inputCurrency: "BRL",
+      network: "polygon",
+      outputCurrency: "USDT",
+      paymentMethod: "pix",
+      rampType: "BUY",
+      to: "polygon",
+    },
+  },
+  {
+    direction: "SELL",
+    request: {
+      from: "polygon",
+      inputAmount: "20",
+      inputCurrency: "USDT",
+      network: "polygon",
+      outputCurrency: "BRL",
+      paymentMethod: "pix",
+      rampType: "SELL",
+      to: "pix",
+    },
+  },
+] as const;
+
+interface QuoteResponse {
+  expiresAt: string;
+  from: string;
+  id: string;
+  inputAmount: string;
+  inputCurrency: string;
+  network: string;
+  outputAmount: string;
+  outputCurrency: string;
+  paymentMethod: string;
+  rampType: string;
+  to: string;
+}
+
+describe.skipIf(apiBaseUrls.length === 0)("deployed quote API", () => {
+  test("has at least one deployment configured", () => {
+    expect(apiBaseUrls.length).toBeGreaterThan(0);
+  });
+
+  for (const apiBaseUrl of apiBaseUrls) {
+    for (const quoteCase of quoteCases) {
+      test(`${apiBaseUrl} serves a cross-chain ${quoteCase.direction} quote`, async () => {
+        const response = await fetch(`${apiBaseUrl}/v1/quotes`, {
+          body: JSON.stringify(quoteCase.request),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+          signal: AbortSignal.timeout(25_000),
+        });
+        const responseText = await response.text();
+
+        if (response.status !== 201) {
+          throw new Error(
+            `${quoteCase.direction} quote failed on ${apiBaseUrl}: HTTP ${response.status} ${responseText}`,
+          );
+        }
+
+        const quote = JSON.parse(responseText) as QuoteResponse;
+        expect(quote).toMatchObject({
+          from: quoteCase.request.from,
+          inputCurrency: quoteCase.request.inputCurrency,
+          network: quoteCase.request.network,
+          outputCurrency: quoteCase.request.outputCurrency,
+          paymentMethod: quoteCase.request.paymentMethod,
+          rampType: quoteCase.request.rampType,
+          to: quoteCase.request.to,
+        });
+        expect(quote.id.length).toBeGreaterThan(0);
+        expect(Number(quote.inputAmount)).toBe(
+          Number(quoteCase.request.inputAmount),
+        );
+        expect(Number(quote.outputAmount)).toBeGreaterThan(0);
+        expect(Date.parse(quote.expiresAt)).toBeGreaterThan(Date.now());
+      }, 30_000);
+    }
+  }
+});

--- a/apps/dashboard/playwright.config.ts
+++ b/apps/dashboard/playwright.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
     command: "bun x --bun vite --port 5174 --strictPort --host 127.0.0.1",
     // A placeholder Alchemy key keeps the frontend-matched transport path active; every endpoint
     // is intercepted per-test. VITE_API_URL defaults to the likewise-intercepted localhost API.
-    env: { VITE_ALCHEMY_API_KEY: "e2e-mock-key" },
+    env: {
+      VITE_ALCHEMY_API_KEY: "e2e-mock-key",
+      VITE_WIDGET_URL: "http://127.0.0.1:5173"
+    },
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     url: "http://127.0.0.1:5174/"

--- a/apps/dashboard/src/services/api/api-client.ts
+++ b/apps/dashboard/src/services/api/api-client.ts
@@ -64,7 +64,7 @@ async function apiFetch<T>(
 
   if (response.status === 401 && initialTokens?.accessToken) {
     const refreshed = await refreshTokenOnce();
-    if (refreshed?.accessToken) {
+    if (refreshed?.accessToken && refreshed.userId === initialTokens.userId) {
       response = await doFetch(refreshed.accessToken);
     }
   }

--- a/apps/dashboard/src/services/api/api-client.ts
+++ b/apps/dashboard/src/services/api/api-client.ts
@@ -1,19 +1,8 @@
 import { AuthService, type AuthTokens } from "../auth";
 import { API_BASE_URL } from "./base-url";
 
-// Single-flight token refresh: concurrent 401s share one refresh instead of each firing
-// their own (which would race the refresh-token rotation and fail).
-let refreshPromise: Promise<AuthTokens | null> | null = null;
-
 function refreshTokenOnce(): Promise<AuthTokens | null> {
-  if (!refreshPromise) {
-    refreshPromise = AuthService.refreshAccessToken()
-      .catch(() => null)
-      .finally(() => {
-        refreshPromise = null;
-      });
-  }
-  return refreshPromise;
+  return AuthService.refreshAccessToken().catch(() => null);
 }
 
 export class ApiError extends Error {

--- a/apps/dashboard/src/services/auth.test.ts
+++ b/apps/dashboard/src/services/auth.test.ts
@@ -75,4 +75,92 @@ describe("AuthService", () => {
       userId: "user-1",
     });
   });
+
+  it("does not let an old refresh flight overwrite a newer session", async () => {
+    let oldRefreshRequests = 0;
+    let newRefreshRequests = 0;
+    let releaseOldRequest: (() => void) | undefined;
+    const oldRequestGate = new Promise<void>((resolve) => {
+      releaseOldRequest = resolve;
+    });
+
+    globalThis.fetch = (async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { refresh_token: string };
+      if (body.refresh_token === "refresh-token") {
+        oldRefreshRequests += 1;
+        await oldRequestGate;
+        return new Response(
+          JSON.stringify({
+            access_token: "stale-access-token",
+            refresh_token: "stale-refresh-token",
+          }),
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        );
+      }
+
+      newRefreshRequests += 1;
+      return new Response(
+        JSON.stringify({
+          access_token: "new-rotated-access-token",
+          refresh_token: "new-rotated-refresh-token",
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
+    }) as typeof fetch;
+
+    const oldRefresh = AuthService.refreshAccessToken();
+    AuthService.storeTokens({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+    const newRefresh = AuthService.refreshAccessToken();
+
+    assert.deepEqual(await newRefresh, {
+      accessToken: "new-rotated-access-token",
+      refreshToken: "new-rotated-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+    releaseOldRequest?.();
+    assert.equal(await oldRefresh, null);
+    assert.equal(oldRefreshRequests, 1);
+    assert.equal(newRefreshRequests, 1);
+    assert.deepEqual(AuthService.getTokens(), {
+      accessToken: "new-rotated-access-token",
+      refreshToken: "new-rotated-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+  });
+
+  it("does not let a stale 401 clear a newer session", async () => {
+    let releaseRequest: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+
+    globalThis.fetch = (async () => {
+      await requestGate;
+      return new Response(null, { status: 401 });
+    }) as typeof fetch;
+
+    const oldRefresh = AuthService.refreshAccessToken();
+    AuthService.storeTokens({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+    releaseRequest?.();
+
+    assert.equal(await oldRefresh, null);
+    assert.deepEqual(AuthService.getTokens(), {
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+  });
 });

--- a/apps/dashboard/src/services/auth.test.ts
+++ b/apps/dashboard/src/services/auth.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, beforeEach, describe, it } from "node:test";
 import { AuthService } from "./auth";
+import { startTokenRefresh } from "./tokenRefresh";
 
 const originalFetch = globalThis.fetch;
 const originalLocalStorage = Object.getOwnPropertyDescriptor(
@@ -76,6 +77,13 @@ describe("AuthService", () => {
     });
   });
 
+  it("clears the current session when its refresh token is rejected", async () => {
+    globalThis.fetch = (async () => new Response(null, { status: 401 })) as typeof fetch;
+
+    assert.equal(await AuthService.refreshAccessToken(), null);
+    assert.equal(AuthService.getTokens(), null);
+  });
+
   it("does not let an old refresh flight overwrite a newer session", async () => {
     let oldRefreshRequests = 0;
     let newRefreshRequests = 0;
@@ -124,7 +132,12 @@ describe("AuthService", () => {
       userId: "user-2",
     });
     releaseOldRequest?.();
-    assert.equal(await oldRefresh, null);
+    assert.deepEqual(await oldRefresh, {
+      accessToken: "new-rotated-access-token",
+      refreshToken: "new-rotated-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
     assert.equal(oldRefreshRequests, 1);
     assert.equal(newRefreshRequests, 1);
     assert.deepEqual(AuthService.getTokens(), {
@@ -155,7 +168,59 @@ describe("AuthService", () => {
     });
     releaseRequest?.();
 
-    assert.equal(await oldRefresh, null);
+    assert.deepEqual(await oldRefresh, {
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+    assert.deepEqual(AuthService.getTokens(), {
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+  });
+
+  it("keeps a replacement session when a proactive refresh is superseded", async () => {
+    let invalidated = false;
+    let releaseRequest: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+    const timers: Array<() => void | Promise<void>> = [];
+
+    globalThis.fetch = (async () => {
+      await requestGate;
+      return new Response(null, { status: 401 });
+    }) as typeof fetch;
+
+    startTokenRefresh({
+      getExpiryMs: () => 60_000,
+      now: () => 0,
+      onInvalid: () => {
+        invalidated = true;
+        AuthService.signOut();
+      },
+      refresh: () => AuthService.refreshAccessToken(),
+      setTimer: (callback) => {
+        timers.push(callback);
+        return callback as unknown as ReturnType<typeof setTimeout>;
+      },
+    });
+
+    const proactiveRefresh = timers.shift()?.();
+    AuthService.storeTokens({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      userEmail: "new@vortex.local",
+      userId: "user-2",
+    });
+    releaseRequest?.();
+    await proactiveRefresh;
+
+    assert.equal(invalidated, false);
+    assert.equal(timers.length, 1);
     assert.deepEqual(AuthService.getTokens(), {
       accessToken: "new-access-token",
       refreshToken: "new-refresh-token",

--- a/apps/dashboard/src/services/auth.test.ts
+++ b/apps/dashboard/src/services/auth.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, describe, it } from "node:test";
+import { AuthService } from "./auth";
+
+const originalFetch = globalThis.fetch;
+const originalLocalStorage = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage",
+);
+const values = new Map<string, string>();
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  },
+});
+
+beforeEach(() => {
+  values.clear();
+  AuthService.storeTokens({
+    accessToken: "expired-access-token",
+    refreshToken: "refresh-token",
+    userEmail: "e2e@vortex.local",
+    userId: "user-1",
+  });
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (originalLocalStorage) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+  } else {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  }
+});
+
+describe("AuthService", () => {
+  it("coalesces concurrent token refreshes across auth callers", async () => {
+    let fetchCalls = 0;
+    let releaseRequest: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      await requestGate;
+      return new Response(
+        JSON.stringify({
+          access_token: "rotated-access-token",
+          refresh_token: "rotated-refresh-token",
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
+    }) as typeof fetch;
+
+    const proactiveRefresh = AuthService.refreshAccessToken();
+    const requestRecoveryRefresh = AuthService.refreshAccessToken();
+    releaseRequest?.();
+
+    const [proactiveTokens, recoveryTokens] = await Promise.all([
+      proactiveRefresh,
+      requestRecoveryRefresh,
+    ]);
+
+    assert.equal(fetchCalls, 1);
+    assert.deepEqual(proactiveTokens, recoveryTokens);
+    assert.deepEqual(AuthService.getTokens(), {
+      accessToken: "rotated-access-token",
+      refreshToken: "rotated-refresh-token",
+      userEmail: "e2e@vortex.local",
+      userId: "user-1",
+    });
+  });
+});

--- a/apps/dashboard/src/services/auth.ts
+++ b/apps/dashboard/src/services/auth.ts
@@ -85,10 +85,11 @@ export class AuthService {
 
   /**
    * Refresh the access token via `/v1/auth/refresh`. Returns the new tokens, or `null`
-   * when the refresh token is confirmed invalid (401 — session cleared). Transient
-   * failures throw so callers can retry without destroying a still-valid session. Callers
-   * in the same session share an in-flight refresh so proactive refresh and 401 recovery
-   * cannot race refresh-token rotation; a replacement session starts its own flight.
+   * when the current refresh token is confirmed invalid (401 — session cleared). A
+   * superseded flight returns the replacement session instead. Transient failures throw so
+   * callers can retry without destroying a still-valid session. Callers in the same session
+   * share an in-flight refresh so proactive refresh and 401 recovery cannot race refresh-token
+   * rotation; a replacement session starts its own flight.
    */
   static refreshAccessToken(): Promise<AuthTokens | null> {
     const tokens = this.getTokens();
@@ -118,10 +119,11 @@ export class AuthService {
       signal: AbortSignal.timeout(30000)
     });
 
+    if (!this.isCurrentSession(tokens.refreshToken, generation)) {
+      return this.getTokens();
+    }
     if (response.status === 401) {
-      if (this.isCurrentSession(tokens.refreshToken, generation)) {
-        this.clearTokens();
-      }
+      this.clearTokens();
       return null;
     }
     if (!response.ok) {
@@ -130,7 +132,7 @@ export class AuthService {
 
     const data = (await response.json()) as { access_token: string; refresh_token: string };
     if (!this.isCurrentSession(tokens.refreshToken, generation)) {
-      return null;
+      return this.getTokens();
     }
     const newTokens: AuthTokens = {
       accessToken: data.access_token,

--- a/apps/dashboard/src/services/auth.ts
+++ b/apps/dashboard/src/services/auth.ts
@@ -16,6 +16,7 @@ export class AuthService {
   private static readonly REFRESH_TOKEN_KEY = "vortex_dashboard_refresh_token";
   private static readonly USER_ID_KEY = "vortex_dashboard_user_id";
   private static readonly USER_EMAIL_KEY = "vortex_dashboard_user_email";
+  private static refreshPromise: Promise<AuthTokens | null> | null = null;
 
   static storeTokens(tokens: AuthTokens): void {
     localStorage.setItem(this.ACCESS_TOKEN_KEY, tokens.accessToken);
@@ -78,9 +79,20 @@ export class AuthService {
   /**
    * Refresh the access token via `/v1/auth/refresh`. Returns the new tokens, or `null`
    * when the refresh token is confirmed invalid (401 — session cleared). Transient
-   * failures throw so callers can retry without destroying a still-valid session.
+   * failures throw so callers can retry without destroying a still-valid session. All
+   * callers share an in-flight refresh so proactive refresh and 401 recovery cannot race
+   * refresh-token rotation.
    */
-  static async refreshAccessToken(): Promise<AuthTokens | null> {
+  static refreshAccessToken(): Promise<AuthTokens | null> {
+    if (!this.refreshPromise) {
+      this.refreshPromise = this.performTokenRefresh().finally(() => {
+        this.refreshPromise = null;
+      });
+    }
+    return this.refreshPromise;
+  }
+
+  private static async performTokenRefresh(): Promise<AuthTokens | null> {
     const tokens = this.getTokens();
     if (!tokens) {
       return null;

--- a/apps/dashboard/src/services/auth.ts
+++ b/apps/dashboard/src/services/auth.ts
@@ -16,9 +16,15 @@ export class AuthService {
   private static readonly REFRESH_TOKEN_KEY = "vortex_dashboard_refresh_token";
   private static readonly USER_ID_KEY = "vortex_dashboard_user_id";
   private static readonly USER_EMAIL_KEY = "vortex_dashboard_user_email";
-  private static refreshPromise: Promise<AuthTokens | null> | null = null;
+  private static sessionGeneration = 0;
+  private static refreshFlight: {
+    generation: number;
+    refreshToken: string;
+    promise: Promise<AuthTokens | null>;
+  } | null = null;
 
   static storeTokens(tokens: AuthTokens): void {
+    this.sessionGeneration += 1;
     localStorage.setItem(this.ACCESS_TOKEN_KEY, tokens.accessToken);
     localStorage.setItem(this.REFRESH_TOKEN_KEY, tokens.refreshToken);
     localStorage.setItem(this.USER_ID_KEY, tokens.userId);
@@ -40,6 +46,7 @@ export class AuthService {
   }
 
   static clearTokens(): void {
+    this.sessionGeneration += 1;
     localStorage.removeItem(this.ACCESS_TOKEN_KEY);
     localStorage.removeItem(this.REFRESH_TOKEN_KEY);
     localStorage.removeItem(this.USER_ID_KEY);
@@ -79,25 +86,31 @@ export class AuthService {
   /**
    * Refresh the access token via `/v1/auth/refresh`. Returns the new tokens, or `null`
    * when the refresh token is confirmed invalid (401 — session cleared). Transient
-   * failures throw so callers can retry without destroying a still-valid session. All
-   * callers share an in-flight refresh so proactive refresh and 401 recovery cannot race
-   * refresh-token rotation.
+   * failures throw so callers can retry without destroying a still-valid session. Callers
+   * in the same session share an in-flight refresh so proactive refresh and 401 recovery
+   * cannot race refresh-token rotation; a replacement session starts its own flight.
    */
   static refreshAccessToken(): Promise<AuthTokens | null> {
-    if (!this.refreshPromise) {
-      this.refreshPromise = this.performTokenRefresh().finally(() => {
-        this.refreshPromise = null;
-      });
-    }
-    return this.refreshPromise;
-  }
-
-  private static async performTokenRefresh(): Promise<AuthTokens | null> {
     const tokens = this.getTokens();
     if (!tokens) {
-      return null;
+      return Promise.resolve(null);
     }
 
+    const generation = this.sessionGeneration;
+    if (this.refreshFlight?.generation === generation && this.refreshFlight.refreshToken === tokens.refreshToken) {
+      return this.refreshFlight.promise;
+    }
+
+    const promise = this.performTokenRefresh(tokens, generation).finally(() => {
+      if (this.refreshFlight?.promise === promise) {
+        this.refreshFlight = null;
+      }
+    });
+    this.refreshFlight = { generation, promise, refreshToken: tokens.refreshToken };
+    return promise;
+  }
+
+  private static async performTokenRefresh(tokens: AuthTokens, generation: number): Promise<AuthTokens | null> {
     const response = await fetch(`${API_BASE_URL}/v1/auth/refresh`, {
       body: JSON.stringify({ refresh_token: tokens.refreshToken }),
       headers: { "Content-Type": "application/json" },
@@ -106,7 +119,9 @@ export class AuthService {
     });
 
     if (response.status === 401) {
-      this.clearTokens();
+      if (this.isCurrentSession(tokens.refreshToken, generation)) {
+        this.clearTokens();
+      }
       return null;
     }
     if (!response.ok) {
@@ -114,6 +129,9 @@ export class AuthService {
     }
 
     const data = (await response.json()) as { access_token: string; refresh_token: string };
+    if (!this.isCurrentSession(tokens.refreshToken, generation)) {
+      return null;
+    }
     const newTokens: AuthTokens = {
       accessToken: data.access_token,
       refreshToken: data.refresh_token,
@@ -122,6 +140,10 @@ export class AuthService {
     };
     this.storeTokens(newTokens);
     return newTokens;
+  }
+
+  private static isCurrentSession(refreshToken: string, generation: number): boolean {
+    return this.sessionGeneration === generation && this.getTokens()?.refreshToken === refreshToken;
   }
 
   static signOut(): void {

--- a/docs/operations-testing.md
+++ b/docs/operations-testing.md
@@ -22,7 +22,7 @@ together with the shared test harness (`apps/api/src/test-utils`) — see "How t
 | 3. Corridor scenarios | Phase processor end-to-end per corridor against the fake world: BRL onramp (pix→BRLA-on-Base), BRL offramp (USDC-on-Base→pix incl. real Nabla swap + both EVM subsidy phases), CROSS-CHAIN BRL offramp (USDC-on-Polygon→squid→Base→pix incl. user-reported squid-hash verification), MXN on/offramp (spei↔USDT-on-Polygon), CROSS-CHAIN MXN onramp (spei→Polygon mint→squid→USDT-on-Arbitrum incl. real squidRouterSwap/Pay + Arbitrum settlement subsidy), CROSS-CHAIN BRL onramp (pix→Base mint+Nabla swap→squid→USDC-on-Arbitrum), a USD/COP/ARS matrix over the same Alfredpay rails (happy paths + per-currency limit breaches + per-currency transient AND unrecoverable failures + per-currency cross-chain BUY and no-permit cross-chain SELL, incl. MXN SELL cross-chain), and EUR (Mykobo) on/offramp scenarios (SEPA↔EURC/USDC-on-Base incl. real Nabla swap; registration stays kill-switched — see the coverage matrix) | `apps/api/src/tests/corridors/` | `bun test` |
 | 4. SDK contract | Real SDK against the real API in-process: BRL onramp lifecycle (`sdk-contract.test.ts`), the SELL/user-transaction surface — offramp lifecycle via submitUserTransactions, updateRamp, getQuote, listAlfredpayFiatAccounts (`sdk-contract.offramp.test.ts`) — and full per-currency lifecycles for all four Alfredpay currencies in both directions: SELL offramp lifecycles for USD/ach, MXN/spei, COP/ach and ARS/cbu (`sdk-contract.alfredpay-offramp.test.ts`) and BUY onramp lifecycles for MXN/spei, USD/ach, COP/ach and ARS/cbu (`sdk-contract.alfredpay-onramp.test.ts`) | `apps/api/src/tests/sdk-contract*.test.ts` | `bun test` |
 | 5. Frontend | XState machine tests, actor tests (register/sign/start/KYC-routing against MSW with mocked wallet seams), component tests (RTL + MSW + mock wagmi) | `apps/frontend/src` | Vitest |
-| 6. E2E | Critical Playwright journeys with a mock wallet: BRL on/offramp plus parameterized Alfredpay journeys for all four currencies in both directions. The dashboard runs its own Playwright config covering auth, account selection, onboarding/KYC/KYB, recipient invitations, the MXN offramp journey, and BRL/MXN/USD/COP/ARS onramps | `apps/frontend/e2e/`, `apps/dashboard/e2e/` | Playwright (non-blocking) |
+| 6. E2E | Critical Playwright journeys with a mock wallet: BRL on/offramp plus parameterized Alfredpay journeys for all four currencies in both directions. The dashboard runs its own Playwright config covering auth, account selection, onboarding/KYC/KYB, recipient invitations, the MXN offramp journey, and BRL/MXN/USD/COP/ARS onramps. The nightly job also smoke-tests deployed staging and production BUY/SELL quotes through a cross-chain Squid corridor. | `apps/frontend/e2e/`, `apps/dashboard/e2e/`, `apps/api/src/tests/deployed-quotes.e2e.test.ts` | Playwright + Bun (non-blocking) |
 | 7. External API contracts | Consumed-contract zod schemas (`packages/shared/src/services/*/schemas.ts`, plus `apps/api/.../priceFeed.schemas.ts`) validated against the fakes (PR-blocking) and against the real partner APIs (live, nightly, non-blocking); SquidRouter, Alfredpay, Avenia/BRLA, CoinGecko | `apps/api/src/tests/contracts/` | `bun test` / nightly `contracts.yml` |
 
 ### The invariants the suite protects
@@ -244,6 +244,11 @@ SDK contract + E2E journey coverage for the reopened entry points.
 Tests that hit real RPCs or sandboxes (e.g. XCM dry-runs in `packages/shared`) are gated behind
 `RUN_LIVE_TESTS=1` via `describe.skipIf`. They are for local debugging and optional nightly runs,
 never PR-blocking.
+
+The e2e workflow sets `VORTEX_QUOTE_SMOKE_URLS` for `deployed-quotes.e2e.test.ts`, which requires
+successful cross-chain BUY and SELL quotes from both staging and production. Ordinary local and
+PR-blocking API runs leave the variable unset, so this deployment smoke test does not make them
+network-dependent.
 
 ### External API contracts (`apps/api/src/tests/contracts/`)
 


### PR DESCRIPTION
## Summary
- route SELL quote simulation to the requested Base or Polygon settlement chain instead of the legacy Moonbeam post-hook
- align Squid quote topology with current offramp transaction preparation
- add nightly deployed BUY and SELL quote smoke tests against staging and production through a cross-chain Squid corridor
- single-flight dashboard token refreshes so proactive refresh and callback 401 recovery cannot race refresh-token rotation
- pin the dashboard Playwright widget origin so its journeys are hermetic

## Testing
- phase-block API suite: 186 passed, 3 skipped
- dashboard unit suite: 72 passed
- dashboard Playwright suite: 64 passed
- API and dashboard typechecks
- Biome, Prettier, and workflow YAML checks
- deployed smoke detector manually confirmed: BUY passes on staging and production; SELL reports the current HTTP 500 on both until this hotfix is deployed

## Scope
The quote hotfix removes legacy Moonbeam routing from quote creation. The separate moonbeamCleanup background-processing failure is not changed here.