### PR TITLE
Fix KYB endpoints for business customers migrated onto individual entities

### DIFF
--- a/apps/api/src/api/controllers/brla.controller.test.ts
+++ b/apps/api/src/api/controllers/brla.controller.test.ts
@@ -1,4 +1,4 @@
-import {AveniaAccountType, BrlaApiError, BrlaApiService, KycAttemptResult, KycAttemptStatus} from "@vortexfi/shared";
+import {AveniaAccountType, AveniaDocumentType, BrlaApiError, BrlaApiService, KycAttemptResult, KycAttemptStatus} from "@vortexfi/shared";
 import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
 import httpStatus from "http-status";
 import logger from "../../config/logger";
@@ -13,6 +13,7 @@ import {
   fetchSubaccountKycStatus,
   getAveniaUser,
   getKybAttemptStatus,
+  getUploadUrls,
   initiateKybLevel1,
   recordInitialKycAttempt
 } from "./brla.controller";
@@ -36,6 +37,7 @@ function createResponse() {
 
 // getOrCreateCustomerEntityForProfile resolves each profile to a deterministic entity id.
 // Type-less lookups resolve via findOne (oldest-entity default); typed ones via findOrCreate.
+// Profile-ownership checks enumerate the profile's entities via findAll.
 function mockEntityPerProfile() {
   CustomerEntity.findOne = mock(async (options: { where: { profileId: string } }) => ({
     id: `entity-${options.where.profileId}`
@@ -44,10 +46,14 @@ function mockEntityPerProfile() {
     { id: `entity-${options.where.profileId}` },
     false
   ]) as unknown as typeof CustomerEntity.findOrCreate;
+  CustomerEntity.findAll = mock(async (options: { where: { profileId: string } }) => [
+    { id: `entity-${options.where.profileId}` }
+  ]) as unknown as typeof CustomerEntity.findAll;
 }
 
 const originalUserFindByPk = User.findByPk;
 const originalManagedProfileFindOne = PartnerManagedProfile.findOne;
+const originalEntityFindAll = CustomerEntity.findAll;
 
 beforeEach(() => {
   PartnerManagedProfile.findOne = mock(async () => null) as unknown as typeof PartnerManagedProfile.findOne;
@@ -57,6 +63,7 @@ beforeEach(() => {
 afterEach(() => {
   PartnerManagedProfile.findOne = originalManagedProfileFindOne;
   User.findByPk = originalUserFindByPk;
+  CustomerEntity.findAll = originalEntityFindAll;
 });
 
 describe("getAveniaUser", () => {
@@ -591,6 +598,33 @@ describe("Avenia company KYB", () => {
     expect(providerStatus).not.toHaveBeenCalled();
   });
 
+  // Migration 040 attached business rows to the profile's (038-backfilled) individual entity.
+  // Comparing ownership against the typed business entity 403'd the legitimate owner and
+  // findOrCreate'd an empty business entity as a side effect of the read.
+  it("resolves a KYB attempt whose rows live on the profile's legacy individual entity", async () => {
+    CustomerEntity.findAll = mock(async () => [
+      { id: "entity-user-1-individual" }
+    ]) as unknown as typeof CustomerEntity.findAll;
+    const strayCreate = mock(async () => [{ id: "entity-user-1-business" }, true]);
+    CustomerEntity.findOrCreate = strayCreate as unknown as typeof CustomerEntity.findOrCreate;
+    KycCase.findOne = mock(async () => ({
+      customerEntityId: "entity-user-1-individual",
+      providerCustomerId: "customer-1"
+    })) as unknown as typeof KycCase.findOne;
+    ProviderCustomer.findByPk = mock(async () => ({
+      customerEntityId: "entity-user-1-individual",
+      provider: "avenia",
+      status: VerificationStatus.Approved
+    })) as unknown as typeof ProviderCustomer.findByPk;
+
+    const res = createResponse();
+    await getKybAttemptStatus({ query: { attemptId: "attempt-1" }, userId: "user-1" } as any, res as any);
+
+    expect(res.statusCode).toBe(httpStatus.OK);
+    expect(res.body).toEqual({ result: KycAttemptResult.APPROVED, status: KycAttemptStatus.COMPLETED });
+    expect(strayCreate).not.toHaveBeenCalled();
+  });
+
   it("persists an approved provider result and returns only normalized browser fields", async () => {
     mockEntityPerProfile();
     const caseUpdate = mock(async () => undefined);
@@ -709,6 +743,39 @@ describe("createSubaccount", () => {
     expect(res.statusCode).toBe(httpStatus.CONFLICT);
     expect(res.body).toEqual({ error: "A subaccount already exists for this taxId" });
     expect(createAveniaSubaccountMock).not.toHaveBeenCalled();
+  });
+
+  // Migration 040 attached business rows to the profile's individual entity; the conflict
+  // check compared against the typed business entity and 409'd the owner's own retry.
+  it("does not 409 the owner's retry when the business row sits on the legacy individual entity", async () => {
+    mockBrlaApi();
+    createAveniaSubaccountMock.mockClear();
+    CustomerEntity.findAll = mock(async () => [
+      { id: "entity-user-1-individual" }
+    ]) as unknown as typeof CustomerEntity.findAll;
+    CustomerEntity.findOrCreate = mock(async () => [
+      { id: "entity-user-1-business" },
+      true
+    ]) as unknown as typeof CustomerEntity.findOrCreate;
+    const existingUpdate = mock(async () => undefined);
+    ProviderCustomer.findOne = mock(async () => ({
+      customerEntityId: "entity-user-1-individual",
+      status: VerificationStatus.Pending,
+      update: existingUpdate
+    })) as unknown as typeof ProviderCustomer.findOne;
+
+    const res = createResponse();
+    await createSubaccount(
+      {
+        body: { accountType: AveniaAccountType.COMPANY, name: "Legacy Co", taxId: "11222333000181" },
+        userId: "user-1"
+      } as any,
+      res as any
+    );
+
+    expect(res.statusCode).toBe(httpStatus.OK);
+    expect(res.body).toEqual({ subAccountId: "new-subaccount" });
+    expect(existingUpdate).toHaveBeenCalledWith(expect.objectContaining({ providerSubaccountId: "new-subaccount" }));
   });
 
   it("rejects when a quarantined legacy record belongs to a different user", async () => {
@@ -866,5 +933,78 @@ describe("createSubaccount", () => {
     expect(res.statusCode).toBe(httpStatus.CONFLICT);
     expect(createAveniaSubaccountMock).not.toHaveBeenCalled();
     expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getUploadUrls", () => {
+  const originalProviderFindOne = ProviderCustomer.findOne;
+  const originalEntityFindOrCreate = CustomerEntity.findOrCreate;
+  const originalGetInstance = BrlaApiService.getInstance;
+  const originalLoggerError = logger.error;
+
+  beforeEach(() => {
+    logger.error = mock(() => logger) as typeof logger.error;
+  });
+
+  afterEach(() => {
+    ProviderCustomer.findOne = originalProviderFindOne;
+    CustomerEntity.findOrCreate = originalEntityFindOrCreate;
+    BrlaApiService.getInstance = originalGetInstance;
+    logger.error = originalLoggerError;
+  });
+
+  const uploadUrlsMock = mock(async () => ({ id: "doc-1", uploadURLBack: "back-url", uploadURLFront: "front-url" }));
+
+  function mockBrlaApi() {
+    BrlaApiService.getInstance = mock(
+      () => ({ getDocumentUploadUrls: uploadUrlsMock }) as unknown as BrlaApiService
+    );
+  }
+
+  // Migration 040 attached business rows to the profile's individual entity; the ownership
+  // check compared against the typed business entity and 403'd the legitimate owner.
+  it("serves upload URLs for a business row on the legacy individual entity without creating entities", async () => {
+    mockBrlaApi();
+    uploadUrlsMock.mockClear();
+    CustomerEntity.findAll = mock(async () => [
+      { id: "entity-user-1-individual" }
+    ]) as unknown as typeof CustomerEntity.findAll;
+    const strayCreate = mock(async () => [{ id: "entity-user-1-business" }, true]);
+    CustomerEntity.findOrCreate = strayCreate as unknown as typeof CustomerEntity.findOrCreate;
+    ProviderCustomer.findOne = mock(async () => ({
+      customerEntityId: "entity-user-1-individual",
+      providerSubaccountId: "subaccount-1"
+    })) as unknown as typeof ProviderCustomer.findOne;
+
+    const res = createResponse();
+    await getUploadUrls(
+      { body: { documentType: AveniaDocumentType.ID, taxId: "11222333000181" }, userId: "user-1" } as any,
+      res as any
+    );
+
+    expect(res.statusCode).toBe(httpStatus.OK);
+    expect(uploadUrlsMock).toHaveBeenCalledTimes(2);
+    expect(strayCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tax id owned by another profile", async () => {
+    mockBrlaApi();
+    uploadUrlsMock.mockClear();
+    CustomerEntity.findAll = mock(async () => [
+      { id: "entity-attacker" }
+    ]) as unknown as typeof CustomerEntity.findAll;
+    ProviderCustomer.findOne = mock(async () => ({
+      customerEntityId: "entity-victim",
+      providerSubaccountId: "subaccount-1"
+    })) as unknown as typeof ProviderCustomer.findOne;
+
+    const res = createResponse();
+    await getUploadUrls(
+      { body: { documentType: AveniaDocumentType.ID, taxId: "11222333000181" }, userId: "attacker" } as any,
+      res as any
+    );
+
+    expect(res.statusCode).toBe(httpStatus.FORBIDDEN);
+    expect(uploadUrlsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/api/controllers/brla.controller.test.ts
+++ b/apps/api/src/api/controllers/brla.controller.test.ts
@@ -753,10 +753,8 @@ describe("createSubaccount", () => {
     CustomerEntity.findAll = mock(async () => [
       { id: "entity-user-1-individual" }
     ]) as unknown as typeof CustomerEntity.findAll;
-    CustomerEntity.findOrCreate = mock(async () => [
-      { id: "entity-user-1-business" },
-      true
-    ]) as unknown as typeof CustomerEntity.findOrCreate;
+    const strayCreate = mock(async () => [{ id: "entity-user-1-business" }, true]);
+    CustomerEntity.findOrCreate = strayCreate as unknown as typeof CustomerEntity.findOrCreate;
     const existingUpdate = mock(async () => undefined);
     ProviderCustomer.findOne = mock(async () => ({
       customerEntityId: "entity-user-1-individual",
@@ -776,6 +774,8 @@ describe("createSubaccount", () => {
     expect(res.statusCode).toBe(httpStatus.OK);
     expect(res.body).toEqual({ subAccountId: "new-subaccount" });
     expect(existingUpdate).toHaveBeenCalledWith(expect.objectContaining({ providerSubaccountId: "new-subaccount" }));
+    // The retry updates the existing row in place — typed-entity creation must not run.
+    expect(strayCreate).not.toHaveBeenCalled();
   });
 
   it("rejects when a quarantined legacy record belongs to a different user", async () => {

--- a/apps/api/src/api/controllers/brla.controller.ts
+++ b/apps/api/src/api/controllers/brla.controller.ts
@@ -366,8 +366,6 @@ export const createSubaccount = async (
     // Use the accountType from the request if provided, otherwise determine from taxId
     const accountType = requestAccountType || (isCnpj ? AveniaAccountType.COMPANY : AveniaAccountType.INDIVIDUAL);
 
-    const entity = await getOrCreateCustomerEntityForProfile(effectiveUserId, accountTypeToCustomerType(accountType));
-
     // Ownership check BEFORE calling the BRLA API to avoid creating a stranded subaccount
     // on every conflict and to prevent account-takeover via subAccountId overwrite.
     // Ownership is profile-level, not typed-entity-level: migration 040 left business rows
@@ -394,6 +392,9 @@ export const createSubaccount = async (
           });
           return;
         }
+        // Typed-entity resolution is deferred to the row-creating branches so a retry that
+        // only updates an existing row cannot create a stray typed entity.
+        const entity = await getOrCreateCustomerEntityForProfile(effectiveUserId, accountTypeToCustomerType(accountType));
         existing = await ProviderCustomer.create({
           country: "BR",
           customerEntityId: entity.id,
@@ -436,6 +437,7 @@ export const createSubaccount = async (
     } else {
       // The entry should have been created the very first a new cpf/cnpj is consulted.
       // We leave this as is for now to avoid breaking changes.
+      const entity = await getOrCreateCustomerEntityForProfile(effectiveUserId, accountTypeToCustomerType(accountType));
       existing = await ProviderCustomer.create({
         companyName,
         country: "BR",

--- a/apps/api/src/api/controllers/brla.controller.ts
+++ b/apps/api/src/api/controllers/brla.controller.ts
@@ -50,7 +50,7 @@ import {
   upsertAveniaKycCase
 } from "../services/avenia/avenia-customer.service";
 import { resolveAveniaAccountForUser } from "../services/avenia-account";
-import { getOrCreateCustomerEntityForProfile } from "../services/customer-entity.service";
+import { findCustomerEntityIdsForProfile, getOrCreateCustomerEntityForProfile } from "../services/customer-entity.service";
 
 // map from subaccountId → last interaction timestamp. Used for fetching the last relevant kyc event.
 const _lastInteractionMap = new Map<string, number>();
@@ -370,8 +370,11 @@ export const createSubaccount = async (
 
     // Ownership check BEFORE calling the BRLA API to avoid creating a stranded subaccount
     // on every conflict and to prevent account-takeover via subAccountId overwrite.
+    // Ownership is profile-level, not typed-entity-level: migration 040 left business rows
+    // on the profile's individual entity, and comparing against the typed entity 409'd the
+    // legitimate owner's own retry.
     let existing = await findAveniaCustomerByTaxId(normalizedTaxId);
-    if (existing && existing.customerEntityId !== entity.id) {
+    if (existing && !(await findCustomerEntityIdsForProfile(effectiveUserId)).includes(existing.customerEntityId)) {
       res.status(httpStatus.CONFLICT).json({
         error: "A subaccount already exists for this taxId"
       });
@@ -668,8 +671,11 @@ export const getUploadUrls = async (
       res.status(httpStatus.FORBIDDEN).json({ error: "This tax ID is not linked to your user profile and cannot be used." });
       return;
     }
-    const entity = await getOrCreateCustomerEntityForProfile(req.userId, "business");
-    if (record.customerEntityId !== entity.id) {
+    // Profile-level ownership: legacy business rows live on the profile's individual
+    // entity, so the owning entity's type cannot gate access — and a read path must not
+    // findOrCreate an entity as a side effect.
+    const ownedEntityIds = await findCustomerEntityIdsForProfile(req.userId);
+    if (!ownedEntityIds.includes(record.customerEntityId)) {
       res.status(httpStatus.FORBIDDEN).json({ error: "This tax ID is not linked to your user profile and cannot be used." });
       return;
     }
@@ -876,14 +882,17 @@ export const getKybAttemptStatus = async (
       return;
     }
 
-    const entity = await getOrCreateCustomerEntityForProfile(effectiveUserId, "business");
-    if (kycCase.customerEntityId !== entity.id) {
+    // Profile-level ownership: legacy business rows live on the profile's individual
+    // entity, so the owning entity's type cannot gate access — and a read path must not
+    // findOrCreate an entity as a side effect.
+    const ownedEntityIds = await findCustomerEntityIdsForProfile(effectiveUserId);
+    if (!ownedEntityIds.includes(kycCase.customerEntityId)) {
       res.status(httpStatus.FORBIDDEN).json({ error: "This KYB attempt is not linked to your user profile." });
       return;
     }
 
     const record = kycCase.providerCustomerId ? await ProviderCustomer.findByPk(kycCase.providerCustomerId) : null;
-    if (!record || record.customerEntityId !== entity.id || record.provider !== "avenia") {
+    if (!record || !ownedEntityIds.includes(record.customerEntityId) || record.provider !== "avenia") {
       res.status(httpStatus.NOT_FOUND).json({ error: "KYB account not found" });
       return;
     }

--- a/apps/api/src/api/services/alfredpay/alfredpay-customer.service.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-customer.service.ts
@@ -8,6 +8,7 @@ import {
 import logger from "../../../config/logger";
 import KycCase from "../../../models/kycCase.model";
 import ProviderCustomer, { ProviderCustomerType, VerificationStatus } from "../../../models/providerCustomer.model";
+import User from "../../../models/user.model";
 import { findCustomerEntityIdsForProfile, getOrCreateCustomerEntityForProfile } from "../customer-entity.service";
 
 export function alfredpayTypeToCustomerType(type: AlfredpayCustomerType): ProviderCustomerType {
@@ -312,18 +313,21 @@ export async function createAlfredpayCustomer(
   values: { alfredPayId: string; country: AlfredPayCountry; status: AlfredPayStatus; type: AlfredpayCustomerType }
 ): Promise<AlfredpayCustomerView> {
   const customerType = alfredpayTypeToCustomerType(values.type);
-  // Keep a profile's rows of one customer_type on a single entity. Legacy business rows
-  // live on the (active) individual entity, and ramp registration resolves the active
-  // entity — homing a new country's row on the typed entity instead would make that
-  // corridor unrampable for migrated profiles.
+  // Keep a profile's rows of one customer_type on a single entity, preferring the entity
+  // quote/ramp resolution actually reads — the active one. Legacy business rows live on the
+  // (active) individual entity, and a profile hit by the pre-fix duplicate bug can also
+  // carry a newer same-type row on a stray business entity; homing the new corridor there
+  // (or on the typed entity) would make it unrampable for migrated profiles.
   const entityIds = await findCustomerEntityIdsForProfile(userId);
-  const sibling =
+  const siblings =
     entityIds.length > 0
-      ? await ProviderCustomer.findOne({
+      ? await ProviderCustomer.findAll({
           order: [["updatedAt", "DESC"]],
           where: { customerEntityId: entityIds, customerType, provider: "alfredpay" }
         })
-      : null;
+      : [];
+  const activeEntityId = siblings.length > 0 ? (await User.findByPk(userId))?.activeCustomerEntityId : null;
+  const sibling = siblings.find(row => row.customerEntityId === activeEntityId) ?? siblings[0];
   const customerEntityId = sibling?.customerEntityId ?? (await getOrCreateCustomerEntityForProfile(userId, customerType)).id;
   const record = await ProviderCustomer.create({
     country: values.country,

--- a/apps/api/src/api/services/alfredpay/alfredpay-customer.service.ts
+++ b/apps/api/src/api/services/alfredpay/alfredpay-customer.service.ts
@@ -8,7 +8,7 @@ import {
 import logger from "../../../config/logger";
 import KycCase from "../../../models/kycCase.model";
 import ProviderCustomer, { ProviderCustomerType, VerificationStatus } from "../../../models/providerCustomer.model";
-import { getOrCreateCustomerEntityForProfile } from "../customer-entity.service";
+import { findCustomerEntityIdsForProfile, getOrCreateCustomerEntityForProfile } from "../customer-entity.service";
 
 export function alfredpayTypeToCustomerType(type: AlfredpayCustomerType): ProviderCustomerType {
   return type === AlfredpayCustomerType.BUSINESS ? "business" : "individual";
@@ -181,18 +181,30 @@ function toView(record: ProviderCustomer): AlfredpayCustomerView {
 /**
  * Latest alfredpay account for (user, country[, type]) — reproduces the legacy
  * updatedAt-DESC tie-break across a user's individual/business rows.
+ *
+ * Typed lookups scan every entity the profile owns: migration 040 attached legacy
+ * business rows to the profile's individual entity, so scoping to the same-typed entity
+ * made every migrated business customer invisible to the KYB endpoints (and findOrCreate'd
+ * an empty business entity as a side effect of a read). The row's customer_type is
+ * authoritative; the owning entity's type is not. Type-less lookups keep resolving the
+ * active entity — that is the quote/ramp account context and must not widen.
  */
 export async function findAlfredpayCustomer(
   userId: string,
   country: AlfredPayCountry,
   type?: AlfredpayCustomerType
 ): Promise<AlfredpayCustomerView | null> {
-  const entity = await getOrCreateCustomerEntityForProfile(userId, type ? alfredpayTypeToCustomerType(type) : undefined);
+  const entityIds = type
+    ? await findCustomerEntityIdsForProfile(userId)
+    : [(await getOrCreateCustomerEntityForProfile(userId)).id];
+  if (entityIds.length === 0) {
+    return null;
+  }
   const record = await ProviderCustomer.findOne({
     order: [["updatedAt", "DESC"]],
     where: {
       country,
-      customerEntityId: entity.id,
+      customerEntityId: entityIds,
       provider: "alfredpay",
       ...(type ? { customerType: alfredpayTypeToCustomerType(type) } : {})
     }
@@ -300,10 +312,22 @@ export async function createAlfredpayCustomer(
   values: { alfredPayId: string; country: AlfredPayCountry; status: AlfredPayStatus; type: AlfredpayCustomerType }
 ): Promise<AlfredpayCustomerView> {
   const customerType = alfredpayTypeToCustomerType(values.type);
-  const entity = await getOrCreateCustomerEntityForProfile(userId, customerType);
+  // Keep a profile's rows of one customer_type on a single entity. Legacy business rows
+  // live on the (active) individual entity, and ramp registration resolves the active
+  // entity — homing a new country's row on the typed entity instead would make that
+  // corridor unrampable for migrated profiles.
+  const entityIds = await findCustomerEntityIdsForProfile(userId);
+  const sibling =
+    entityIds.length > 0
+      ? await ProviderCustomer.findOne({
+          order: [["updatedAt", "DESC"]],
+          where: { customerEntityId: entityIds, customerType, provider: "alfredpay" }
+        })
+      : null;
+  const customerEntityId = sibling?.customerEntityId ?? (await getOrCreateCustomerEntityForProfile(userId, customerType)).id;
   const record = await ProviderCustomer.create({
     country: values.country,
-    customerEntityId: entity.id,
+    customerEntityId,
     customerType,
     provider: "alfredpay",
     providerCustomerId: values.alfredPayId,

--- a/apps/api/src/api/services/customer-entity.service.ts
+++ b/apps/api/src/api/services/customer-entity.service.ts
@@ -60,6 +60,26 @@ export async function getOrCreateCustomerEntityForProfile(
   return entity;
 }
 
+/**
+ * All customer entity ids owned by a profile, oldest first. Read-only counterpart to
+ * getOrCreateCustomerEntityForProfile for lookup/ownership paths: migration 040 attached
+ * legacy business provider rows to the profile's individual entity, so a row's owning
+ * entity does not reliably carry the row's customer_type — callers that filter provider
+ * rows by customer_type must scope by every entity the profile owns, and a pure lookup
+ * must not leave an empty entity behind.
+ */
+export async function findCustomerEntityIdsForProfile(profileId: string): Promise<string[]> {
+  const entities = await CustomerEntity.findAll({
+    attributes: ["id"],
+    order: [
+      ["createdAt", "ASC"],
+      ["id", "ASC"]
+    ],
+    where: { profileId }
+  });
+  return entities.map(entity => entity.id);
+}
+
 export async function selectActiveCustomerEntity(
   profileId: string,
   type: CustomerEntityType,

--- a/apps/api/src/tests/alfredpay-kyb-legacy-entity.integration.test.ts
+++ b/apps/api/src/tests/alfredpay-kyb-legacy-entity.integration.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  AlfredPayCountry,
+  AlfredPayStatus,
+  AlfredpayApiService,
+  AlfredpayCustomerType,
+  AlfredpayKycStatus
+} from "@vortexfi/shared";
+import { createAlfredpayCustomer, findAlfredpayCustomer } from "../api/services/alfredpay/alfredpay-customer.service";
+import { getOrCreateCustomerEntityForProfile } from "../api/services/customer-entity.service";
+import CustomerEntity from "../models/customerEntity.model";
+import KycCase from "../models/kycCase.model";
+import ProviderCustomer, { VerificationStatus } from "../models/providerCustomer.model";
+import { resetTestDatabase, setupTestDatabase } from "../test-utils/db";
+import { createTestUser } from "../test-utils/factories";
+import { type FakeSupabaseAuth, installFakeSupabaseAuth, testUserToken } from "../test-utils/fake-world/fake-auth";
+import { startTestApp, type TestApp } from "../test-utils/test-app";
+
+// Regression suite for the migrated-entity mismatch: migration 038 backfilled one *individual*
+// entity per profile, and migration 040 attached the legacy provider rows to it — including
+// business-typed (KYB) rows. Typed business lookups then resolved a fresh, empty *business*
+// entity, so every KYB wizard endpoint 404'd ("Alfredpay business customer not found") for
+// migrated business customers and left the stray entity behind, while the type-less
+// dashboard/ramp lookups kept finding the rows on the active entity — a resumable KYB the
+// wizard could not act on. Typed lookups now scan every entity the profile owns.
+
+let api: TestApp;
+let fakeAuth: FakeSupabaseAuth;
+const realGetInstance = AlfredpayApiService.getInstance;
+
+beforeAll(async () => {
+  await setupTestDatabase();
+  fakeAuth = installFakeSupabaseAuth();
+  api = await startTestApp();
+});
+
+afterAll(async () => {
+  await api.close();
+  fakeAuth.restore();
+});
+
+beforeEach(async () => {
+  await resetTestDatabase();
+});
+
+afterEach(() => {
+  AlfredpayApiService.getInstance = realGetInstance;
+});
+
+function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+// The exact post-migration production shape: a business-typed alfredpay row (plus its kyb
+// kyc_case) parked on the profile's active individual entity.
+async function seedLegacyBusinessCustomer(email: string) {
+  const user = await createTestUser({ email });
+  const token = testUserToken(user.id, email);
+  const entity = await getOrCreateCustomerEntityForProfile(user.id);
+  await user.update({ activeCustomerEntityId: entity.id });
+  const record = await ProviderCustomer.create({
+    country: "CO",
+    customerEntityId: entity.id,
+    customerType: "business",
+    provider: "alfredpay",
+    providerCustomerId: "ap-legacy-kyb",
+    rail: "cop",
+    status: VerificationStatus.Pending,
+    statusExternal: "PENDING"
+  });
+  await KycCase.create({
+    customerEntityId: entity.id,
+    level: "level_1",
+    provider: "alfredpay",
+    providerCaseId: "kyb-sub-legacy",
+    providerCustomerId: record.id,
+    status: VerificationStatus.Pending,
+    statusExternal: "PENDING",
+    type: "kyb"
+  });
+  return { entity, record, token, user };
+}
+
+// Carries the compliance questionnaire because `validateKybSubmission` rejects a submission
+// without it.
+const KYB_FORM = {
+  accountPurpose: "Treasury management",
+  address: "Calle 1 # 2-3",
+  businessActivities: "Cross-border payments software",
+  businessName: "Legacy SAS",
+  city: "Bogota",
+  country: "CO",
+  expectedMonthlyTransactions: 120,
+  expectedMonthlyVolumeUsd: 50000,
+  isRegulatedBusiness: false,
+  operatesInSanctionedCountries: false,
+  relatedPersons: [
+    {
+      dateOfBirth: "1990-01-01",
+      email: "rep@example.com",
+      firstName: "Ana",
+      lastName: "Rep",
+      nationalities: ["CO"],
+      pep: false
+    }
+  ],
+  sourceOfFunds: "Sale of goods/services",
+  state: "DC",
+  taxId: "900123456",
+  transmitsCustomerFunds: false,
+  walletAddresses: "N/A",
+  website: "https://legacy.example.com",
+  zipCode: "110111"
+};
+
+describe("Alfredpay KYB on a migrated (individual-entity) profile", () => {
+  it("typed and type-less lookups agree on the migrated business customer", async () => {
+    const { user } = await seedLegacyBusinessCustomer("kyb-legacy-agree@example.com");
+
+    const typeless = await findAlfredpayCustomer(user.id, AlfredPayCountry.CO);
+    const typed = await findAlfredpayCustomer(user.id, AlfredPayCountry.CO, AlfredpayCustomerType.BUSINESS);
+
+    expect(typeless?.alfredPayId).toBe("ap-legacy-kyb");
+    expect(typed?.alfredPayId).toBe("ap-legacy-kyb");
+  });
+
+  it("findKybCustomerAndBusiness resolves the migrated customer without creating a stray entity", async () => {
+    const { token, user } = await seedLegacyBusinessCustomer("kyb-legacy-find@example.com");
+
+    AlfredpayApiService.getInstance = mock(
+      () =>
+        ({
+          getKybBusinessDetails: mock(async () => [{ relatedPersons: [], submissionId: "kyb-sub-legacy" }])
+        }) as unknown as AlfredpayApiService
+    );
+
+    const response = await api.request("/v1/alfredpay/findKybCustomerAndBusiness?country=CO", {
+      headers: authHeaders(token)
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([{ relatedPersons: [], submissionId: "kyb-sub-legacy" }]);
+    expect(await CustomerEntity.count({ where: { profileId: user.id } })).toBe(1);
+  });
+
+  it("submitKybInformation resumes the migrated customer's pending submission in place", async () => {
+    const { token } = await seedLegacyBusinessCustomer("kyb-legacy-resume@example.com");
+
+    const updateKybInformation = mock(async (_customerId: string, _submissionId: string, _data: unknown) => undefined);
+    const submitKybInformation = mock(async () => ({ submissionId: "should-not-be-created" }));
+    AlfredpayApiService.getInstance = mock(
+      () =>
+        ({
+          getKybStatus: mock(async () => ({ status: AlfredpayKycStatus.PENDING })),
+          getLastKybSubmission: mock(async () => ({ submissionId: "kyb-sub-legacy" })),
+          submitKybInformation,
+          updateKybInformation
+        }) as unknown as AlfredpayApiService
+    );
+
+    const response = await api.request("/v1/alfredpay/submitKybInformation", {
+      body: JSON.stringify(KYB_FORM),
+      headers: authHeaders(token),
+      method: "POST"
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ submissionId: "kyb-sub-legacy" });
+    expect(updateKybInformation).toHaveBeenCalledTimes(1);
+    expect(updateKybInformation.mock.calls[0]).toEqual(["ap-legacy-kyb", "kyb-sub-legacy", KYB_FORM]);
+    expect(submitKybInformation).not.toHaveBeenCalled();
+  });
+
+  it("createBusinessCustomer refuses to duplicate the migrated customer", async () => {
+    const { token } = await seedLegacyBusinessCustomer("kyb-legacy-duplicate@example.com");
+
+    const createCustomer = mock(async () => ({ customerId: "ap-duplicate" }));
+    AlfredpayApiService.getInstance = mock(() => ({ createCustomer }) as unknown as AlfredpayApiService);
+
+    const response = await api.request("/v1/alfredpay/createBusinessCustomer", {
+      body: JSON.stringify({ country: "CO" }),
+      headers: authHeaders(token),
+      method: "POST"
+    });
+
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { error: string }).error).toBe("Business customer already exists");
+    expect(createCustomer).not.toHaveBeenCalled();
+    expect(await ProviderCustomer.count({ where: { provider: "alfredpay" } })).toBe(1);
+  });
+
+  it("a typed lookup with no business rows answers 404 without creating an entity", async () => {
+    const email = "kyb-no-rows@example.com";
+    const user = await createTestUser({ email });
+    const token = testUserToken(user.id, email);
+    await getOrCreateCustomerEntityForProfile(user.id);
+
+    const response = await api.request("/v1/alfredpay/findKybCustomerAndBusiness?country=CO", {
+      headers: authHeaders(token)
+    });
+
+    expect(response.status).toBe(404);
+    expect(await CustomerEntity.count({ where: { profileId: user.id } })).toBe(1);
+  });
+
+  it("createAlfredpayCustomer homes a new corridor's business row with the existing legacy rows", async () => {
+    const { entity, user } = await seedLegacyBusinessCustomer("kyb-legacy-colocate@example.com");
+
+    // Ramp registration resolves the active entity — a new corridor's row must land next to
+    // the legacy rows there, not on a fresh business entity it can never reach.
+    await createAlfredpayCustomer(user.id, {
+      alfredPayId: "ap-legacy-mx",
+      country: AlfredPayCountry.MX,
+      status: AlfredPayStatus.Consulted,
+      type: AlfredpayCustomerType.BUSINESS
+    });
+
+    const created = await ProviderCustomer.findOne({ where: { providerCustomerId: "ap-legacy-mx" } });
+    expect(created?.customerEntityId).toBe(entity.id);
+    expect(await CustomerEntity.count({ where: { profileId: user.id } })).toBe(1);
+  });
+});

--- a/apps/api/src/tests/alfredpay-kyb-legacy-entity.integration.test.ts
+++ b/apps/api/src/tests/alfredpay-kyb-legacy-entity.integration.test.ts
@@ -219,4 +219,32 @@ describe("Alfredpay KYB on a migrated (individual-entity) profile", () => {
     expect(created?.customerEntityId).toBe(entity.id);
     expect(await CustomerEntity.count({ where: { profileId: user.id } })).toBe(1);
   });
+
+  it("createAlfredpayCustomer prefers the active entity when rows are split across entities", async () => {
+    const { entity, user } = await seedLegacyBusinessCustomer("kyb-legacy-split@example.com");
+
+    // A profile hit by the pre-fix duplicate bug: a *newer* same-type row sits on a stray
+    // business entity. The new corridor must still land on the active entity — the only one
+    // quote/ramp resolution reads — not on the most recently updated sibling's entity.
+    const strayBusinessEntity = await CustomerEntity.create({ profileId: user.id, status: "active", type: "business" });
+    await ProviderCustomer.create({
+      country: "MX",
+      customerEntityId: strayBusinessEntity.id,
+      customerType: "business",
+      provider: "alfredpay",
+      providerCustomerId: "ap-legacy-duplicate",
+      rail: "mxn",
+      status: VerificationStatus.Started
+    });
+
+    await createAlfredpayCustomer(user.id, {
+      alfredPayId: "ap-legacy-us",
+      country: AlfredPayCountry.US,
+      status: AlfredPayStatus.Consulted,
+      type: AlfredpayCustomerType.BUSINESS
+    });
+
+    const created = await ProviderCustomer.findOne({ where: { providerCustomerId: "ap-legacy-us" } });
+    expect(created?.customerEntityId).toBe(entity.id);
+  });
 });

--- a/docs/architecture-identity-model.md
+++ b/docs/architecture-identity-model.md
@@ -55,6 +55,12 @@ fields required by runtime behavior.
 the normalized lifecycle `started`, `pending`, `in_review`, `approved`, or `rejected`,
 while `status_external` preserves a provider's original value when one exists.
 
+Legacy placement caveat: the migration 040 backfill attached pre-cutover provider rows to
+the profile's 038-backfilled *individual* entity — including business-typed rows. The
+row's `customer_type` is therefore authoritative for type-scoped lookups; the owning
+entity's `type` is not. Typed provider lookups and ownership checks scope by profile, and
+new alfredpay rows co-locate with a profile's existing rows of the same `customer_type`.
+
 Avenia is the one current exception to the general preference against retaining raw tax
 references: `provider_customers.tax_reference` remains a runtime join key for in-flight
 ramp state. Its SHA-256 value backs lookup and uniqueness; masked display is derived at

--- a/docs/security-spec/05-integrations/alfredpay.md
+++ b/docs/security-spec/05-integrations/alfredpay.md
@@ -143,9 +143,11 @@ Alfredpay identity moved from `alfredpay_customers` (keyed by `user_id`) to
   profile's (038-backfilled) individual entity, so scoping to the same-typed entity made
   migrated business customers invisible to every KYB endpoint and findOrCreate'd stray
   empty business entities as a side effect of reads. `createAlfredpayCustomer` homes a new
-  row on the entity already carrying the profile's alfredpay rows of that `customer_type`
-  (typed entity otherwise), so ramp registration — which resolves the active entity — keeps
-  seeing every corridor of a migrated profile. `lookupAlfredpayCustomerType` keeps the
-  type-ASC precedence ('business' < 'individual').
+  row on the entity already carrying the profile's alfredpay rows of that `customer_type`,
+  preferring the *active* entity when such rows are split across entities (a pre-fix
+  duplicate can sit on a stray business entity) and falling back to the typed entity, so
+  ramp registration — which resolves the active entity — keeps seeing every corridor of a
+  migrated profile. `lookupAlfredpayCustomerType` keeps the type-ASC precedence
+  ('business' < 'individual').
 - Canonical and external status transitions mirror into the account's `kyc_cases` row in the same code path.
 - The legacy `alfredpay_customers` table is a read-only backup with no remaining readers.

--- a/docs/security-spec/05-integrations/alfredpay.md
+++ b/docs/security-spec/05-integrations/alfredpay.md
@@ -136,8 +136,16 @@ Alfredpay identity moved from `alfredpay_customers` (keyed by `user_id`) to
   `IN_REVIEW`, `COMPLETED`, and `FAILED` map to `in_review`, `approved`, and `rejected`
   respectively.
 - All controller lookups go through `findAlfredpayCustomer(userId, country[, type])`, which
-  resolves the caller's `customer_entity` first and preserves the legacy updatedAt-DESC
-  tie-break across a user's individual/business rows; `lookupAlfredpayCustomerType` keeps the
+  preserves the legacy updatedAt-DESC tie-break across a user's individual/business rows.
+  Type-less lookups resolve the caller's active `customer_entity` (the quote/ramp account
+  context). Typed lookups scope by the row's `customer_type` across every entity the profile
+  owns, and never create entities: migration 040 attached legacy business rows to the
+  profile's (038-backfilled) individual entity, so scoping to the same-typed entity made
+  migrated business customers invisible to every KYB endpoint and findOrCreate'd stray
+  empty business entities as a side effect of reads. `createAlfredpayCustomer` homes a new
+  row on the entity already carrying the profile's alfredpay rows of that `customer_type`
+  (typed entity otherwise), so ramp registration — which resolves the active entity — keeps
+  seeing every corridor of a migrated profile. `lookupAlfredpayCustomerType` keeps the
   type-ASC precedence ('business' < 'individual').
 - Canonical and external status transitions mirror into the account's `kyc_cases` row in the same code path.
 - The legacy `alfredpay_customers` table is a read-only backup with no remaining readers.

--- a/docs/security-spec/05-integrations/brla.md
+++ b/docs/security-spec/05-integrations/brla.md
@@ -165,8 +165,14 @@ Key properties:
 - Ownership gaps closed in the cutover: `fetchSubaccountKycStatus` (which also WRITES status
   transitions) and `getSelfieLivenessUrl` require the effective user to own the account.
   KYB initiation stores Avenia's opaque attempt ID in the owned `kyc_cases.provider_case_id`;
-  `getKybAttemptStatus` resolves that binding and verifies entity ownership before querying Avenia.
+  `getKybAttemptStatus` resolves that binding and verifies ownership before querying Avenia.
   The browser receives only normalized status/result fields, never provider submission data.
+- Ownership is profile-level: a row must belong to one of the effective user's customer
+  entities, never to a specific typed entity. Migration 040 attached legacy business rows to
+  the profile's individual entity, so comparing against the typed business entity 403'd/409'd
+  the legitimate owner (`getUploadUrls`, `getKybAttemptStatus`, the `createSubaccount`
+  conflict check) and findOrCreate'd stray empty business entities as a read side effect.
+  Cross-profile requests still fail closed.
 - KYC/KYB state transitions update canonical status and provider status on both
   `provider_customers` and the account's `kyc_cases` row in the same code path.
   `updateAveniaKycOutcome` treats `approved` as terminal (a stale attempt read never

--- a/docs/security-spec/05-integrations/brla.md
+++ b/docs/security-spec/05-integrations/brla.md
@@ -172,7 +172,9 @@ Key properties:
   the profile's individual entity, so comparing against the typed business entity 403'd/409'd
   the legitimate owner (`getUploadUrls`, `getKybAttemptStatus`, the `createSubaccount`
   conflict check) and findOrCreate'd stray empty business entities as a read side effect.
-  Cross-profile requests still fail closed.
+  `createSubaccount` defers typed-entity creation to the branches that persist a new row,
+  so a retry that updates an existing row creates no entity. Cross-profile requests still
+  fail closed.
 - KYC/KYB state transitions update canonical status and provider status on both
   `provider_customers` and the account's `kyc_cases` row in the same code path.
   `updateAveniaKycOutcome` treats `approved` as terminal (a stale attempt read never


### PR DESCRIPTION
## Summary

Migration 040 backfilled legacy provider rows onto the individual entities created by migration 038 — including business-typed (KYB) rows. Typed business lookups resolved (and `findOrCreate`'d) a same-typed entity instead, so for every migrated business customer:

- all Alfredpay KYB wizard endpoints 404'd with "Alfredpay business customer not found" (or created a duplicate Alfredpay customer via `createBusinessCustomer`),
- the Avenia KYB paths (`getUploadUrls`, `getKybAttemptStatus`, the `createSubaccount` conflict check) 403'd/409'd the legitimate owner,
- while type-less dashboard/ramp lookups (active entity) still found the rows — showing a resumable KYB the wizard could not act on,
- and every typed read left a stray empty business entity behind as a side effect.

Verified blast radius in production (2026-08-03): 13 business-typed `provider_customers` rows on individual-typed entities across 11 profiles.

## Approach

Legacy-tolerant reads at the consumer level, no data migration:

- `findAlfredpayCustomer` typed lookups scope by the row's `customer_type` across **all** entities the profile owns, and never create entities. Type-less lookups keep resolving the active entity (the quote/ramp account context is unchanged).
- The three Avenia ownership checks compare **profile-level** ownership instead of a typed entity id; cross-profile requests still fail closed.
- `createAlfredpayCustomer` co-locates a new corridor's row with the profile's existing same-type rows, so ramp registration (active-entity scoped) keeps seeing every corridor of a migrated profile.

A re-homing data migration was rejected: type-less ramp registration resolves the *active* entity, so moving rows breaks ramping unless the active pointer moves too. A fallback inside the shared `getOrCreateCustomerEntityForProfile` was rejected because Monerium explicitly 400s on type-mismatched entities — it would have broken Monerium business onboarding for exactly these profiles.

Security spec (`05-integrations/alfredpay.md`, `05-integrations/brla.md`) and `docs/architecture-identity-model.md` are updated in the same change.

## Test plan

- New integration suite `alfredpay-kyb-legacy-entity.integration.test.ts` seeds the exact migrated shape (business row + kyb case on the active individual entity); all 6 tests fail on unfixed staging code and pass with the fix — including "no stray entity created" and "no duplicate Alfredpay customer" regressions.
- New unit tests in `brla.controller.test.ts` cover legacy-ownership acceptance for `getUploadUrls`, `getKybAttemptStatus`, and the `createSubaccount` retry, plus cross-profile rejection.
- Full api suite: 933 pass / 0 fail. `bun verify` and monorepo `bun typecheck` clean.