### PR TITLE
test(dashboard): align e2e amount formatting

### DIFF
--- a/apps/dashboard/e2e/funding-gate.spec.ts
+++ b/apps/dashboard/e2e/funding-gate.spec.ts
@@ -23,7 +23,7 @@ test("funding panel offers connected-wallet submission only", async ({ page }) =
   await expect(page.getByText("Connected")).toBeVisible({ timeout: 20_000 });
 
   await expect(page.getByText("Send crypto")).toHaveCount(0);
-  await expect(page.getByText("Available: 1000.00 USDC on Polygon", { exact: true })).toBeVisible();
+  await expect(page.getByText("Available: 1,000 USDC on Polygon", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: /^Send/ })).toBeEnabled();
   await expect(page.getByText(/reach out to/)).toHaveCount(0);
   expect(backend.balanceRequests.at(-1)).toMatchObject({ network: "polygon-mainnet" });
@@ -40,8 +40,8 @@ test("insufficient selected-network USDC balance blocks an offramp", async ({ pa
 
   await page.locator("#token-amount").fill("54.054054");
 
-  await expect(page.getByText("Available: 50.00 USDC on Polygon", { exact: true })).toBeVisible({ timeout: 20_000 });
-  await expect(page.getByText(/Insufficient USDC balance.*54\.054054 USDC on Polygon/)).toBeVisible();
+  await expect(page.getByText("Available: 50 USDC on Polygon", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText(/Insufficient USDC balance.*54\.054 USDC on Polygon/)).toBeVisible();
   await expect(page.getByRole("button", { name: /^Send/ })).toBeDisabled();
   expect(backend.registerRequests).toHaveLength(0);
 });
@@ -64,7 +64,7 @@ test("balance check follows the selected payin network, not the wallet chain", a
   await page.getByRole("combobox").filter({ hasText: "Polygon" }).click();
   await page.getByRole("option", { exact: true, name: "Arbitrum One" }).click();
 
-  await expect(page.getByText("Available: 1.00 USDC on Arbitrum One", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText("Available: 1 USDC on Arbitrum One", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(sendButton).toBeDisabled();
   expect(backend.balanceRequests.map(request => request.network)).toEqual(
     expect.arrayContaining(["polygon-mainnet", "arb-mainnet"])
@@ -118,7 +118,7 @@ test("balance gate checks the selected ERC-20 rather than another held token", a
   await page.getByRole("option", { exact: true, name: "USDT" }).click();
   await page.locator("#token-amount").fill("100");
 
-  await expect(page.getByText("Available: 50.00 USDT on Polygon", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText("Available: 50 USDT on Polygon", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(page.getByText(/Insufficient USDT balance/)).toBeVisible();
   await expect(page.getByRole("button", { name: /^Send/ })).toBeDisabled();
   expect(backend.registerRequests).toHaveLength(0);
@@ -134,7 +134,7 @@ test("native POL uses the portfolio native balance", async ({ page }) => {
   await page.getByRole("option", { exact: true, name: "POL" }).click();
   await page.locator("#token-amount").fill("1");
 
-  await expect(page.getByText("Available: 2.000000 POL on Polygon", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText("Available: 2 POL on Polygon", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(page.getByRole("button", { name: /Send ≈ 1 POL/ })).toBeEnabled();
 });
 

--- a/apps/dashboard/e2e/onramp-journeys.spec.ts
+++ b/apps/dashboard/e2e/onramp-journeys.spec.ts
@@ -47,7 +47,7 @@ test("Onramp prefills the connected wallet but keeps a manually edited destinati
   await expect(destination).toHaveValue(DESTINATION);
   await expect(page.getByText("1 MXN = 0.2022 USDC", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Fee details" }).click();
-  await expect(page.getByText("1 MXN = 0.1820 USDC", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 MXN = 0.182 USDC", { exact: true })).toBeVisible();
 
   expect(backend.unmatchedRequests).toEqual([]);
   expect(backend.unexpectedExternalRequests).toEqual([]);

--- a/apps/dashboard/e2e/transfer-mxn-journey.spec.ts
+++ b/apps/dashboard/e2e/transfer-mxn-journey.spec.ts
@@ -60,7 +60,7 @@ test("SELL MXN transfer: quote, register, ephemeral presigning, wallet broadcast
   await expect(sendButton).toContainText(DISPLAY_PAYIN_USDC);
   await expect(page.getByText("1 USDC = 18.69 MXN", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Fee details" }).click();
-  await expect(page.getByText("1 USDC = 18.50 MXN", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 USDC = 18.5 MXN", { exact: true })).toBeVisible();
 
   // Stage 3: submitting runs register -> presign -> user signing -> start. The form toasts and
   // navigates once the machine reaches Tracking.


### PR DESCRIPTION
## Summary

- align dashboard E2E balance expectations with locale-aware amount formatting
- update fee-rate assertions for trimmed insignificant zeroes
- keep the insufficient-balance assertion consistent with the four-decimal crypto display cap

## Verification

- `env CI=true bun run test:e2e -- --retries=0`
- 65 dashboard E2E tests passed

Fixes the failure observed in https://github.com/pendulum-chain/vortex/actions/runs/31070131394/job/92516156318.
