### PR TITLE
Wire the Settings email notification toggles to the backend

### DIFF
--- a/apps/api/src/models/emailNotification.model.ts
+++ b/apps/api/src/models/emailNotification.model.ts
@@ -1,3 +1,4 @@
+import { EmailNotificationType } from "@vortexfi/shared";
 import { DataTypes, Model, Optional } from "sequelize";
 import sequelize from "../config/database";
 
@@ -9,12 +10,11 @@ export enum NotificationProvider {
   Vortex = "vortex"
 }
 
-export enum NotificationType {
-  RampCompleted = "ramp_completed",
-  VerificationApproved = "verification_approved",
-  VerificationExpired = "verification_expired",
-  VerificationRejected = "verification_rejected"
-}
+// The stored type values live in @vortexfi/shared: they are the wire contract with the
+// dashboard's notification-preference toggles, which write prefs keyed by these strings.
+// Re-exported under the model's historical name for the API's existing imports.
+export { EmailNotificationType as NotificationType };
+type NotificationType = EmailNotificationType;
 
 export enum NotificationStatus {
   Abandoned = "abandoned",

--- a/apps/dashboard/src/hooks/useNotificationPreferences.test.ts
+++ b/apps/dashboard/src/hooks/useNotificationPreferences.test.ts
@@ -1,0 +1,64 @@
+import { QueryClient } from "@tanstack/react-query";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { NotificationPreferencesDto } from "@/services/api/notification-preferences.service";
+import { createPreferencesMutationHandlers, NOTIFICATION_PREFERENCES_QUERY_KEY } from "./useNotificationPreferences";
+
+const SAVED: NotificationPreferencesDto = { emailEnabled: true, prefs: { ramp_completed: true, verification_approved: true } };
+
+function clientWith(data: NotificationPreferencesDto | undefined) {
+  const queryClient = new QueryClient();
+  if (data) {
+    queryClient.setQueryData(NOTIFICATION_PREFERENCES_QUERY_KEY, data);
+  }
+  return queryClient;
+}
+
+function cached(queryClient: QueryClient): NotificationPreferencesDto | undefined {
+  return queryClient.getQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY);
+}
+
+describe("preferences mutation handlers", () => {
+  it("optimistically applies the update and returns the snapshot", async () => {
+    const queryClient = clientWith(SAVED);
+    const handlers = createPreferencesMutationHandlers(queryClient);
+
+    const context = await handlers.onMutate({ prefs: { ...SAVED.prefs, ramp_completed: false } });
+
+    assert.deepEqual(context.previous, SAVED);
+    assert.deepEqual(cached(queryClient), {
+      emailEnabled: true,
+      prefs: { ramp_completed: false, verification_approved: true }
+    });
+  });
+
+  it("carries a lifted master switch into the optimistic cache", async () => {
+    const queryClient = clientWith({ emailEnabled: false, prefs: {} });
+    const handlers = createPreferencesMutationHandlers(queryClient);
+
+    await handlers.onMutate({ emailEnabled: true, prefs: { ramp_completed: true } });
+
+    assert.equal(cached(queryClient)?.emailEnabled, true);
+  });
+
+  it("rolls the cache back when the PUT fails", async () => {
+    const queryClient = clientWith(SAVED);
+    const handlers = createPreferencesMutationHandlers(queryClient);
+
+    const context = await handlers.onMutate({ prefs: { ramp_completed: false } });
+    handlers.onError(new Error("PUT failed"), { prefs: { ramp_completed: false } }, context);
+
+    assert.deepEqual(cached(queryClient), SAVED);
+  });
+
+  it("does not fabricate cache state when nothing was loaded", async () => {
+    const queryClient = clientWith(undefined);
+    const handlers = createPreferencesMutationHandlers(queryClient);
+
+    const context = await handlers.onMutate({ prefs: { ramp_completed: false } });
+    handlers.onError(new Error("PUT failed"), { prefs: { ramp_completed: false } }, context);
+
+    assert.equal(context.previous, undefined);
+    assert.equal(cached(queryClient), undefined);
+  });
+});

--- a/apps/dashboard/src/hooks/useNotificationPreferences.ts
+++ b/apps/dashboard/src/hooks/useNotificationPreferences.ts
@@ -1,13 +1,44 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type EmailNotificationCategory,
   isCategoryEnabled,
   type NotificationPreferencesDto,
   NotificationPreferencesService,
-  prefsWithCategory
+  type NotificationPreferencesUpdate,
+  preferencesUpdateFor
 } from "@/services/api/notification-preferences.service";
 
 export const NOTIFICATION_PREFERENCES_QUERY_KEY = ["notification-preferences"] as const;
+
+/**
+ * Optimistic-update handlers for the preferences mutation, extracted so the cache and
+ * rollback semantics are testable against a real QueryClient without rendering React.
+ */
+export function createPreferencesMutationHandlers(queryClient: QueryClient) {
+  return {
+    onError: (
+      _error: unknown,
+      _update: NotificationPreferencesUpdate,
+      context: { previous: NotificationPreferencesDto | undefined } | undefined
+    ) => {
+      if (context?.previous) {
+        queryClient.setQueryData(NOTIFICATION_PREFERENCES_QUERY_KEY, context.previous);
+      }
+    },
+    onMutate: async (update: NotificationPreferencesUpdate) => {
+      await queryClient.cancelQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY });
+      const previous = queryClient.getQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY);
+      if (previous) {
+        queryClient.setQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY, {
+          emailEnabled: update.emailEnabled ?? previous.emailEnabled,
+          prefs: update.prefs
+        });
+      }
+      return { previous };
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY })
+  };
+}
 
 /**
  * The user's email notification opt-outs, exposed as per-category toggles.
@@ -23,29 +54,28 @@ export function useNotificationPreferences() {
   });
 
   const mutation = useMutation({
-    mutationFn: NotificationPreferencesService.updatePrefs,
-    onError: (_error, _prefs, previous) => {
-      if (previous) {
-        queryClient.setQueryData(NOTIFICATION_PREFERENCES_QUERY_KEY, previous);
-      }
-    },
-    onMutate: async prefs => {
-      await queryClient.cancelQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY });
-      const previous = queryClient.getQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY);
-      if (previous) {
-        queryClient.setQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY, { ...previous, prefs });
-      }
-      return previous;
-    },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY })
+    mutationFn: NotificationPreferencesService.update,
+    ...createPreferencesMutationHandlers(queryClient)
   });
 
   const categoryEnabled = (category: EmailNotificationCategory): boolean =>
-    query.data ? isCategoryEnabled(query.data.prefs, category) : true;
+    query.data ? isCategoryEnabled(query.data, category) : true;
 
+  // Never PUT before the GET has resolved: the update is a full document, so a body
+  // built from a fallback would replace the saved preferences and wipe keys this page
+  // does not own.
   const setCategoryEnabled = (category: EmailNotificationCategory, enabled: boolean): void => {
-    mutation.mutate(prefsWithCategory(query.data?.prefs ?? {}, category, enabled));
+    if (!query.data) {
+      return;
+    }
+    mutation.mutate(preferencesUpdateFor(query.data, category, enabled));
   };
 
-  return { categoryEnabled, isLoading: query.isLoading, setCategoryEnabled };
+  return {
+    categoryEnabled,
+    // Interactive only with loaded data and no PUT in flight: overlapping full-document
+    // PUTs can complete out of order, with the older snapshot winning.
+    controlsDisabled: query.data === undefined || mutation.isPending,
+    setCategoryEnabled
+  };
 }

--- a/apps/dashboard/src/hooks/useNotificationPreferences.ts
+++ b/apps/dashboard/src/hooks/useNotificationPreferences.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type EmailNotificationCategory,
+  isCategoryEnabled,
+  type NotificationPreferencesDto,
+  NotificationPreferencesService,
+  prefsWithCategory
+} from "@/services/api/notification-preferences.service";
+
+export const NOTIFICATION_PREFERENCES_QUERY_KEY = ["notification-preferences"] as const;
+
+/**
+ * The user's email notification opt-outs, exposed as per-category toggles.
+ * Toggles apply optimistically — a checkbox that lags its click reads as broken —
+ * and roll back if the PUT fails.
+ */
+export function useNotificationPreferences() {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryFn: NotificationPreferencesService.get,
+    queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY
+  });
+
+  const mutation = useMutation({
+    mutationFn: NotificationPreferencesService.updatePrefs,
+    onError: (_error, _prefs, previous) => {
+      if (previous) {
+        queryClient.setQueryData(NOTIFICATION_PREFERENCES_QUERY_KEY, previous);
+      }
+    },
+    onMutate: async prefs => {
+      await queryClient.cancelQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY });
+      const previous = queryClient.getQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY);
+      if (previous) {
+        queryClient.setQueryData<NotificationPreferencesDto>(NOTIFICATION_PREFERENCES_QUERY_KEY, { ...previous, prefs });
+      }
+      return previous;
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY })
+  });
+
+  const categoryEnabled = (category: EmailNotificationCategory): boolean =>
+    query.data ? isCategoryEnabled(query.data.prefs, category) : true;
+
+  const setCategoryEnabled = (category: EmailNotificationCategory, enabled: boolean): void => {
+    mutation.mutate(prefsWithCategory(query.data?.prefs ?? {}, category, enabled));
+  };
+
+  return { categoryEnabled, isLoading: query.isLoading, setCategoryEnabled };
+}

--- a/apps/dashboard/src/routes/_app/settings.tsx
+++ b/apps/dashboard/src/routes/_app/settings.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/_app/settings")({
 function SettingsPage() {
   const user = useAuthStore(state => state.user);
   const account = useActiveAccount();
-  const { categoryEnabled, isLoading: preferencesLoading, setCategoryEnabled } = useNotificationPreferences();
+  const { categoryEnabled, controlsDisabled, setCategoryEnabled } = useNotificationPreferences();
 
   return (
     <Stagger className="mx-auto grid max-w-3xl gap-6">
@@ -74,7 +74,7 @@ function SettingsPage() {
               >
                 <Checkbox
                   checked={categoryEnabled(pref.id)}
-                  disabled={preferencesLoading}
+                  disabled={controlsDisabled}
                   id={pref.id}
                   onCheckedChange={checked => setCategoryEnabled(pref.id, checked === true)}
                 />

--- a/apps/dashboard/src/routes/_app/settings.tsx
+++ b/apps/dashboard/src/routes/_app/settings.tsx
@@ -7,28 +7,22 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useActiveAccount } from "@/hooks/useActiveAccount";
+import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
+import type { EmailNotificationCategory } from "@/services/api/notification-preferences.service";
 import { useAuthStore } from "@/stores/auth.store";
 
-const NOTIFICATION_PREFS = [
+const NOTIFICATION_PREFS: Array<{ id: EmailNotificationCategory; label: string; description: string }> = [
   {
-    defaultChecked: true,
     description: "When a corridor's KYB/KYC is approved or rejected.",
     id: "onboarding",
     label: "Onboarding updates"
   },
   {
-    defaultChecked: true,
-    description: "When an invited recipient completes KYC/KYB.",
-    id: "recipients",
-    label: "Recipient approvals"
-  },
-  {
-    defaultChecked: true,
-    description: "When a wallet-to-fiat pay-out settles or fails.",
+    description: "When a ramp settles.",
     id: "transfers",
     label: "Transfer status"
   }
-] as const;
+];
 
 export const Route = createFileRoute("/_app/settings")({
   component: SettingsPage
@@ -37,6 +31,7 @@ export const Route = createFileRoute("/_app/settings")({
 function SettingsPage() {
   const user = useAuthStore(state => state.user);
   const account = useActiveAccount();
+  const { categoryEnabled, isLoading: preferencesLoading, setCategoryEnabled } = useNotificationPreferences();
 
   return (
     <Stagger className="mx-auto grid max-w-3xl gap-6">
@@ -77,7 +72,12 @@ function SettingsPage() {
                 htmlFor={pref.id}
                 key={pref.id}
               >
-                <Checkbox defaultChecked={pref.defaultChecked} id={pref.id} />
+                <Checkbox
+                  checked={categoryEnabled(pref.id)}
+                  disabled={preferencesLoading}
+                  id={pref.id}
+                  onCheckedChange={checked => setCategoryEnabled(pref.id, checked === true)}
+                />
                 <span className="grid gap-0.5">
                   <span className="font-medium text-sm">{pref.label}</span>
                   <span className="text-muted-foreground text-xs">{pref.description}</span>

--- a/apps/dashboard/src/services/api/notification-preferences.service.test.ts
+++ b/apps/dashboard/src/services/api/notification-preferences.service.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CATEGORY_TYPE_KEYS, isCategoryEnabled, prefsWithCategory } from "./notification-preferences.service";
+
+describe("category type keys", () => {
+  // The dispatch worker consults prefs[<stored type>], and the PUT endpoint accepts any
+  // keys without validation — a drifted string would mute nothing, silently. These
+  // literals are the wire contract with apps/api's NotificationType enum.
+  it("match the stored notification type strings the API dispatches on", () => {
+    assert.deepEqual(CATEGORY_TYPE_KEYS.onboarding, ["verification_approved", "verification_rejected", "verification_expired"]);
+    assert.deepEqual(CATEGORY_TYPE_KEYS.transfers, ["ramp_completed"]);
+  });
+});
+
+describe("isCategoryEnabled", () => {
+  it("treats missing keys as enabled (email is opt-out)", () => {
+    assert.equal(isCategoryEnabled({}, "onboarding"), true);
+    assert.equal(isCategoryEnabled({}, "transfers"), true);
+  });
+
+  it("only an explicit false mutes", () => {
+    assert.equal(isCategoryEnabled({ ramp_completed: true }, "transfers"), true);
+    assert.equal(isCategoryEnabled({ ramp_completed: false }, "transfers"), false);
+  });
+
+  it("shows a partially muted category as off", () => {
+    assert.equal(isCategoryEnabled({ verification_rejected: false }, "onboarding"), false);
+  });
+});
+
+describe("prefsWithCategory", () => {
+  it("sets every type of the category", () => {
+    assert.deepEqual(prefsWithCategory({}, "onboarding", false), {
+      verification_approved: false,
+      verification_expired: false,
+      verification_rejected: false
+    });
+  });
+
+  it("re-enabling heals a partial mute", () => {
+    const healed = prefsWithCategory({ verification_rejected: false }, "onboarding", true);
+    assert.equal(isCategoryEnabled(healed, "onboarding"), true);
+  });
+
+  it("preserves keys it does not own", () => {
+    const prefs = prefsWithCategory({ ramp_completed: false, someday_a_new_type: false }, "onboarding", true);
+    assert.equal(prefs.ramp_completed, false);
+    assert.equal(prefs.someday_a_new_type, false);
+  });
+});

--- a/apps/dashboard/src/services/api/notification-preferences.service.test.ts
+++ b/apps/dashboard/src/services/api/notification-preferences.service.test.ts
@@ -1,36 +1,62 @@
+import { EmailNotificationType } from "@vortexfi/shared";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { CATEGORY_TYPE_KEYS, isCategoryEnabled, prefsWithCategory } from "./notification-preferences.service";
+import {
+  CATEGORY_TYPE_KEYS,
+  isCategoryEnabled,
+  type NotificationPreferencesDto,
+  preferencesUpdateFor
+} from "./notification-preferences.service";
+
+function dto(prefs: Record<string, unknown> = {}, emailEnabled = true): NotificationPreferencesDto {
+  return { emailEnabled, prefs };
+}
 
 describe("category type keys", () => {
-  // The dispatch worker consults prefs[<stored type>], and the PUT endpoint accepts any
-  // keys without validation — a drifted string would mute nothing, silently. These
-  // literals are the wire contract with apps/api's NotificationType enum.
-  it("match the stored notification type strings the API dispatches on", () => {
-    assert.deepEqual(CATEGORY_TYPE_KEYS.onboarding, ["verification_approved", "verification_rejected", "verification_expired"]);
-    assert.deepEqual(CATEGORY_TYPE_KEYS.transfers, ["ramp_completed"]);
+  // The dispatch worker consults prefs[<stored type>]; both sides consume the shared
+  // EmailNotificationType enum so the strings cannot drift between workspaces.
+  it("cover every stored notification type exactly once", () => {
+    const mapped = Object.values(CATEGORY_TYPE_KEYS).flat().sort();
+    assert.deepEqual(mapped, Object.values(EmailNotificationType).sort());
+  });
+
+  it("group verification under onboarding and ramp completion under transfers", () => {
+    assert.deepEqual(CATEGORY_TYPE_KEYS.onboarding, [
+      EmailNotificationType.VerificationApproved,
+      EmailNotificationType.VerificationRejected,
+      EmailNotificationType.VerificationExpired
+    ]);
+    assert.deepEqual(CATEGORY_TYPE_KEYS.transfers, [EmailNotificationType.RampCompleted]);
   });
 });
 
 describe("isCategoryEnabled", () => {
   it("treats missing keys as enabled (email is opt-out)", () => {
-    assert.equal(isCategoryEnabled({}, "onboarding"), true);
-    assert.equal(isCategoryEnabled({}, "transfers"), true);
+    assert.equal(isCategoryEnabled(dto(), "onboarding"), true);
+    assert.equal(isCategoryEnabled(dto(), "transfers"), true);
   });
 
   it("only an explicit false mutes", () => {
-    assert.equal(isCategoryEnabled({ ramp_completed: true }, "transfers"), true);
-    assert.equal(isCategoryEnabled({ ramp_completed: false }, "transfers"), false);
+    assert.equal(isCategoryEnabled(dto({ ramp_completed: true }), "transfers"), true);
+    assert.equal(isCategoryEnabled(dto({ ramp_completed: false }), "transfers"), false);
   });
 
   it("shows a partially muted category as off", () => {
-    assert.equal(isCategoryEnabled({ verification_rejected: false }, "onboarding"), false);
+    assert.equal(isCategoryEnabled(dto({ verification_rejected: false }), "onboarding"), false);
+  });
+
+  it("shows every category as off while the master switch is off", () => {
+    assert.equal(isCategoryEnabled(dto({}, false), "onboarding"), false);
+    assert.equal(isCategoryEnabled(dto({}, false), "transfers"), false);
   });
 });
 
-describe("prefsWithCategory", () => {
-  it("sets every type of the category", () => {
-    assert.deepEqual(prefsWithCategory({}, "onboarding", false), {
+describe("preferencesUpdateFor", () => {
+  it("normally updates only prefs, setting every type of the category", () => {
+    const update = preferencesUpdateFor(dto(), "onboarding", false);
+
+    assert.equal(update.emailEnabled, undefined);
+    assert.deepEqual(update.prefs, {
       verification_approved: false,
       verification_expired: false,
       verification_rejected: false
@@ -38,13 +64,33 @@ describe("prefsWithCategory", () => {
   });
 
   it("re-enabling heals a partial mute", () => {
-    const healed = prefsWithCategory({ verification_rejected: false }, "onboarding", true);
-    assert.equal(isCategoryEnabled(healed, "onboarding"), true);
+    const update = preferencesUpdateFor(dto({ verification_rejected: false }), "onboarding", true);
+
+    assert.equal(isCategoryEnabled({ emailEnabled: true, prefs: update.prefs }, "onboarding"), true);
   });
 
   it("preserves keys it does not own", () => {
-    const prefs = prefsWithCategory({ ramp_completed: false, someday_a_new_type: false }, "onboarding", true);
-    assert.equal(prefs.ramp_completed, false);
-    assert.equal(prefs.someday_a_new_type, false);
+    const update = preferencesUpdateFor(dto({ ramp_completed: false, someday_a_new_type: false }), "onboarding", true);
+
+    assert.equal(update.prefs.ramp_completed, false);
+    assert.equal(update.prefs.someday_a_new_type, false);
+  });
+
+  // A profile stored with emailEnabled=false shows both categories off. Enabling one
+  // must lift the master switch without silently re-enabling the other category.
+  it("enabling under a global mute lifts the switch and pins other categories to muted", () => {
+    const update = preferencesUpdateFor(dto({}, false), "transfers", true);
+
+    assert.equal(update.emailEnabled, true);
+    const after = { emailEnabled: true, prefs: update.prefs };
+    assert.equal(isCategoryEnabled(after, "transfers"), true);
+    assert.equal(isCategoryEnabled(after, "onboarding"), false);
+  });
+
+  it("disabling under a global mute leaves the switch alone", () => {
+    const update = preferencesUpdateFor(dto({}, false), "transfers", false);
+
+    assert.equal(update.emailEnabled, undefined);
+    assert.equal(update.prefs.ramp_completed, false);
   });
 });

--- a/apps/dashboard/src/services/api/notification-preferences.service.ts
+++ b/apps/dashboard/src/services/api/notification-preferences.service.ts
@@ -1,0 +1,52 @@
+import { apiClient } from "./api-client";
+
+/**
+ * Stored notification type strings, exactly as the API's dispatch worker consults them
+ * (apps/api `NotificationType` values). The PUT endpoint accepts arbitrary prefs keys
+ * without validation, so a key that does not match these strings mutes nothing —
+ * silently. Keep them in sync with the backend enum.
+ */
+const VERIFICATION_TYPES = ["verification_approved", "verification_rejected", "verification_expired"] as const;
+const RAMP_COMPLETED_TYPE = "ramp_completed" as const;
+
+/** The settings-page categories, each fanning out to one or more stored types. */
+export type EmailNotificationCategory = "onboarding" | "transfers";
+
+export const CATEGORY_TYPE_KEYS: Record<EmailNotificationCategory, readonly string[]> = {
+  onboarding: VERIFICATION_TYPES,
+  transfers: [RAMP_COMPLETED_TYPE]
+};
+
+export interface NotificationPreferencesDto {
+  emailEnabled: boolean;
+  prefs: Record<string, unknown>;
+}
+
+/**
+ * The dispatcher mutes a type only on an explicit `false`, so a category counts as
+ * enabled while none of its types is muted. A partial mute (written by something other
+ * than this page) therefore shows as off; re-enabling rewrites every key of the
+ * category, which heals the partial state.
+ */
+export function isCategoryEnabled(prefs: Record<string, unknown>, category: EmailNotificationCategory): boolean {
+  return CATEGORY_TYPE_KEYS[category].every(type => prefs[type] !== false);
+}
+
+/** Returns `prefs` with every type of `category` set, preserving unrelated keys. */
+export function prefsWithCategory(
+  prefs: Record<string, unknown>,
+  category: EmailNotificationCategory,
+  enabled: boolean
+): Record<string, unknown> {
+  return { ...prefs, ...Object.fromEntries(CATEGORY_TYPE_KEYS[category].map(type => [type, enabled])) };
+}
+
+export const NotificationPreferencesService = {
+  get(): Promise<NotificationPreferencesDto> {
+    return apiClient.get<NotificationPreferencesDto>("/notifications/preferences");
+  },
+
+  updatePrefs(prefs: Record<string, unknown>): Promise<NotificationPreferencesDto> {
+    return apiClient.put<NotificationPreferencesDto>("/notifications/preferences", { prefs });
+  }
+};

--- a/apps/dashboard/src/services/api/notification-preferences.service.ts
+++ b/apps/dashboard/src/services/api/notification-preferences.service.ts
@@ -1,39 +1,41 @@
+import { EmailNotificationType } from "@vortexfi/shared";
 import { apiClient } from "./api-client";
-
-/**
- * Stored notification type strings, exactly as the API's dispatch worker consults them
- * (apps/api `NotificationType` values). The PUT endpoint accepts arbitrary prefs keys
- * without validation, so a key that does not match these strings mutes nothing —
- * silently. Keep them in sync with the backend enum.
- */
-const VERIFICATION_TYPES = ["verification_approved", "verification_rejected", "verification_expired"] as const;
-const RAMP_COMPLETED_TYPE = "ramp_completed" as const;
 
 /** The settings-page categories, each fanning out to one or more stored types. */
 export type EmailNotificationCategory = "onboarding" | "transfers";
 
-export const CATEGORY_TYPE_KEYS: Record<EmailNotificationCategory, readonly string[]> = {
-  onboarding: VERIFICATION_TYPES,
-  transfers: [RAMP_COMPLETED_TYPE]
+export const CATEGORY_TYPE_KEYS: Record<EmailNotificationCategory, readonly EmailNotificationType[]> = {
+  onboarding: [
+    EmailNotificationType.VerificationApproved,
+    EmailNotificationType.VerificationRejected,
+    EmailNotificationType.VerificationExpired
+  ],
+  transfers: [EmailNotificationType.RampCompleted]
 };
+
+const CATEGORIES = Object.keys(CATEGORY_TYPE_KEYS) as EmailNotificationCategory[];
 
 export interface NotificationPreferencesDto {
   emailEnabled: boolean;
   prefs: Record<string, unknown>;
 }
 
+export interface NotificationPreferencesUpdate {
+  emailEnabled?: boolean;
+  prefs: Record<string, unknown>;
+}
+
 /**
- * The dispatcher mutes a type only on an explicit `false`, so a category counts as
- * enabled while none of its types is muted. A partial mute (written by something other
- * than this page) therefore shows as off; re-enabling rewrites every key of the
- * category, which heals the partial state.
+ * Delivery requires the master switch on AND no type of the category muted, so that is
+ * what the checkbox reflects. A partial mute (written by something other than this page)
+ * shows as off; re-enabling rewrites every key of the category, which heals it.
  */
-export function isCategoryEnabled(prefs: Record<string, unknown>, category: EmailNotificationCategory): boolean {
-  return CATEGORY_TYPE_KEYS[category].every(type => prefs[type] !== false);
+export function isCategoryEnabled(preferences: NotificationPreferencesDto, category: EmailNotificationCategory): boolean {
+  return preferences.emailEnabled && CATEGORY_TYPE_KEYS[category].every(type => preferences.prefs[type] !== false);
 }
 
 /** Returns `prefs` with every type of `category` set, preserving unrelated keys. */
-export function prefsWithCategory(
+function prefsWithCategory(
   prefs: Record<string, unknown>,
   category: EmailNotificationCategory,
   enabled: boolean
@@ -41,12 +43,36 @@ export function prefsWithCategory(
   return { ...prefs, ...Object.fromEntries(CATEGORY_TYPE_KEYS[category].map(type => [type, enabled])) };
 }
 
+/**
+ * The wire update a toggle produces. Normally only `prefs` changes. Enabling a category
+ * while the master switch is off additionally lifts the switch and pins every *other*
+ * category to muted — its current effective state — so turning one toggle on cannot
+ * silently re-enable the rest.
+ */
+export function preferencesUpdateFor(
+  current: NotificationPreferencesDto,
+  category: EmailNotificationCategory,
+  enabled: boolean
+): NotificationPreferencesUpdate {
+  if (enabled && !current.emailEnabled) {
+    let prefs = { ...current.prefs };
+    for (const other of CATEGORIES) {
+      if (other !== category) {
+        prefs = prefsWithCategory(prefs, other, false);
+      }
+    }
+    return { emailEnabled: true, prefs: prefsWithCategory(prefs, category, true) };
+  }
+
+  return { prefs: prefsWithCategory(current.prefs, category, enabled) };
+}
+
 export const NotificationPreferencesService = {
   get(): Promise<NotificationPreferencesDto> {
     return apiClient.get<NotificationPreferencesDto>("/notifications/preferences");
   },
 
-  updatePrefs(prefs: Record<string, unknown>): Promise<NotificationPreferencesDto> {
-    return apiClient.put<NotificationPreferencesDto>("/notifications/preferences", { prefs });
+  update(update: NotificationPreferencesUpdate): Promise<NotificationPreferencesDto> {
+    return apiClient.put<NotificationPreferencesDto>("/notifications/preferences", update);
   }
 };

--- a/docs/product-dashboard.md
+++ b/docs/product-dashboard.md
@@ -135,9 +135,11 @@ two people.
   remain in the `initial` phase are omitted from history.
 
 ### Notifications & settings
-- As a user, I get in-app and email alerts when a corridor's KYC/KYB resolves, when an invited
-  recipient completes onboarding, and when a payout settles or fails.
-- As a user, I toggle each of those three notification categories.
+- As a user, I get in-app and email alerts when a corridor's KYC/KYB resolves and when a ramp
+  settles.
+- As a user, I toggle each of those two email notification categories on Settings. (A third
+  category — recipient-approval alerts — was dropped for now: no such notification type exists
+  in the backend yet.)
 
 ## High-level implementation strategy
 
@@ -263,15 +265,17 @@ provider-shaped rather than UI-shaped.
   #2 stops at "onboarded", not "payable". The product and provider contract must define how
   payout instruments are created for both senders creating links and recipients redeeming them,
   while keeping raw bank PII provider-side.
-- The notification feed rendered in the dashboard shell and the three notification preference
-  toggles on Settings are still client-mocked even though `/v1/notifications` exists; wiring them
-  up is listed under next steps.
+- The notification feed rendered in the dashboard shell is still client-mocked even though
+  `/v1/notifications` exists; wiring it up is listed under next steps. The Settings email
+  preference toggles are wired to `/v1/notifications/preferences`: "Onboarding updates" maps to
+  the three `verification_*` types and "Transfer status" to `ramp_completed`, the stored type
+  strings the email dispatch worker consults at delivery time.
 
 ## Next steps
 
 - Display relationship status and authoritative transfer eligibility, including the reason a
   recipient is not payable, instead of deriving availability from onboarding status alone.
-- Connect the dashboard notification feed and its three preference controls to the backend.
+- Connect the dashboard notification feed to the backend.
 - Consider persisting intended corridor selection independently of provider entities. A small
   backend table could support adding/removing tracked corridors and explicit status management;
   provider-created entities remain the authoritative persisted onboarding state meanwhile.

--- a/docs/product-dashboard.md
+++ b/docs/product-dashboard.md
@@ -269,7 +269,9 @@ provider-shaped rather than UI-shaped.
   `/v1/notifications` exists; wiring it up is listed under next steps. The Settings email
   preference toggles are wired to `/v1/notifications/preferences`: "Onboarding updates" maps to
   the three `verification_*` types and "Transfer status" to `ramp_completed`, the stored type
-  strings the email dispatch worker consults at delivery time.
+  strings the email dispatch worker consults at delivery time (shared `EmailNotificationType`
+  enum). The stored master switch is honored too: a globally muted profile shows both
+  categories off, and re-enabling one lifts the switch while pinning the other to muted.
 
 ## Next steps
 

--- a/docs/security-spec/07-operations/notifications.md
+++ b/docs/security-spec/07-operations/notifications.md
@@ -39,8 +39,8 @@ content is rendered verbatim to users and may later be emailed, so it is a PII-l
   (`notifications-onboarding.integration.test.ts`).
 - **Client-forged notifications (phishing inside the product UI)**: no write endpoint exists;
   emission is server-side only (invariant 2).
-- **PII leakage via feed or future email**: content rules (invariant 4) apply to every emitter;
-  the planned invite email must contain the invite **link only**, never payout or identity data.
+- **PII leakage via feed or email**: content rules (invariant 4) apply to every emitter;
+  a future invite email must contain the invite **link only**, never payout or identity data.
 - **Unbounded query cost**: limit clamp + indexed `(profile_id, created_at)` reads.
 
 ## Audit Checklist
@@ -50,7 +50,12 @@ content is rendered verbatim to users and may later be emailed, so it is a PII-l
       services/controllers acting on server-derived events.
 - [ ] `emitNotification` cannot throw into its caller.
 - [ ] Existing emitters carry no PII in `title`/`body`/`metadata`.
-- [ ] **Email dispatch is NOT implemented** (plan D7 — Supabase SMTP/edge function pending):
-      `email_enabled` is a stored preference with no effect yet. When the transport lands it must
-      gate on preferences, be server-side triggered only, and follow the content rules — update
-      this spec in the same change.
+- [ ] **Email dispatch is implemented and gates on these preferences at delivery time**
+      (see [`05-integrations/resend.md`](../05-integrations/resend.md) for the transport,
+      queue, and its own invariants). Before every send the dispatch worker re-reads
+      `notification_preferences`: `email_enabled` is the master switch, and
+      `prefs[<stored type>] === false` mutes one type — the stored type strings are the
+      shared `EmailNotificationType` enum consumed by both the worker and the dashboard's
+      Settings toggles. A muted row is recorded `skipped`, never sent. Sending remains
+      server-side triggered only; the `email_notifications` queue is unrelated to the
+      in-app `notifications` table this spec covers, and no client can write either.

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -11,4 +11,5 @@ export interface EphemeralAccount {
   address: string;
 }
 
+export * from "./types/emailNotifications";
 export * from "./types/rampDirection";

--- a/packages/shared/src/types/emailNotifications.ts
+++ b/packages/shared/src/types/emailNotifications.ts
@@ -1,0 +1,13 @@
+/**
+ * Stored `email_notifications.type` values — the wire contract between the API's email
+ * dispatch worker (which mutes a type when `notification_preferences.prefs[type]` is
+ * `false`) and the dashboard's Settings toggles that write those keys. The preferences
+ * endpoint accepts arbitrary keys without validation, so a drifted string mutes
+ * nothing, silently; both sides must consume this enum.
+ */
+export enum EmailNotificationType {
+  RampCompleted = "ramp_completed",
+  VerificationApproved = "verification_approved",
+  VerificationExpired = "verification_expired",
+  VerificationRejected = "verification_rejected"
+}


### PR DESCRIPTION
The three notification checkboxes on the dashboard Settings page were uncontrolled `defaultChecked` stubs: toggling persisted nothing and reset on reload (an acknowledged gap in `docs/product-dashboard.md`).

They are now wired to `GET`/`PUT /v1/notifications/preferences`, which the email dispatch worker consults at delivery time — so an opt-out applies even to rows already sitting in the queue.

**Category mapping.** The prefs keys the dispatcher checks are the stored notification type strings, and the PUT endpoint accepts arbitrary keys without validation, so a drifted key would mute nothing, silently. The mapping is therefore pinned by a unit test:

- **Onboarding updates** → `verification_approved`, `verification_rejected`, `verification_expired`
- **Transfer status** → `ramp_completed`

A category displays as off when any of its types is muted; re-enabling rewrites all of them, so partial states written by anything else self-heal. Unrelated prefs keys are preserved on write.

**Product changes**
- The **Recipient approvals** toggle is dropped for now — no such notification type exists in the backend, so the checkbox controlled nothing.
- The **Transfer status** caption now reads "When a ramp settles." (no failure phrasing).
- Toggles apply optimistically with rollback on a failed PUT.

**Testing:** new unit tests cover the type-key contract, the opt-out semantics (only explicit `false` mutes), partial-mute display/healing, and foreign-key preservation. 84/84 dashboard unit tests, `tsc`, and Biome pass. The product spec's acknowledged-gaps and next-steps sections are updated in the same change (the in-app feed remains client-mocked and stays listed).